### PR TITLE
fix(coding-agent): dedupe skills from duplicate copies of one package

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,22 @@
+## 2026-09-07 - Dedupe skills from duplicate copies of one package
+
+### What changed
+
+- `src/core/package-identity.ts`: `findNearestPackageIdentity` and `dedupePathsByPackageIdentity` moved out of the resource loader as pure functions (nearest `package.json` name + relative resource path).
+- `src/core/resource-loader.ts`: skill paths assembled during `reload()` are deduped by package identity the same way extension paths already were, so a second physical copy of one package contributes no skills and no collision diagnostics.
+
+### Why
+
+- omo-ai loads its plugin via `--extension`; when `settings.packages` also held a worktree checkout of `@code-yeongyu/omo-senpi`, extensions deduped by package name but every one of the 24 skills raised a "name collision" warning at startup. Skills and extensions from one package identity now follow one rule: the earliest registration wins.
+
+### Why an extension could not handle it
+
+- Skill discovery and collision diagnostics run in the core loader before any extension code executes.
+
+### Expected merge conflict zones
+
+- LOW: `resource-loader.ts` around skill path assembly and the former private package-identity helpers.
+
 
 ## 2026-09-05 - Persist Astra reasoning configuration updates
 

--- a/packages/coding-agent/src/core/package-identity.ts
+++ b/packages/coding-agent/src/core/package-identity.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+/**
+ * Nearest `package.json` name plus the resource path relative to that package root, so two
+ * physical copies of one package (global install vs worktree checkout) share one identity.
+ */
+export interface PackageIdentity {
+	readonly key: string;
+	readonly packageName: string;
+}
+
+export function findNearestPackageIdentity(resourcePath: string): PackageIdentity | undefined {
+	if (resourcePath.startsWith("<")) {
+		return undefined;
+	}
+
+	const normalizedResourcePath = resolve(resourcePath);
+	let currentPath = resolve(resourcePath);
+	try {
+		if (!statSync(currentPath).isDirectory()) {
+			currentPath = resolve(currentPath, "..");
+		}
+	} catch {
+		currentPath = resolve(currentPath, "..");
+	}
+
+	while (true) {
+		const packageJsonPath = join(currentPath, "package.json");
+		if (existsSync(packageJsonPath)) {
+			try {
+				const packageJson: { name?: unknown } = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+				if (typeof packageJson.name !== "string" || packageJson.name.length === 0) {
+					return undefined;
+				}
+				return {
+					key: `${packageJson.name}:${relative(currentPath, normalizedResourcePath)}`,
+					packageName: packageJson.name,
+				};
+			} catch {
+				return undefined;
+			}
+		}
+
+		const parentPath = resolve(currentPath, "..");
+		if (parentPath === currentPath) {
+			return undefined;
+		}
+		currentPath = parentPath;
+	}
+}
+
+/** First path per identity wins (CLI before settings before discovery); unpackaged paths pass through. */
+export function dedupePathsByPackageIdentity(paths: readonly string[]): string[] {
+	const dedupedPaths: string[] = [];
+	const seenIdentityKeys = new Set<string>();
+
+	for (const path of paths) {
+		const packageIdentity = findNearestPackageIdentity(path);
+		if (packageIdentity) {
+			if (seenIdentityKeys.has(packageIdentity.key)) {
+				continue;
+			}
+			seenIdentityKeys.add(packageIdentity.key);
+		}
+		dedupedPaths.push(path);
+	}
+
+	return dedupedPaths;
+}

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import chalk from "chalk";
 import { CONFIG_DIR_NAME, getAgentDir, getPackageDir, isBunBinary } from "../config.ts";
@@ -35,6 +35,7 @@ import type {
 	LoadedHookSources,
 } from "./extensions/types.ts";
 import { findGitPaths } from "./footer-data-provider.ts";
+import { dedupePathsByPackageIdentity, findNearestPackageIdentity } from "./package-identity.ts";
 import { DefaultPackageManager, type PathMetadata, type ResolvedResource } from "./package-manager.ts";
 import type { PromptTemplate } from "./prompt-templates.ts";
 import { loadPromptTemplates } from "./prompt-templates.ts";
@@ -666,7 +667,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const extensionPaths = this.noExtensions
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, enabledExtensions);
-		const dedupedExtensionPaths = this.dedupeExtensionPathsByPackageName(
+		const dedupedExtensionPaths = dedupePathsByPackageIdentity(
 			this.shadowVendoredBuiltinExtensionPaths(extensionPaths, metadataByPath),
 		);
 
@@ -682,9 +683,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionsResult = this.extensionsOverride ? this.extensionsOverride(extensionsResult) : extensionsResult;
 		this.applyExtensionSourceInfo(this.extensionsResult.extensions, metadataByPath);
 
-		const skillPaths = this.noSkills
-			? this.mergePaths(cliEnabledSkills, this.additionalSkillPaths)
-			: this.mergePaths([...cliEnabledSkills, ...enabledSkills], this.additionalSkillPaths);
+		const skillPaths = dedupePathsByPackageIdentity(
+			this.noSkills
+				? this.mergePaths(cliEnabledSkills, this.additionalSkillPaths)
+				: this.mergePaths([...cliEnabledSkills, ...enabledSkills], this.additionalSkillPaths),
+		);
 
 		this.lastSkillPaths = skillPaths;
 		this.updateSkillsFromPaths(skillPaths, metadataByPath);
@@ -1146,64 +1149,6 @@ export class DefaultResourceLoader implements ResourceLoader {
 		return resolvePath(p, this.cwd, { trim: true });
 	}
 
-	private findNearestPackageIdentity(resourcePath: string): { key: string; packageName: string } | undefined {
-		if (resourcePath.startsWith("<")) {
-			return undefined;
-		}
-
-		const normalizedResourcePath = resolve(resourcePath);
-		let currentPath = resolve(resourcePath);
-		try {
-			if (!statSync(currentPath).isDirectory()) {
-				currentPath = resolve(currentPath, "..");
-			}
-		} catch {
-			currentPath = resolve(currentPath, "..");
-		}
-
-		while (true) {
-			const packageJsonPath = join(currentPath, "package.json");
-			if (existsSync(packageJsonPath)) {
-				try {
-					const packageJson: { name?: unknown } = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-					if (typeof packageJson.name !== "string" || packageJson.name.length === 0) {
-						return undefined;
-					}
-					return {
-						key: `${packageJson.name}:${relative(currentPath, normalizedResourcePath)}`,
-						packageName: packageJson.name,
-					};
-				} catch {
-					return undefined;
-				}
-			}
-
-			const parentPath = resolve(currentPath, "..");
-			if (parentPath === currentPath) {
-				return undefined;
-			}
-			currentPath = parentPath;
-		}
-	}
-
-	private dedupeExtensionPathsByPackageName(extensionPaths: string[]): string[] {
-		const dedupedPaths: string[] = [];
-		const seenPackageNames = new Set<string>();
-
-		for (const extensionPath of extensionPaths) {
-			const packageIdentity = this.findNearestPackageIdentity(extensionPath);
-			if (packageIdentity) {
-				if (seenPackageNames.has(packageIdentity.key)) {
-					continue;
-				}
-				seenPackageNames.add(packageIdentity.key);
-			}
-			dedupedPaths.push(extensionPath);
-		}
-
-		return dedupedPaths;
-	}
-
 	private getActiveBuiltinExtensionIds(): Set<string> {
 		const enabledBuiltinExtensions = this.settingsManager.getEnabledBuiltinExtensions();
 		const enabledBuiltinExtensionSet = enabledBuiltinExtensions ? new Set(enabledBuiltinExtensions) : undefined;
@@ -1261,7 +1206,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 				continue;
 			}
 
-			const packageIdentity = this.findNearestPackageIdentity(extensionPath);
+			const packageIdentity = findNearestPackageIdentity(extensionPath);
 			if (packageIdentity && shadowedPackageNames.has(packageIdentity.packageName)) {
 				continue;
 			}
@@ -1541,8 +1486,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 			return true;
 		}
 
-		const existingPackageIdentity = this.findNearestPackageIdentity(existingOwner);
-		const candidatePackageIdentity = this.findNearestPackageIdentity(candidateOwner);
+		const existingPackageIdentity = findNearestPackageIdentity(existingOwner);
+		const candidatePackageIdentity = findNearestPackageIdentity(candidateOwner);
 		return existingPackageIdentity !== undefined && existingPackageIdentity.key === candidatePackageIdentity?.key;
 	}
 

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -72,7 +72,7 @@ Legacy root helpers: `test-harness.ts` (superseded), `utilities.ts`, `model-runt
 
 - Run every added or changed test file directly until green.
 - Run the narrow owning directory or package suite when shared harnesses, fixtures, or lifecycle behavior change.
-- Package runner is Vitest: `bun run --cwd packages/coding-agent test --run <path>`.
+- Package runner is Vitest: `bun run --cwd packages/coding-agent test <path>` (the `test` script already passes `--run`; passing it again makes vitest reject the duplicated flag).
 - Root `bun run check` is static validation and does not replace tests.
 
 ---

--- a/packages/coding-agent/test/resource-loader-skill-package-dedupe.test.ts
+++ b/packages/coding-agent/test/resource-loader-skill-package-dedupe.test.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+describe("DefaultResourceLoader skill dedupe by package identity", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let cwd: string;
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `rl-skill-dedupe-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		cwd = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		originalHome = process.env.HOME;
+		process.env.HOME = tempDir;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function writeSkillPackage(root: string, packageName: string, skillName: string): string {
+		const skillDir = join(root, "skills", skillName);
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(join(root, "package.json"), JSON.stringify({ name: packageName, pi: { skills: ["./skills"] } }));
+		const skillFile = join(skillDir, "SKILL.md");
+		writeFileSync(skillFile, `---\nname: ${skillName}\ndescription: ${skillName} from ${root}\n---\n${root}\n`);
+		return skillFile;
+	}
+
+	function collisionLosers(loader: DefaultResourceLoader): string[] {
+		return loader
+			.getSkills()
+			.diagnostics.filter((diagnostic) => diagnostic.type === "collision")
+			.flatMap((diagnostic) => (diagnostic.collision ? [diagnostic.collision.loserPath] : []));
+	}
+
+	function skillFiles(loader: DefaultResourceLoader, skillName: string): string[] {
+		return loader
+			.getSkills()
+			.skills.filter((skill) => skill.name === skillName)
+			.map((skill) => skill.filePath);
+	}
+
+	it("loads skills once when a second copy of the same package is registered in settings", async () => {
+		// given: one package as the CLI extension (global install) and again as a settings package (worktree checkout)
+		const cliCopy = join(tempDir, "global-copy");
+		const settingsCopy = join(tempDir, "worktree-copy");
+		const cliSkill = writeSkillPackage(cliCopy, "same-skill-package", "shared-skill");
+		writeSkillPackage(settingsCopy, "same-skill-package", "shared-skill");
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalExtensionPaths: [cliCopy],
+			settingsManager: SettingsManager.inMemory({
+				disabledBuiltinExtensions: ["codemode"],
+				packages: [settingsCopy],
+			}),
+		});
+
+		// when
+		await loader.reload();
+
+		// then
+		expect(collisionLosers(loader)).toEqual([]);
+		expect(skillFiles(loader, "shared-skill")).toEqual([cliSkill]);
+	});
+
+	it("still reports a collision when distinct packages ship the same skill name", async () => {
+		// given
+		const firstPackage = join(tempDir, "first-package");
+		const secondPackage = join(tempDir, "second-package");
+		const firstSkill = writeSkillPackage(firstPackage, "first-skill-package", "shared-skill");
+		const secondSkill = writeSkillPackage(secondPackage, "second-skill-package", "shared-skill");
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalExtensionPaths: [firstPackage, secondPackage],
+			settingsManager: SettingsManager.inMemory({ disabledBuiltinExtensions: ["codemode"] }),
+		});
+
+		// when
+		await loader.reload();
+
+		// then
+		expect(collisionLosers(loader)).toEqual([secondSkill]);
+		expect(skillFiles(loader, "shared-skill")).toEqual([firstSkill]);
+	});
+});


### PR DESCRIPTION
## Why

omo-ai loads its plugin through `--extension <omo-ai/plugin>`. When `settings.packages` also held a second checkout of `@code-yeongyu/omo-senpi` (a dev worktree registered by the local installer), the extension was silently deduped by package identity but every one of its 24 skills raised a `name "<skill>" collision` warning on each start:

```
"refactor" collision:
  ✓ path (temp) ~/.bun/install/global/node_modules/omo-ai/plugin/skills/refactor/SKILL.md
  ✗ /Volumes/.../oh-my-openagent-wt/memory-eperm-20260906/packages/omo-senpi/plugin/skills/refactor/SKILL.md (skipped)
```

Extensions and skills from one package identity now follow one rule: the earliest registration (CLI before settings before discovery) wins, and the duplicate copy contributes nothing.

## What

- `src/core/package-identity.ts`: `findNearestPackageIdentity` / `dedupePathsByPackageIdentity` extracted from the resource loader as pure functions (nearest `package.json` name + relative resource path).
- `src/core/resource-loader.ts`: skill paths assembled in `reload()` are deduped by package identity exactly like extension paths.
- `test/resource-loader-skill-package-dedupe.test.ts`: duplicate copy of one package → no collision, CLI copy wins; distinct packages sharing a skill name still collide.
- `test/AGENTS.md`: the documented vitest invocation passed `--run` twice, which vitest rejects.
- `src/core/changes.md` entry.

## Verification (ascii box bx_gb9cmax7, x86_64, bun 1.4.0, fresh `bun install --frozen-lockfile`)

- `bunx vitest --run test/resource-loader-skill-package-dedupe.test.ts test/resource-loader.test.ts test/skills.test.ts` → green.
- Mutation: replacing the skill-path `dedupePathsByPackageIdentity(...)` call with an identity function makes the new test fail (collision reported); restored.
- `bunx tsc --noEmit`, `scripts/check-ts-relative-imports.mjs`, biome on the touched files → clean.
- Real surface: on the reporting machine the loader probe went from 24 collision diagnostics to 0 and an interactive `omo` boot shows no "Skill conflicts" block.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes startup collision warnings when one package ships skills from two physical copies (for example, a global `--extension` install plus a worktree checkout in `settings.packages`). Skill paths now dedupe by package identity exactly like extension paths already did: the earliest registration wins (CLI before settings before discovery), and the duplicate copy contributes no skills and no diagnostics. Distinct packages that share a skill name still collide as before.

**Refactors**
- Extracted the package-identity helpers from the resource loader into `src/core/package-identity.ts` as pure functions.
- Corrected the vitest invocation documented in `test/AGENTS.md` that passed `--run` twice.

<sup>Written for commit 6d3ee8cbc8674de344e59b738f2848b2217bebe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

