### PR TITLE
fix(codemode): fail clearly when compiled runtime assets are missing

### DIFF
--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,16 @@
 # senpi-codemode fork changes
 
+## 2026-09-07 - Fail clearly when compiled codemode assets are missing
+
+### What changed
+
+- Kernel runtime asset resolution now rejects Bun virtual paths and reports the missing codemode sidecar beside the executable, while skill contribution resolution remains non-throwing.
+
+### Why
+
+- Compiled binaries cannot pass embedded `/$bunfs` paths to workers or subprocesses; the actionable error identifies the expected sidecar asset and deployment fix.
+
+
 ## 2026-09-06 - Bun eval description steers away from Bun.spawnSync
 
 ### What changed

--- a/packages/senpi-codemode/src/kernels/jl/kernel.ts
+++ b/packages/senpi-codemode/src/kernels/jl/kernel.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { SubprocessKernel, type SubprocessSpawn } from "../shared/subprocess-kernel.ts";
 
 export interface JuliaKernelStartOptions {
@@ -17,7 +17,7 @@ export interface JuliaRunnerPathOptions extends CodemodeRuntimeAssetEnvironment 
 }
 
 export function resolveJuliaRunnerPath(options: JuliaRunnerPathOptions = {}): string {
-	return resolveCodemodeRuntimeAsset(
+	return requireCodemodeRuntimeAsset(
 		options.localPath ?? join(import.meta.dirname, "runner.jl"),
 		join("kernels", "jl", "runner.jl"),
 		options,

--- a/packages/senpi-codemode/src/kernels/js/inline-worker.ts
+++ b/packages/senpi-codemode/src/kernels/js/inline-worker.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import type { JavaScriptKernelMode } from "./kernel-contract.ts";
 import { spawnNodeWorker } from "./worker-host.ts";
 
@@ -12,7 +12,7 @@ export interface JavaScriptInlineWorkerEntryUrlOptions extends CodemodeRuntimeAs
 export function resolveInlineWorkerEntryUrl(options: JavaScriptInlineWorkerEntryUrlOptions = {}): URL {
 	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "inline-worker-entry.js");
 	return pathToFileURL(
-		resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "inline-worker-entry.js"), options),
+		requireCodemodeRuntimeAsset(localPath, join("kernels", "js", "inline-worker-entry.js"), options),
 	);
 }
 

--- a/packages/senpi-codemode/src/kernels/js/worker-startup.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-startup.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { createInlineWorker, type WorkerLike } from "./inline-worker.ts";
 import { type JavaScriptKernelOptions, localBridgeConnection } from "./local-module-loader.ts";
 import { spawnNodeWorker, WorkerStartupCancelledError, waitForReady } from "./worker-host.ts";
@@ -11,7 +11,7 @@ export interface JavaScriptWorkerEntryUrlOptions extends CodemodeRuntimeAssetEnv
 
 export function resolveJsWorkerEntryUrl(options: JavaScriptWorkerEntryUrlOptions = {}): URL {
 	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "worker-entry.js");
-	return pathToFileURL(resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "worker-entry.js"), options));
+	return pathToFileURL(requireCodemodeRuntimeAsset(localPath, join("kernels", "js", "worker-entry.js"), options));
 }
 
 export interface WorkerStartupHooks {

--- a/packages/senpi-codemode/src/kernels/py/transport.ts
+++ b/packages/senpi-codemode/src/kernels/py/transport.ts
@@ -8,7 +8,7 @@ import {
 	isKernelToHostMessage,
 	type KernelToHostMessage,
 } from "../../bridge/protocol.ts";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import {
 	defaultSpawn,
 	hardKill,
@@ -53,7 +53,7 @@ export interface PythonPreludePathOptions extends CodemodeRuntimeAssetEnvironmen
 }
 
 export function resolvePythonPreludePath(options: PythonPreludePathOptions = {}): string {
-	return resolveCodemodeRuntimeAsset(
+	return requireCodemodeRuntimeAsset(
 		options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "prelude.py"),
 		join("kernels", "py", "prelude.py"),
 		options,

--- a/packages/senpi-codemode/src/kernels/rb/kernel.ts
+++ b/packages/senpi-codemode/src/kernels/rb/kernel.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { SubprocessKernel, type SubprocessSpawn } from "../shared/subprocess-kernel.ts";
 
 export interface RubyKernelStartOptions {
@@ -17,7 +17,7 @@ export interface RubyRunnerPathOptions extends CodemodeRuntimeAssetEnvironment {
 }
 
 export function resolveRubyRunnerPath(options: RubyRunnerPathOptions = {}): string {
-	return resolveCodemodeRuntimeAsset(
+	return requireCodemodeRuntimeAsset(
 		options.localPath ?? join(import.meta.dirname, "runner.rb"),
 		join("kernels", "rb", "runner.rb"),
 		options,

--- a/packages/senpi-codemode/src/kernels/shared/runtime-asset.ts
+++ b/packages/senpi-codemode/src/kernels/shared/runtime-asset.ts
@@ -6,26 +6,52 @@ export interface CodemodeRuntimeAssetEnvironment {
 	readonly executablePath?: string;
 }
 
+export class CodemodeRuntimeAssetMissingError extends Error {
+	readonly packageRelativePath: string;
+	readonly localPath: string;
+	readonly sidecarPath: string;
+	readonly executablePath: string;
+
+	constructor(packageRelativePath: string, localPath: string, sidecarPath: string, executablePath: string) {
+		super(
+			`codemode runtime asset ${packageRelativePath} is unavailable: module-relative path ${localPath} is not readable and the codemode sidecar is missing beside the executable ${executablePath} (expected ${sidecarPath}). Ship node_modules/@code-yeongyu/senpi-codemode next to the executable.`,
+		);
+		this.name = "CodemodeRuntimeAssetMissingError";
+		this.packageRelativePath = packageRelativePath;
+		this.localPath = localPath;
+		this.sidecarPath = sidecarPath;
+		this.executablePath = executablePath;
+	}
+}
+
+export function isBunVirtualPath(path: string): boolean {
+	return path.includes("/$bunfs/") || path.includes("~BUN") || path.includes("%7EBUN");
+}
+
+function sidecarPathFor(packageRelativePath: string, executablePath: string): string {
+	return join(dirname(executablePath), "node_modules", "@code-yeongyu", "senpi-codemode", "src", packageRelativePath);
+}
+
+export function requireCodemodeRuntimeAsset(
+	localPath: string,
+	packageRelativePath: string,
+	{ executablePath = process.execPath }: CodemodeRuntimeAssetEnvironment = {},
+): string {
+	const sidecarPath = sidecarPathFor(packageRelativePath, executablePath);
+	if (!isBunVirtualPath(localPath) && existsSync(localPath)) return localPath;
+	if (existsSync(sidecarPath)) return sidecarPath;
+	throw new CodemodeRuntimeAssetMissingError(packageRelativePath, localPath, sidecarPath, executablePath);
+}
+
 export function resolveCodemodeRuntimeAsset(
 	localPath: string,
 	packageRelativePath: string,
 	{ bunVersion = process.versions.bun, executablePath = process.execPath }: CodemodeRuntimeAssetEnvironment = {},
 ): string {
-	if (existsSync(localPath)) {
-		return localPath;
-	}
+	if (existsSync(localPath)) return localPath;
 	if (bunVersion) {
-		const sidecarPath = join(
-			dirname(executablePath),
-			"node_modules",
-			"@code-yeongyu",
-			"senpi-codemode",
-			"src",
-			packageRelativePath,
-		);
-		if (existsSync(sidecarPath)) {
-			return sidecarPath;
-		}
+		const sidecarPath = sidecarPathFor(packageRelativePath, executablePath);
+		if (existsSync(sidecarPath)) return sidecarPath;
 	}
 	return localPath;
 }

--- a/packages/senpi-codemode/test/kernels/shared/runtime-asset.test.ts
+++ b/packages/senpi-codemode/test/kernels/shared/runtime-asset.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveInlineWorkerEntryUrl } from "../../../src/kernels/js/inline-worker.ts";
+import { resolvePythonPreludePath } from "../../../src/kernels/py/transport.ts";
+import {
+	CodemodeRuntimeAssetMissingError,
+	isBunVirtualPath,
+	requireCodemodeRuntimeAsset,
+} from "../../../src/kernels/shared/runtime-asset.ts";
+
+const rel = "kernels/js/inline-worker-entry.js";
+function env() {
+	const root = mkdtempSync(join(tmpdir(), "codemode-"));
+	return { root, executablePath: join(root, "senpi") };
+}
+function sidecar(root: string, path = rel) {
+	const file = join(root, "node_modules/@code-yeongyu/senpi-codemode/src", path);
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, "asset");
+	return file;
+}
+
+describe("codemode runtime assets", () => {
+	it("uses local assets", () => {
+		const e = env();
+		const local = join(e.root, "asset");
+		writeFileSync(local, "x");
+		expect(requireCodemodeRuntimeAsset(local, rel, e)).toBe(local);
+	});
+	it("uses the sidecar", () => {
+		const e = env();
+		const expected = sidecar(e.root);
+		expect(requireCodemodeRuntimeAsset(join(e.root, "missing"), rel, e)).toBe(expected);
+	});
+	it("replaces Bun virtual paths", () => {
+		const e = env();
+		const expected = sidecar(e.root);
+		expect(requireCodemodeRuntimeAsset("/$bunfs/root/inline-worker-entry.js", rel, e)).toBe(expected);
+	});
+	it("throws an actionable error", () => {
+		const e = env();
+		const missing = join(e.root, "node_modules/@code-yeongyu/senpi-codemode/src", rel);
+		expect(() => requireCodemodeRuntimeAsset("/$bunfs/root/inline-worker-entry.js", rel, e)).toThrow(
+			CodemodeRuntimeAssetMissingError,
+		);
+		expect(() => requireCodemodeRuntimeAsset("/$bunfs/root/inline-worker-entry.js", rel, e)).toThrow(
+			`${e.executablePath} (expected ${missing})`,
+		);
+	});
+	it("throws for missing local assets", () => {
+		const e = env();
+		expect(() => requireCodemodeRuntimeAsset(join(e.root, "missing"), rel, e)).toThrow(
+			CodemodeRuntimeAssetMissingError,
+		);
+	});
+	it.each([
+		["/$bunfs/x", true],
+		["~BUN/x", true],
+		["%7EBUN/x", true],
+		["/tmp/x", false],
+	])("detects virtual path %s", (path, result) => expect(isBunVirtualPath(path)).toBe(result));
+	it("propagates through JS resolver", () => {
+		const e = env();
+		expect(() => resolveInlineWorkerEntryUrl({ ...e, localPath: "/$bunfs/root/inline-worker-entry.js" })).toThrow(
+			/codemode runtime asset/,
+		);
+	});
+	it("propagates through Python resolver", () => {
+		const e = env();
+		expect(() => resolvePythonPreludePath({ ...e, localPath: "/$bunfs/root/prelude.py", bunVersion: "1" })).toThrow(
+			/codemode runtime asset/,
+		);
+	});
+});


### PR DESCRIPTION
## Incident
Desktop-app sessions on 2026-09-07 lost both eval kernels and, because `bash` is hidden whenever `eval` is registered, every shell: `Cannot find module '/$bunfs/root/inline-worker-entry.js'` and `python: can't open file '/$bunfs/root/prelude.py'`. The deployed runtime bundle had shipped without the `node_modules/@code-yeongyu/senpi-codemode` sidecar, and `resolveCodemodeRuntimeAsset` fell back to the compiled binary's virtual `$bunfs` path, which no Worker or python subprocess can open. Nothing named the sidecar, so the outage cost hours to diagnose.

## Change
- `kernels/shared/runtime-asset.ts`: new `requireCodemodeRuntimeAsset` never returns a Bun virtual path (`/$bunfs/`, `~BUN`, `%7EBUN`); it returns the module-relative asset when readable, else the sidecar beside `process.execPath`, else throws `CodemodeRuntimeAssetMissingError` whose message names the asset, the executable, and the expected sidecar file plus the fix ("Ship node_modules/@code-yeongyu/senpi-codemode next to the executable").
- js inline-worker / worker-startup, py transport, jl and rb runners route through the throwing resolver. `bundledBunSkillPath` keeps the non-throwing `resolveCodemodeRuntimeAsset` (logs once, returns undefined).
- `changes.md` entry.

## Tests
`packages/senpi-codemode/test/kernels/shared/runtime-asset.test.ts` (11 cases: local/sidecar/virtual-path resolution, the error's message fields, `isBunVirtualPath` table, propagation through the JS inline-worker and Python prelude resolvers).

Ran remotely on a Linux ascii box (bun 1.4.0 / node 24), never on the dev machine:
- RED (production change stashed, tests present): 10 failed | 1 passed.
- GREEN (focused file): 11 passed.
- Whole `packages/senpi-codemode` scope after `bun run build`: 107 files passed, 755 tests passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 2026-09-07 kernel outage caused by a missing codemode sidecar in deployed runtime bundles. Kernel asset resolution now fails with `CodemodeRuntimeAssetMissingError` instead of returning unopenable Bun virtual paths.

- `requireCodemodeRuntimeAsset` uses the local asset, then the sidecar beside the executable, then throws with the executable, expected sidecar path, and fix.
- Rejects Bun virtual paths (`/$bunfs/`, `~BUN`, `%7EBUN`) in the JS inline-worker, worker-startup, Python prelude, Julia, and Ruby resolvers; `bundledBunSkillPath` keeps the non-throwing resolver.
- Compiled binaries must ship `node_modules/@code-yeongyu/senpi-codemode` next to the executable.
- Adds 11 test cases covering local, sidecar, and virtual-path resolution plus error propagation.

<sup>Written for commit d11b259f5e7b826f86c8151701d31b464811685d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

