### PR TITLE
fix(claude-sdk-oauth): reattach restart bindings across prompt and toolset drift

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- A plain `--session <id>` resume on the `claude-sdk-oauth` provider no longer re-sends the whole conversation with `Session continuity lost (options_changed)` after a restart (code-yeongyu/oh-my-openagent#7884). A restored session binding whose system prompt or toolset fingerprint drifted - an engine upgrade, a prompt-content change, or the UTC date rolling over - now reattaches to the existing SDK session and sends only the new turn, the same way a live session already did; only an account or model identity change still cold-seeds. The continuity observation names which half drifted (`system_prompt_changed` / `toolset_changed`) instead of the bare `options_changed`.
+- The `Current date:` line is normalized out of the `claude-sdk-oauth` prompt fingerprint even when extension prompt sections follow the `Current working directory:` line, which is the shape every real session has. Previously the normalization only matched when that line ended the prompt, so the fingerprint changed at every UTC midnight.
+
 ### Removed
 
 ## [2026.9.7] - 2026-09-07

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -31,12 +31,12 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 
 ## INVARIANTS (from changes.md)
 
-- Resume-first: every live query replacement re-attaches with `resume`; persisted restarts reattach only when the private sidecar, session marker, committed assistant, identity, prefix, and SDK transcript agree. A live session is never abandoned for a flattened re-send.
+- Resume-first: every live query replacement re-attaches with `resume`; persisted restarts reattach only when the private sidecar, session marker, committed assistant, account/model identity, prefix, and SDK transcript agree - prompt/toolset fingerprint drift reattaches with `system_prompt_changed` / `toolset_changed` instead of flattening (oh-my-openagent#7884). A live session is never abandoned for a flattened re-send.
 - The SDK ledger is authoritative for divergence; decide at the `message_end` commit boundary. Result-only turns are a supported shape, not divergence.
 - Fork point is the last assistant boundary strictly before the divergence.
 - Non-fork reattach passes `resume` and must omit `sessionId` (the SDK rejects the pair). Fork adds `resumeSessionAt` + `forkSession`.
 - Abort never taints and never flattens; `interrupt()` receipts gate keep-vs-close.
-- Fingerprint normalizes the `Current date:` line (no midnight retirement); cwd and other regions stay fail-closed. Host-tool denial copy is versioned by `HOST_TOOL_POLICY_FINGERPRINT` in `toolsetHash`; bump it when the copy changes so resident sessions re-fingerprint instead of keeping the old reason. `config-dir` lane failover is the one declared residual that still flattens.
+- Fingerprint normalizes the `Current date:` line wherever the date/cwd pair sits (extension appends follow it; no midnight retirement); cwd and other regions stay fail-closed. Host-tool denial copy is versioned by `HOST_TOOL_POLICY_FINGERPRINT` in `toolsetHash`; bump it when the copy changes so resident sessions re-fingerprint instead of keeping the old reason. `config-dir` lane failover is the one declared residual that still flattens.
 - Every main turn emits exactly one continuity observation; TUI notices only for degradations.
 - `resumeMode: "off"` / `SENPI_CLAUDE_SDK_OAUTH_RESUME=off` restores legacy per-turn behavior.
 - `full`/`override` prompt modes default `settingSources` to `[]` (no CLAUDE.md double-injection). The CLI still prepends its own agent preamble; `full` means senpi's prompt arrives intact, not alone.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,28 @@
 # claude-sdk-oauth
 
+## 2026-09-07 - Reattach restart bindings across prompt/toolset drift; date-line normalization survives trailing appends
+
+### What changed
+
+- `session-continuity.ts`: `identityDrift` now reports `system_prompt_changed` / `toolset_changed` instead of the bare `options_changed`. `decideFromBinding` flattens only on `account_changed` / `model_changed`; prompt/toolset drift falls through to the normal prefix checks and a matching prefix reattaches with the drift reason (divergence reasons still win). The live-entry path is unchanged structurally and simply surfaces the split reasons.
+- `session-sync.ts`: `GENERATED_DATE_LINE` no longer anchors the `Current working directory:` line to end-of-string, so the date/cwd pair is neutralized wherever it sits in the prompt.
+- Tests: `claude-sdk-oauth-restart-binding-drift.test.ts` (new) pins the restart contract and midnight stability with trailing appends; `claude-sdk-oauth-fingerprint.test.ts`, `claude-sdk-oauth-restored-security.test.ts`, `claude-sdk-oauth-continuity-decision.test.ts`, `claude-sdk-oauth-session-registry-wiring.test.ts` expectations moved from `options_changed` / `flatten` to the split reasons / `reattach`.
+
+### Why
+
+- oh-my-openagent#7884: a plain `omo --session <id>` resume after a restart printed `Session continuity lost - resent the full conversation (options_changed) - sent 485.5KB`. Two defects compounded: (1) a restart binding flattened on any fingerprint drift, while the live path reattaches on the same drift; (2) the date-line normalization required the cwd line to be the last line of the prompt, but a real prompt carries hundreds of lines of extension appends (`<Task_Management>`, bash timeout policy, terminal prompt, memory) after it, so `systemPromptHash` drifted at every UTC midnight and every restart-resume across a midnight or an engine/prompt upgrade re-sent the whole conversation.
+- A restart has no live query: the resume builds a fresh `query()` carrying the CURRENT options and hooks, so the 2026-09-0x note that a `HOST_TOOL_POLICY_FINGERPRINT` bump "cold-seeds once" on the first admission after upgrade is superseded - the bump now reattaches with `toolset_changed`, and resident sessions still re-fingerprint through the live path as before. Account/model drift keeps failing closed because those are lineage identity, not per-query options.
+- The split reasons answer the issue's request to see WHICH option group changed: `session.log` continuity events now carry `system_prompt_changed` or `toolset_changed`. `options_changed` stays in the sanitized vocabulary for historical log lines but is no longer emitted.
+
+### Why an extension could not handle it
+
+- The continuity decision table, the persisted binding admission, and the fingerprint digest are private to this builtin provider; no extension hook observes the restart binding or the hash inputs.
+
+### Expected merge conflict zones
+
+- MEDIUM: `session-continuity.ts` `identityDrift` and the head of `decideFromBinding` (drift gate + reattach reasons).
+- LOW: `session-sync.ts` `GENERATED_DATE_LINE` regex and its docblock; the four updated test files around `options_changed` expectations.
+
 ## 2026-09-06 - Preserve early terminal results during turn claim
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts
@@ -96,8 +96,8 @@ function identityDrift(
 ): ContinuityReason | null {
 	if (entry.accountName !== input.accountName) return "account_changed";
 	if (entry.modelId !== input.modelId) return "model_changed";
-	if (entry.systemPromptHash !== input.fingerprint.systemPromptHash) return "options_changed";
-	if (entry.toolsetHash !== input.fingerprint.toolsetHash) return "options_changed";
+	if (entry.systemPromptHash !== input.fingerprint.systemPromptHash) return "system_prompt_changed";
+	if (entry.toolsetHash !== input.fingerprint.toolsetHash) return "toolset_changed";
 	return null;
 }
 
@@ -154,7 +154,12 @@ function withoutUnconfirmedResume(
 function decideFromBinding(input: ContinuityDecisionInput, binding: ContinuityBindingSnapshot): ContinuityDecision {
 	if (!input.transcriptAvailable) return { kind: "flatten", reason: "transcript_missing" };
 	const drift = identityDrift(input, binding);
-	if (drift) return { kind: "flatten", reason: drift };
+	// Account/model identity drift fails closed: the persisted identity no longer
+	// matches the turn. Prompt/toolset drift instead reattaches like the live path
+	// (oh-my-openagent#7884) - a restart has no live query, so the resume builds a
+	// fresh query carrying the CURRENT options and hooks, and flattening would
+	// re-send the whole conversation for drift the SDK applies per-query anyway.
+	if (drift === "account_changed" || drift === "model_changed") return { kind: "flatten", reason: drift };
 	const retry = retryCheckpointDecision(input, binding);
 	if (retry) return retry;
 	if (binding.sentPrefixHash !== undefined) {
@@ -166,7 +171,7 @@ function decideFromBinding(input: ContinuityDecisionInput, binding: ContinuityBi
 				kind: "reattach",
 				sdkSessionId: binding.sdkSessionId,
 				from: binding.sentCount,
-				reason: "registry_miss",
+				reason: drift ?? "registry_miss",
 			};
 		}
 		return {
@@ -176,7 +181,12 @@ function decideFromBinding(input: ContinuityDecisionInput, binding: ContinuityBi
 	}
 	const shared = commonPrefixLength(binding.sentHashes, input.currentHashes);
 	if (shared === binding.sentCount) {
-		return { kind: "reattach", sdkSessionId: binding.sdkSessionId, from: binding.sentCount, reason: "registry_miss" };
+		return {
+			kind: "reattach",
+			sdkSessionId: binding.sdkSessionId,
+			from: binding.sentCount,
+			reason: drift ?? "registry_miss",
+		};
 	}
 	if (!binding.lastAssistantUuid) return { kind: "flatten", reason: "registry_miss" };
 	return {
@@ -224,9 +234,9 @@ export function decideFailoverContinuity(input: FailoverContinuityInput): Contin
 
 /**
  * Resume-first: a live session is never abandoned for a flattened re-send. Only a
- * missing transcript or an unrecoverable boundary reaches `flatten`; every other
- * divergence resolves to `fork` (same lineage, new branch) or `reattach` (same
- * session, new query).
+ * missing transcript, an unrecoverable boundary, or account/model identity drift
+ * on a persisted binding reaches `flatten`; every other divergence resolves to
+ * `fork` (same lineage, new branch) or `reattach` (same session, new query).
  */
 export function decideNativeContinuity(input: ContinuityDecisionInput): ContinuityDecision {
 	const { entry, binding } = input;

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -111,13 +111,15 @@ export function recordSyncedStream(entry: ClaudeSdkOauthSessionEntry, hashes: re
 	entry.branchInfo = null;
 }
 
-const GENERATED_DATE_LINE = /\nCurrent date: \d{4}-\d{2}-\d{2}(?=\nCurrent working directory: [^\n]*$)/;
+const GENERATED_DATE_LINE = /\nCurrent date: \d{4}-\d{2}-\d{2}(?=\nCurrent working directory: [^\n]*)/;
 
 /**
  * The generated date line advances at UTC midnight while the conversation is
  * unchanged; hashing it verbatim retires a live session at midnight for no
- * semantic reason. Only that exact terminal line is neutralized - cwd and every
- * other prompt region stay fail-closed.
+ * semantic reason. Only that exact date-plus-cwd pair is neutralized - cwd and
+ * every other prompt region stay fail-closed. Extension appends legitimately
+ * follow the cwd line (oh-my-openagent#7884), so the pair is matched wherever
+ * it appears, not only at the end of the prompt.
  */
 function fingerprintSystemPrompt(systemPrompt: Options["systemPrompt"]): unknown {
 	if (typeof systemPrompt !== "string") return systemPrompt ?? null;

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
@@ -22,11 +22,12 @@ export const PI_TO_SDK_TOOL_NAME: Readonly<Record<string, string>> = {
 
 /**
  * Versioned host-tool denial policy. `configFingerprint` in session-sync.ts hashes this as
- * `hostToolPolicy` into `toolsetHash`; a mismatch is `options_changed` and retires the live
- * resident query. The same hash is persisted in the restart sidecar, so a bump also makes
- * the first admission after an upgrade cold-seed (`flatten` / `options_changed`) instead of
- * resuming the pre-bump SDK session - once per session, intended. Bump when denial copy or
- * hooks change so wording-only edits cannot keep serving the old reason.
+ * `hostToolPolicy` into `toolsetHash`; a mismatch is `toolset_changed` and retires the live
+ * resident query (reattach with the current hooks). The same hash is persisted in the
+ * restart sidecar, so the first admission after an upgrade also reattaches with
+ * `toolset_changed` - the resumed query carries the current hooks, so the pre-bump
+ * denial text is never served again. Bump when denial copy or hooks change so
+ * wording-only edits cannot keep serving the old reason.
  */
 export const HOST_TOOL_POLICY_FINGERPRINT = "host-tool-denial-v2";
 

--- a/packages/coding-agent/test/claude-sdk-oauth-continuity-decision.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-continuity-decision.test.ts
@@ -89,7 +89,7 @@ describe("claude-sdk-oauth native continuity decisions", () => {
 			input({ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: FINGERPRINT.toolsetHash } }),
 		);
 
-		expect(decision).toMatchObject({ kind: "reattach", reason: "options_changed", sdkSessionId: "sdk-1" });
+		expect(decision).toMatchObject({ kind: "reattach", reason: "system_prompt_changed", sdkSessionId: "sdk-1" });
 	});
 
 	it("reattaches rather than flattens when the model changed", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
@@ -116,9 +116,10 @@ describe("claude-sdk-oauth config fingerprint stability", () => {
 		expect(withDifferentCallbackIdentity.toolsetHash).toBe(policyProbe.toolsetHash);
 	});
 
-	it("cold-seeds a restart binding persisted under an older host-tool policy version", () => {
-		// The sidecar stores toolsetHash; after a policy bump the first admission
-		// must not resume the pre-bump SDK session (its hooks carried the old reason).
+	it("reattaches a restart binding persisted under an older host-tool policy version", () => {
+		// A restart has no live query: resume builds a fresh query carrying the
+		// CURRENT hooks and options, so the pre-bump denial text is never resumed.
+		// Flattening here was the #7884 full-resend; continuity must survive the bump.
 		const current = configFingerprint(options(), context(), "oauth-slots", "primary");
 		const decision = decideNativeContinuity({
 			entry: undefined,
@@ -139,7 +140,7 @@ describe("claude-sdk-oauth config fingerprint stability", () => {
 			fingerprint: current,
 			transcriptAvailable: true,
 		});
-		expect(decision).toEqual({ kind: "flatten", reason: "options_changed" });
+		expect(decision).toEqual({ kind: "reattach", sdkSessionId: "sdk-v1", from: 1, reason: "toolset_changed" });
 	});
 
 	it("stays fail-closed when the resolved Claude executable changes", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-restart-binding-drift.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-restart-binding-drift.test.ts
@@ -1,0 +1,185 @@
+import type { Context } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { Options } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import {
+	type ContinuityDecisionInput,
+	decideNativeContinuity,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts";
+import {
+	configFingerprint,
+	sentHashPrefixDigest,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts";
+
+// oh-my-openagent#7884: restart-binding fingerprint drift flattened the whole
+// conversation with a bare `options_changed`; the live path reattaches on the same drift.
+
+const FINGERPRINT = { systemPromptHash: "prompt-v1", toolsetHash: "tools-v1" };
+
+function binding(overrides: Partial<NonNullable<ContinuityDecisionInput["binding"]>> = {}) {
+	return {
+		sdkSessionId: "sdk-1",
+		sentCount: 2,
+		sentHashes: ["h1", "h2"],
+		lastAssistantUuid: "uuid-a2",
+		accountName: "primary",
+		modelId: "claude-opus-4-5",
+		systemPromptHash: FINGERPRINT.systemPromptHash,
+		toolsetHash: FINGERPRINT.toolsetHash,
+		...overrides,
+	} satisfies NonNullable<ContinuityDecisionInput["binding"]>;
+}
+
+function input(overrides: Partial<ContinuityDecisionInput> = {}): ContinuityDecisionInput {
+	return {
+		entry: undefined,
+		binding: binding(),
+		currentHashes: ["h1", "h2", "h3"],
+		accountName: "primary",
+		modelId: "claude-opus-4-5",
+		fingerprint: FINGERPRINT,
+		transcriptAvailable: true,
+		...overrides,
+	};
+}
+
+describe("claude-sdk-oauth restart binding drift (#7884)", () => {
+	it("reattaches with system_prompt_changed when only the prompt hash drifted", () => {
+		const decision = decideNativeContinuity(
+			input({ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: FINGERPRINT.toolsetHash } }),
+		);
+
+		expect(decision).toEqual({
+			kind: "reattach",
+			sdkSessionId: "sdk-1",
+			from: 2,
+			reason: "system_prompt_changed",
+		});
+	});
+
+	it("reattaches with toolset_changed when only the toolset hash drifted", () => {
+		const decision = decideNativeContinuity(
+			input({ fingerprint: { systemPromptHash: FINGERPRINT.systemPromptHash, toolsetHash: "tools-v2" } }),
+		);
+
+		expect(decision).toEqual({
+			kind: "reattach",
+			sdkSessionId: "sdk-1",
+			from: 2,
+			reason: "toolset_changed",
+		});
+	});
+
+	it("reports the prompt first when both fingerprint halves drifted", () => {
+		const decision = decideNativeContinuity(
+			input({ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v2" } }),
+		);
+
+		expect(decision).toMatchObject({ kind: "reattach", reason: "system_prompt_changed" });
+	});
+
+	it("reattaches with the drift reason instead of registry_miss behind a prefix digest", () => {
+		const decision = decideNativeContinuity(
+			input({
+				binding: binding({ sentPrefixHash: sentHashPrefixDigest(["h1", "h2"]) }),
+				fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: FINGERPRINT.toolsetHash },
+			}),
+		);
+
+		expect(decision).toEqual({
+			kind: "reattach",
+			sdkSessionId: "sdk-1",
+			from: 2,
+			reason: "system_prompt_changed",
+		});
+	});
+
+	it("lets a sent-stream divergence dominate the drift reason", () => {
+		const decision = decideNativeContinuity(
+			input({
+				currentHashes: ["h1", "h2-rewritten", "h3"],
+				fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v2" },
+			}),
+		);
+
+		expect(decision.kind).not.toBe("flatten");
+		expect(decision.kind === "reattach" && decision.reason).not.toBe("system_prompt_changed");
+	});
+
+	it.each([
+		["account", { accountName: "secondary" }, "account_changed"],
+		["model", { modelId: "claude-sonnet-5" }, "model_changed"],
+	] as const)("still flattens fail-closed when the %s drifts", (_label, override, reason) => {
+		expect(decideNativeContinuity(input(override))).toEqual({ kind: "flatten", reason });
+	});
+
+	it("still flattens transcript_missing before any drift is considered", () => {
+		const decision = decideNativeContinuity(
+			input({
+				transcriptAvailable: false,
+				fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v2" },
+			}),
+		);
+
+		expect(decision).toEqual({ kind: "flatten", reason: "transcript_missing" });
+	});
+});
+
+describe("claude-sdk-oauth fingerprint midnight stability (#7884)", () => {
+	const STABLE = ["You are senpi, a coding agent.", "", "## Available Tools", "- read: Read file contents"].join("\n");
+	const APPEND = [
+		"",
+		"<Task_Management>",
+		"## Todo Management",
+		"",
+		"Use the todo tool for multi-step work.",
+		"</Task_Management>",
+		"",
+	].join("\n");
+
+	function omoPrompt(date: string, append = APPEND): string {
+		return `${STABLE}\n\nCurrent date: ${date}\nCurrent working directory: /repo\n${append}`;
+	}
+
+	function options(systemPrompt: string): Options {
+		return {
+			cwd: "/repo",
+			model: "claude-opus-4-5",
+			tools: ["Read"],
+			permissionMode: "dontAsk",
+			includePartialMessages: true,
+			systemPrompt,
+			settingSources: [],
+		} as Options;
+	}
+
+	function context(): Context {
+		return { systemPrompt: "", messages: [], tools: [] } as unknown as Context;
+	}
+
+	it("stays stable across midnight when extension appends follow the cwd line", () => {
+		const before = configFingerprint(options(omoPrompt("2026-09-06")), context(), "oauth-slots", "primary");
+		const after = configFingerprint(options(omoPrompt("2026-09-07")), context(), "oauth-slots", "primary");
+
+		expect(after.systemPromptHash).toBe(before.systemPromptHash);
+	});
+
+	it("stays stable across midnight for the bare generated prompt shape", () => {
+		const bare = (date: string): string => `${STABLE}\n\nCurrent date: ${date}\nCurrent working directory: /repo`;
+		const before = configFingerprint(options(bare("2026-09-06")), context(), "oauth-slots", "primary");
+		const after = configFingerprint(options(bare("2026-09-07")), context(), "oauth-slots", "primary");
+
+		expect(after.systemPromptHash).toBe(before.systemPromptHash);
+	});
+
+	it("stays fail-closed when a trailing append changes content", () => {
+		const before = configFingerprint(options(omoPrompt("2026-09-07")), context(), "oauth-slots", "primary");
+		const after = configFingerprint(
+			options(omoPrompt("2026-09-07", "\nAlways respond in Korean.\n")),
+			context(),
+			"oauth-slots",
+			"primary",
+		);
+
+		expect(after.systemPromptHash).not.toBe(before.systemPromptHash);
+	});
+});

--- a/packages/coding-agent/test/claude-sdk-oauth-restored-security.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-restored-security.test.ts
@@ -93,12 +93,6 @@ describe("claude-sdk-oauth restored security", () => {
 		it.each([
 			["account", { accountName: "secondary" }, "account_changed"],
 			["model", { modelId: "claude-sonnet-5" }, "model_changed"],
-			[
-				"system-prompt",
-				{ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v1" } },
-				"options_changed",
-			],
-			["toolset", { fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v2" } }, "options_changed"],
 		] as const)("cold-seeds a persisted binding when %s drifts", (_label, override, reason) => {
 			const decision = decideNativeContinuity(baseInput(override));
 			expect(decision).toEqual({ kind: "flatten", reason });
@@ -110,11 +104,23 @@ describe("claude-sdk-oauth restored security", () => {
 			[
 				"system-prompt",
 				{ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v1" } },
-				"options_changed",
+				"system_prompt_changed",
 			],
-			["toolset", { fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v2" } }, "options_changed"],
+			["toolset", { fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v2" } }, "toolset_changed"],
 		] as const)("keeps live-entry reattach behavior when %s drifts", (_label, override, reason) => {
 			const decision = decideNativeContinuity(baseInput({ entry: liveEntry(), ...override }));
+			expect(decision).toMatchObject({ kind: "reattach", reason, sdkSessionId: SDK_SESSION_ID, from: 2 });
+		});
+
+		it.each([
+			[
+				"system-prompt",
+				{ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: "tools-v1" } },
+				"system_prompt_changed",
+			],
+			["toolset", { fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v2" } }, "toolset_changed"],
+		] as const)("reattaches a persisted binding when %s drifts (#7884)", (_label, override, reason) => {
+			const decision = decideNativeContinuity(baseInput(override));
 			expect(decision).toMatchObject({ kind: "reattach", reason, sdkSessionId: SDK_SESSION_ID, from: 2 });
 		});
 	});

--- a/packages/coding-agent/test/claude-sdk-oauth-session-registry-wiring.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-session-registry-wiring.test.ts
@@ -264,7 +264,7 @@ describe("Claude SDK OAuth session registry lifecycle wiring", () => {
 			transcriptAvailable: true,
 		});
 
-		expect(decision).toMatchObject({ kind: "reattach", reason: "options_changed" });
+		expect(decision).toMatchObject({ kind: "reattach", reason: "toolset_changed" });
 		expect(decision.kind).not.toBe("flatten");
 	});
 


### PR DESCRIPTION
Fixes code-yeongyu/oh-my-openagent#7884

## Problem

A plain `omo --session <id>` resume after a restart printed `Session continuity lost - resent the full conversation (options_changed) - sent 485.5KB` even though the user changed nothing. Two defects in the `claude-sdk-oauth` continuity lane compound:

1. **Restart bindings flattened on any fingerprint drift, while live sessions reattach on the same drift.** `decideFromBinding` returned `{ kind: "flatten", reason: "options_changed" }` whenever the persisted `systemPromptHash`/`toolsetHash` differed from the current turn. A restart has no live query: the resume builds a fresh `query()` carrying the current options and hooks anyway, so the flatten only re-paid the whole conversation.
2. **The midnight date-line normalization never matched a real prompt.** `GENERATED_DATE_LINE` required the `Current working directory:` line to be the last line of the prompt. A captured live prompt (51,457 chars / 686 lines) has `Current date:` at line 477, the cwd line at 478, and **207 more lines** of extension appends after it, so `systemPromptHash` drifted at every UTC midnight and every restart-resume across a midnight or an engine upgrade hit defect 1.

## Fix

- `session-continuity.ts`: `identityDrift` reports `system_prompt_changed` / `toolset_changed` (both already in the fixed observability vocabulary) instead of the bare `options_changed`. `decideFromBinding` flattens only on `account_changed` / `model_changed`; prompt/toolset drift falls through to the prefix checks and a matching prefix reattaches with the drift reason (divergence reasons still win). Live-entry behavior is unchanged apart from the split reasons.
- `session-sync.ts`: the date/cwd pair is neutralized wherever it sits in the prompt; every other region stays fail-closed.
- `changes.md`: entry with conflict zones; supersedes the note that a `HOST_TOOL_POLICY_FINGERPRINT` bump cold-seeds once after upgrade (it now reattaches with `toolset_changed`).

## Evidence (TDD, all runs on a remote ascii box, bun 1.4.0, vitest)

- **RED** (commit 72979d6ec, tests only): 5 files, **13 failed / 48 passed** - every failure is the target contract (`flatten/options_changed` where `reattach` is pinned; hash drift with trailing appends).
- **GREEN** (commit f75fd896c): same 5 files **61/61 passed**.
- **Regression**: full `claude-sdk-oauth-*` cluster **72 files, 510 passed, 3 skipped (pre-existing), 0 failed**.
- **Real surface**: the captured live prompt run through the pre-fix module gives a different `systemPromptHash` when only the date flips; the fixed module gives an identical hash and still changes when trailing content changes.
- Fail-closed pins kept: account/model drift on a persisted binding still flattens; `transcript_missing` precedes drift; sent-stream divergence dominates the drift reason.

## Notes

- `options_changed` remains in the sanitized vocabulary for historical `session.log` lines; nothing emits it anymore.
- `claude-sdk-oauth-session-registry-wiring.test.ts` was already above the 250 pure-LOC ceiling; this PR changes one expectation line there without growing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes restart resume so `omo --session <id>` reattaches on prompt/toolset fingerprint drift instead of re-sending the whole conversation, and makes midnight date-line normalization survive trailing extension appends.

**Bug Fixes**
- `decideFromBinding` now flattens only on account/model identity drift; prompt/toolset drift reattaches with `system_prompt_changed` / `toolset_changed` instead of a bare `options_changed`. Account/model drift and `transcript_missing` still fail closed.
- The date/cwd pair is now neutralized wherever it appears in the prompt; the old end-anchored regex never matched a real prompt with 200+ lines of extension appends after the cwd line, so `systemPromptHash` drifted at every UTC midnight.
- `options_changed` is no longer emitted; it stays in the sanitized vocabulary only for historical `session.log` lines. A `HOST_TOOL_POLICY_FINGERPRINT` bump now reattaches with `toolset_changed` instead of cold-seeding once after upgrade.

<sup>Written for commit 9639878323dcdebf533446bf2b31c86da9a0f6c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

