### PR TITLE
feat(coding-agent): add a workflow tip for the report-bug skill

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,22 @@
 
+## 2026-09-07 - Add a workflow tip for the report-bug skill
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts`: added a workflow tip that points users to the report-bug skill and explains that it records provider and model details, routes the issue, and waits for confirmation before filing.
+
+### Why
+
+- Users need a concise discovery path when they encounter a bug.
+
+### Why this lives in the fork
+
+- This tip describes a workflow skill shipped by the fork.
+
+### Expected merge conflict zones
+
+- LOW: appended array element in `subagent-tips.ts` and the `expectedTips` list.
+
 ## 2026-09-07 - /settings auto-compaction toggle persists explicitly (#1422)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
@@ -71,6 +71,12 @@ export const SUBAGENT_TIPS = [
 		render: () => 'Trigger "visual QA" to capture browser or xterm evidence and review web or terminal interfaces.',
 	},
 	{
+		id: "workflow-skills.report-bug",
+		bindings: [],
+		render: () =>
+			'Hit a bug? Say "report a bug" - the report-bug skill finds the session, records the exact provider and model, routes it to the right repository, and files an evidence-backed issue only after you confirm.',
+	},
+	{
 		id: "subagent-categories",
 		bindings: [],
 		requiresCommand: "tasks",

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -46,6 +46,10 @@ describe("collectTips", () => {
 				text: 'Trigger "visual QA" to capture browser or xterm evidence and review web or terminal interfaces.',
 				requiresCommand: "tasks",
 			},
+			{
+				id: "workflow-skills.report-bug",
+				text: 'Hit a bug? Say "report a bug" - the report-bug skill finds the session, records the exact provider and model, routes it to the right repository, and files an evidence-backed issue only after you confirm.',
+			},
 		];
 		const expectedIds = new Set(expectedTips.map((tip) => tip.id));
 


### PR DESCRIPTION
## What changed

Added the workflow tip `workflow-skills.report-bug`:

> Hit a bug? Say "report a bug" - the report-bug skill finds the session, records the exact provider and model, routes it to the right repository, and files an evidence-backed issue only after you confirm.

## Why

This improves discoverability for the report-bug skill shipped by omo-senpi.

## Changes catalog

Added the required `changes.md` entry. The tips catalog is upstream-tracked, so the entry documents the fork change and expected merge conflict zones.

## Verification

- Box tests: RED before the catalog entry, then GREEN with 17 pass and 0 fail.
- Mutation proof: removing the tip made the list-tips test fail; restoring it made the full test set pass.
- `bun run check`: exit 0.
- Omo skill PR: The omo skill PR follows.

---
Tag: omo-generated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow tip that surfaces the report-bug skill when users hit a bug, pointing them to a skill that records provider/model details, routes the issue, and waits for confirmation before filing.

- The tip is registered in the subagent tips catalog with id `workflow-skills.report-bug` and a bindings-free render.
- `changes.md` documents the fork-tracked edit and calls out the expected merge conflict zones.
- The tips test now pins the new tip, so removing it fails `list-tips.test.ts`.

<sup>Written for commit ea7e83b5b5ca81ce0673fe0ab5120608db8e1880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

