### PR TITLE
fix(coding-agent): gate the report-bug tip on the tasks command like its siblings

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -4,6 +4,7 @@
 ### What changed
 
 - `packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts`: added a workflow tip that points users to the report-bug skill and explains that it records provider and model details, routes the issue, and waits for confirmation before filing.
+- The tip is gated with requiresCommand: "tasks" like every other workflow tip, so it only surfaces where the omo-senpi task command exists.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
@@ -73,6 +73,7 @@ export const SUBAGENT_TIPS = [
 	{
 		id: "workflow-skills.report-bug",
 		bindings: [],
+		requiresCommand: "tasks",
 		render: () =>
 			'Hit a bug? Say "report a bug" - the report-bug skill finds the session, records the exact provider and model, routes it to the right repository, and files an evidence-backed issue only after you confirm.',
 	},

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -49,6 +49,7 @@ describe("collectTips", () => {
 			{
 				id: "workflow-skills.report-bug",
 				text: 'Hit a bug? Say "report a bug" - the report-bug skill finds the session, records the exact provider and model, routes it to the right repository, and files an evidence-backed issue only after you confirm.',
+				requiresCommand: "tasks",
 			},
 		];
 		const expectedIds = new Set(expectedTips.map((tip) => tip.id));


### PR DESCRIPTION
## Problem
The report-bug tip merged in #1433 was the only tip in `subagent-tips.ts` without `requiresCommand`, so it could surface for users without the omo-senpi skill. The catalog measured 15/16 gated, with all gated tips requiring `tasks`.

## Fix
- Add `requiresCommand: "tasks"`, matching every sibling.
- Pin the gate in `list-tips.test.ts`.
- Add a one-line `changes.md` note.

## Verification
- [x] RED: 5 pass / 1 fail before the catalog line
- [x] GREEN: 17 pass / 0 fail across list-tips, tips-registry, and brand-tips
- [x] Mutation: RED after removal -> GREEN after restore
- [x] `bun run check` exit 0

Closes #1434

---
Tag: omo-generated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the report-bug tip on the `tasks` command so it only surfaces where the omo-senpi skill exists, matching every other workflow tip in the catalog.

- Adds `requiresCommand: "tasks"` to the report-bug tip.
- Pins the gate in `list-tips.test.ts` and notes the change in `changes.md`.

<sup>Written for commit 2b3456e5108a173ed7c89f6296d5cf94b369bda3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

