### PR TITLE
fix(rpc): unlink only the host's own socket on close

### DIFF
--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Socket teardown is ownership-checked, never path-only (2026-09-07)
+
+### What changed
+
+- New `socket-ownership.ts`: `statSocketIdentity()` (dev+ino of a socket path entry), an ownership token sidecar in the lifecycle supervisor's private scratch directory (`public-socket.owner`), and `unlinkOwnedSocket()`, which unlinks a socket path only while its current stat identity matches the recorded one. ENOENT is nothing to do; a mismatch logs `socket path ... now owned by another host; leaving it`; an unknown identity is never guessed at and the path is left.
+- `multi-session-host.ts`: the socket host records its bound entry's identity right after `listen()` (same step as the existing 0600 chmod) and its shutdown replaces the unconditional `unlink(socketPath)` with the ownership-checked removal. A supervised host additionally removes the supervisor's public socket through the same check, using the token its supervisor published; that covers the watchdog crash path, which previously removed the public socket by path from `HOST_CLEANUP_PATHS`.
+- `host-lifecycle.ts`: the supervisor stats the public entry it just bound, publishes the token into its scratch directory for its child, and its shutdown replaces `rm(publicSocket)` with the ownership-checked removal. On POSIX the public socket is no longer listed in `HOST_CLEANUP_PATHS` (the child removes it token-checked); Windows named pipes keep the old behavior since they have no filesystem entry to own.
+- `test/suite/rpc-socket-ownership.test.ts`: for both a direct multi-session host and a supervisor-managed one, a replacement socket renamed over the live path (the takeover dance) survives SIGTERM shutdown and still connects, while the no-takeover path is removed and an already-absent path is tolerated; a supervisor SIGKILL (watchdog crash path) preserves a taken-over path and still removes an untaken one.
+
+### Why
+
+The startup path already refuses to touch a socket path owned by a live server (`prepareSocketPath` probes before unlinking), but every teardown path removed by path only. The OmO desktop replaces a socketless host by starting the new host on `<socket>.takeover-<pid>`, renaming it over `rpc.sock`, then SIGTERMing the old host; the old host's shutdown unlinked `rpc.sock` - now the NEW host's entry - leaving the supervisor alive, `rpc host ready on .../rpc.sock` logged, the socket absent, and every desktop session failing `connect ENOENT rpc.sock`. The same blind removal existed on the supervisor's own shutdown and on the child watchdog's crash-path cleanup (`HOST_CLEANUP_PATHS`). A probe-if-live check alone does not close this: after the rename and before the new host's listen completes, a probe would also fail, and crash/signal paths reintroduce the race. The dev+ino token captured at bind is what closes every teardown path deterministically.
+
+### Why an extension could not handle it
+
+Socket bind, unlink, and process-teardown ordering are transport lifecycle internals below every extension hook; no extension observes or intercepts host shutdown.
+
+### Expected merge conflict zones
+
+- LOW: `socket-ownership.ts` is fork-only and additive.
+- LOW: the `listen()` tail and shutdown-removal call in `multi-session-host.ts`, and the public-socket cleanup swap plus token write in `host-lifecycle.ts`.
+- LOW: `test/suite/rpc-socket-ownership.test.ts` (new).
+
 ## Shared-host logical sessions are unlimited by default (2026-09-06)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -50,11 +50,20 @@ import { processIsLive, readProcessStartTime } from "../app-server/daemon/proces
 import { createHostDaemonPaths } from "./host-ensure.ts";
 import {
 	HOST_CLEANUP_PATHS_ENV,
+	HOST_PUBLIC_SOCKET_ENV,
 	HOST_SCRATCH_DIR_ENV,
 	HOST_WATCH_FD_ENV,
 	HOST_WATCH_PPID_ENV,
 } from "./host-watchdog.ts";
 import { attachJsonlLineReader, MAX_RPC_LINE_CHARACTERS } from "./jsonl.ts";
+import {
+	PUBLIC_SOCKET_IDENTITY_FILE,
+	type SocketFileIdentity,
+	shieldSocketDuringClose,
+	statSocketIdentity,
+	unlinkOwnedSocket,
+	writeSocketIdentityFile,
+} from "./socket-ownership.ts";
 import {
 	authenticateSocket,
 	createSocketSecret,
@@ -390,8 +399,15 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 			[HOST_CLEANUP_PATHS_ENV]: [
 				paths.pidFile,
 				paths.settingsFile,
-				...(process.platform === "win32" ? [] : [publicSocket]),
+				// POSIX public sockets are removed ownership-checked by the host child
+				// (token: the scratch-directory sidecar plus HOST_PUBLIC_SOCKET_ENV),
+				// never by path from a crash-path cleanup: a blind removal here would
+				// unlink a newer host's freshly published entry after a takeover.
+				// Windows named pipes have no filesystem entry to own, so they stay
+				// listed for the crash-path cleanup.
+				...(process.platform === "win32" ? [publicSocket] : []),
 			].join("\n"),
+			...(process.platform === "win32" ? {} : { [HOST_PUBLIC_SOCKET_ENV]: publicSocket }),
 		},
 		// Slot 3 is the lifetime pipe: "pipe" gives the child a read end it can
 		// wait on and keeps the write end owned by this process alone.
@@ -498,7 +514,10 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 		try {
 			writeStderrLine(`senpi rpc host supervisor: ${reason} shutdown`);
 			for (const client of clientSockets) client.destroy();
-			await closeServer(server);
+			// libuv unlinks the bound NAME when the listening handle closes - which
+			// would delete a newer host's entry renamed over this path. Shield the
+			// current entry for the close, then let the ownership check decide.
+			await shieldSocketDuringClose(publicSocket, () => closeServer(server));
 			// Unlink the private directory BEFORE the child stop, which can take seconds:
 			// an external SIGKILL landing during that wait (ensureHost escalates while
 			// replacing a host) would otherwise leave the directory behind. The child
@@ -507,7 +526,12 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 			if (internal.dir) await rm(internal.dir, { recursive: true, force: true });
 			await stopChild(child);
 			observer?.destroy();
-			if (publicSocketOwned && process.platform !== "win32") await rm(publicSocket, { force: true });
+			if (publicSocketOwned && process.platform !== "win32") {
+				// Ownership-checked: after a takeover, a newer host may have published
+				// a fresh entry at this path; only the entry THIS supervisor bound is
+				// removed. (The host child applies the same rule to its crash path.)
+				await unlinkOwnedSocket(publicSocket, publicSocketIdentity, supervisorLog);
+			}
 			// Mirror ensureHost's cleanupState: the pidfile and settings describe a
 			// live host only; the stderr log stays for diagnostics.
 			await rm(paths.pidFile, { force: true });
@@ -523,6 +547,10 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 
 	let observer: Socket | undefined;
 	let publicSocketOwned = false;
+	let publicSocketIdentity: SocketFileIdentity | undefined;
+	function supervisorLog(message: string): void {
+		writeStderrLine(`senpi rpc host supervisor: ${message}`);
+	}
 	// Registered before the startup handshake, not after it: the private internal
 	// directory already exists at this point, so a SIGTERM arriving during host
 	// startup must run the same cleanup instead of Node's default kill, which
@@ -534,6 +562,13 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 		await prepareSocketPath(publicSocket);
 		await listen(server, publicSocket, publicSecret);
 		publicSocketOwned = true;
+		publicSocketIdentity = await statSocketIdentity(publicSocket);
+		// Publish the ownership token inside this supervisor's private scratch
+		// directory (which no replacement supervisor writes): the host child's
+		// crash-path cleanup compares the public path against THIS entry only.
+		if (publicSocketIdentity && internal.dir) {
+			await writeSocketIdentityFile(join(internal.dir, PUBLIC_SOCKET_IDENTITY_FILE), publicSocketIdentity);
+		}
 	} catch (cause) {
 		await shutdown(`startup failed: ${errorMessage(cause)}`, 1);
 	}

--- a/packages/coding-agent/src/modes/rpc/host-watchdog.ts
+++ b/packages/coding-agent/src/modes/rpc/host-watchdog.ts
@@ -23,6 +23,8 @@ import { readProcessIdentity } from "../app-server/daemon/process.ts";
 export const HOST_WATCH_FD_ENV = "SENPI_RPC_HOST_WATCH_FD";
 /** Supervisor-owned private directory the host removes on watchdog shutdown. */
 export const HOST_SCRATCH_DIR_ENV = "SENPI_RPC_HOST_SCRATCH_DIR";
+/** Public socket path the supervisor bound; the host removes it ownership-checked. */
+export const HOST_PUBLIC_SOCKET_ENV = "SENPI_RPC_HOST_PUBLIC_SOCKET";
 /** Fallback binding when no inherited fd is available: poll this pid. */
 export const HOST_WATCH_PPID_ENV = "SENPI_RPC_HOST_WATCH_PPID";
 /** Poll cadence for the ppid fallback. */
@@ -36,6 +38,7 @@ export interface HostWatchdogConfig {
 	readonly ppid?: number;
 	readonly scratchDir?: string;
 	readonly cleanupPaths?: readonly string[];
+	readonly publicSocket?: string;
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
@@ -57,11 +60,13 @@ export function readHostWatchdogConfig(
 	if (fd === undefined && ppid === undefined) return undefined;
 	const scratchDir = env[HOST_SCRATCH_DIR_ENV];
 	const cleanupPaths = env[HOST_CLEANUP_PATHS_ENV]?.split("\n").filter(Boolean);
+	const publicSocket = env[HOST_PUBLIC_SOCKET_ENV];
 	return {
 		fd,
 		ppid,
 		scratchDir: scratchDir === undefined || scratchDir === "" ? undefined : scratchDir,
 		cleanupPaths,
+		publicSocket: publicSocket === "" ? undefined : publicSocket,
 	};
 }
 
@@ -75,6 +80,7 @@ export function readHostWatchdogConfigFromBrandEnv(): HostWatchdogConfig | undef
 		[HOST_WATCH_FD_ENV]: process.env[HOST_WATCH_FD_ENV] ?? envValue("RPC_HOST_WATCH_FD"),
 		[HOST_WATCH_PPID_ENV]: process.env[HOST_WATCH_PPID_ENV] ?? envValue("RPC_HOST_WATCH_PPID"),
 		[HOST_SCRATCH_DIR_ENV]: process.env[HOST_SCRATCH_DIR_ENV] ?? envValue("RPC_HOST_SCRATCH_DIR"),
+		[HOST_PUBLIC_SOCKET_ENV]: process.env[HOST_PUBLIC_SOCKET_ENV] ?? envValue("RPC_HOST_PUBLIC_SOCKET"),
 		[HOST_CLEANUP_PATHS_ENV]: process.env[HOST_CLEANUP_PATHS_ENV] ?? envValue("RPC_HOST_CLEANUP_PATHS"),
 	});
 }

--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -21,6 +21,14 @@ import { type RpcBindingFactory, SessionCommandRouter } from "./session-command-
 import { SessionEventWriter } from "./session-event-writer.ts";
 import { RpcSessionRegistry } from "./session-registry.ts";
 import {
+	PUBLIC_SOCKET_IDENTITY_FILE,
+	type SocketFileIdentity,
+	shieldSocketDuringClose,
+	statSocketIdentity,
+	unlinkOwnedSocket,
+	waitForSocketIdentityFile,
+} from "./socket-ownership.ts";
+import {
 	authenticateSocket,
 	ensureSocketSecret,
 	resolveSocketTransportAddress,
@@ -202,6 +210,22 @@ async function runSocketHost(options: MultiSessionHostOptions, socketPath: strin
 		process.platform === "win32"
 			? await ensureSocketSecret(process.env[SOCKET_SECRET_FILE_ENV] ?? socketSecretPath(socketPath))
 			: undefined;
+	const watchdogConfig = readHostWatchdogConfigFromBrandEnv();
+	// Crash-path ownership for the supervisor's PUBLIC socket: the supervisor
+	// records the identity of the entry it bound (inside its private scratch
+	// directory, which no replacement supervisor writes) right after its listen,
+	// and this host removes that path only while the identity still matches. A
+	// blind path removal here would unlink a newer host's freshly published
+	// entry after a takeover - the startup path already refuses to touch a
+	// socket owned by a live server; teardown follows the same rule.
+	const supervisorPublicSocketPath =
+		process.platform === "win32" || socketPath.startsWith("\0") ? undefined : watchdogConfig?.publicSocket;
+	const supervisorPublicOwnerFile =
+		supervisorPublicSocketPath && watchdogConfig?.scratchDir
+			? join(watchdogConfig.scratchDir, PUBLIC_SOCKET_IDENTITY_FILE)
+			: undefined;
+	let boundIdentity: SocketFileIdentity | undefined;
+	let supervisorPublicIdentity: SocketFileIdentity | undefined;
 	const server = createServer((socket) => {
 		const accept = (): void => {
 			const id = `socket-${++nextConnection}`;
@@ -266,12 +290,23 @@ async function runSocketHost(options: MultiSessionHostOptions, socketPath: strin
 				connection.detach();
 				connection.close();
 			}
-			await (process.platform === "win32"
-				? Promise.race([closeServer(server), delay(WINDOWS_SHUTDOWN_HARD_EXIT_MS)])
-				: closeServer(server));
+			// libuv unlinks the bound NAME when the listening handle closes - which
+			// would delete a newer host's entry renamed over this path. Shield the
+			// current entry for the close, then let the ownership check decide.
+			await shieldSocketDuringClose(socketPath, () =>
+				process.platform === "win32"
+					? Promise.race([closeServer(server), delay(WINDOWS_SHUTDOWN_HARD_EXIT_MS)])
+					: closeServer(server),
+			);
 			await router.dispose();
 			await writer.flush();
-			await removeSocketPath(socketPath);
+			// Ownership-checked: unlink only the entry THIS process bound. After a
+			// takeover renamed a newer host's socket over the same path, the
+			// identity no longer matches and the replacement stays published.
+			await unlinkOwnedSocket(socketPath, boundIdentity, hostLog);
+			if (supervisorPublicSocketPath) {
+				await unlinkOwnedSocket(supervisorPublicSocketPath, supervisorPublicIdentity, hostLog);
+			}
 			if (watchdogCleanup) await watchdogCleanup;
 		} finally {
 			// Explicitly terminate after every shutdown trigger. Windows named-pipe
@@ -283,7 +318,7 @@ async function runSocketHost(options: MultiSessionHostOptions, socketPath: strin
 	registerShutdownSignals(shutdown);
 	// Arm before listen: a supervisor death during the listen transition must
 	// still close the child and clean its private endpoint.
-	armHostWatchdog(readHostWatchdogConfigFromBrandEnv(), (reason, cleanup) => {
+	armHostWatchdog(watchdogConfig, (reason, cleanup) => {
 		process.stderr.write(`senpi rpc host: ${reason}; shutting down\n`);
 		// Enter shutdown before killing session-owned child processes. The Windows
 		// tree killer is synchronous, while the shutdown fallback must be armed
@@ -291,7 +326,13 @@ async function runSocketHost(options: MultiSessionHostOptions, socketPath: strin
 		void shutdown(0, cleanup);
 		setImmediate(killTrackedDetachedChildren);
 	});
-	await listen(server, socketPath, secret);
+	boundIdentity = await listen(server, socketPath, secret);
+	if (supervisorPublicOwnerFile) {
+		// The supervisor publishes its public-socket token after this internal
+		// listener is ready, so a short bounded wait keeps the lifecycles in step
+		// without delaying unsupervised hosts.
+		supervisorPublicIdentity = await waitForSocketIdentityFile(supervisorPublicOwnerFile);
+	}
 	process.stderr.write(`senpi rpc listening on ${formatSocketAddress(socketPath)}\n`);
 
 	// Opt-in only: set by the lifecycle supervisor so this host can never outlive
@@ -381,14 +422,19 @@ function probeSocket(socketPath: string): Promise<boolean> {
 	});
 }
 
-function listen(server: Server, socketPath: string, secret?: Uint8Array): Promise<void> {
+function listen(server: Server, socketPath: string, secret?: Uint8Array): Promise<SocketFileIdentity | undefined> {
 	return new Promise((resolve, reject) => {
 		server.once("error", reject);
 		server.listen(resolveSocketTransportAddress(socketPath, process.platform, secret), async () => {
 			server.off("error", reject);
 			try {
-				if (process.platform !== "win32" && !socketPath.startsWith("\0")) await chmod(socketPath, 0o600);
-				resolve();
+				if (process.platform !== "win32" && !socketPath.startsWith("\0")) {
+					await chmod(socketPath, 0o600);
+					// Record which filesystem entry THIS listener created; shutdown
+					// removes the path only while this identity still matches.
+					return resolve(await statSocketIdentity(socketPath));
+				}
+				resolve(undefined);
 			} catch (cause) {
 				reject(cause);
 			}
@@ -402,13 +448,8 @@ function closeServer(server: Server): Promise<void> {
 	});
 }
 
-async function removeSocketPath(socketPath: string): Promise<void> {
-	if (process.platform === "win32" || socketPath.startsWith("\0")) return;
-	try {
-		await unlink(socketPath);
-	} catch (cause) {
-		if (!isNodeErrorCode(cause, "ENOENT")) throw cause;
-	}
+function hostLog(message: string): void {
+	process.stderr.write(`senpi rpc host: ${message}\n`);
 }
 
 function isNodeErrorCode(cause: unknown, code: string): boolean {

--- a/packages/coding-agent/src/modes/rpc/socket-ownership.ts
+++ b/packages/coding-agent/src/modes/rpc/socket-ownership.ts
@@ -1,0 +1,190 @@
+/**
+ * Ownership-checked removal for Unix domain socket path entries.
+ *
+ * A socket path is a rendezvous name, not a capability: once a host unlinks
+ * its entry, any other process may bind the same path. Teardown that removes
+ * "its" socket by path alone can therefore delete a NEWER host's freshly
+ * published entry after a takeover renamed a replacement over that path. The
+ * startup path already refuses to touch a socket owned by a live server
+ * (`prepareSocketPath`); these helpers give every teardown path the same rule:
+ * capture the bound entry's filesystem identity (dev + ino) at listen time and
+ * unlink only while the path still stat-matches that identity.
+ */
+import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/** Filesystem identity of one bound socket path entry. */
+export interface SocketFileIdentity {
+	readonly dev: number;
+	readonly ino: number;
+}
+
+/**
+ * Name of the sidecar, inside the lifecycle supervisor's private scratch
+ * directory, that records which public socket entry that supervisor bound. The
+ * directory is per-supervisor, so a replacement supervisor's token can never be
+ * mistaken for the old one's.
+ */
+export const PUBLIC_SOCKET_IDENTITY_FILE = "public-socket.owner";
+
+/** Default bound on waiting for a supervisor to publish its ownership token. */
+export const SOCKET_IDENTITY_WAIT_MS = 30_000;
+
+function sameSocketIdentity(a: SocketFileIdentity, b: SocketFileIdentity): boolean {
+	return a.dev === b.dev && a.ino === b.ino;
+}
+
+/** Reads the current identity of a socket path entry; `undefined` once absent. */
+export async function statSocketIdentity(socketPath: string): Promise<SocketFileIdentity | undefined> {
+	try {
+		const { dev, ino } = await stat(socketPath);
+		return { dev, ino };
+	} catch (cause) {
+		if (isNodeErrorCode(cause, "ENOENT")) return undefined;
+		throw cause;
+	}
+}
+
+/** Records a bound socket identity for teardown paths that cannot hold it in memory. */
+export async function writeSocketIdentityFile(path: string, identity: SocketFileIdentity): Promise<void> {
+	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	const tmpPath = `${path}.${process.pid}.tmp`;
+	await writeFile(tmpPath, `${JSON.stringify(identity)}\n`, { mode: 0o600 });
+	await rename(tmpPath, path);
+}
+
+export async function readSocketIdentityFile(path: string): Promise<SocketFileIdentity | undefined> {
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf8");
+	} catch (cause) {
+		if (isNodeErrorCode(cause, "ENOENT")) return undefined;
+		throw cause;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		// Truncated or in-progress JSON is not a token: callers wait or leave the path.
+		return undefined;
+	}
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		typeof (parsed as { dev?: unknown }).dev !== "number" ||
+		typeof (parsed as { ino?: unknown }).ino !== "number"
+	) {
+		return undefined;
+	}
+	return { dev: (parsed as { dev: number }).dev, ino: (parsed as { ino: number }).ino };
+}
+
+/**
+ * Waits, bounded, for an identity file to appear. The lifecycle supervisor
+ * publishes its public-socket token after this host's internal listener is
+ * ready, so supervised hosts poll briefly instead of assuming ordering.
+ */
+export async function waitForSocketIdentityFile(
+	path: string,
+	timeoutMs: number = SOCKET_IDENTITY_WAIT_MS,
+	intervalMs = 25,
+): Promise<SocketFileIdentity | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const identity = await readSocketIdentityFile(path);
+		if (identity !== undefined) return identity;
+		if (Date.now() >= deadline) return undefined;
+		await delayUnrefed(intervalMs);
+	}
+}
+
+/**
+ * Unlinks a socket path only while it still refers to the entry `identity`
+ * describes. An absent path is nothing to do; a mismatched identity means a
+ * newer host owns the name now and is left alone; an unknown identity can
+ * never be proven ours, so the path is left and the decision is logged.
+ */
+export async function unlinkOwnedSocket(
+	socketPath: string,
+	identity: SocketFileIdentity | undefined,
+	log: (message: string) => void,
+): Promise<void> {
+	if (process.platform === "win32" || socketPath.startsWith("\0")) return;
+	let current: SocketFileIdentity | undefined;
+	try {
+		current = await statSocketIdentity(socketPath);
+	} catch (cause) {
+		log(`socket ${socketPath} ownership could not be verified (${errorMessage(cause)}); leaving it`);
+		return;
+	}
+	if (current === undefined) return;
+	if (identity === undefined) {
+		log(`socket path ${socketPath} ownership unknown; leaving it`);
+		return;
+	}
+	if (!sameSocketIdentity(current, identity)) {
+		log(`socket path ${socketPath} now owned by another host; leaving it`);
+		return;
+	}
+	try {
+		await unlink(socketPath);
+	} catch (cause) {
+		if (!isNodeErrorCode(cause, "ENOENT")) {
+			log(`socket ${socketPath} removal failed (${errorMessage(cause)})`);
+		}
+	}
+}
+
+/**
+ * Runs `close` with the socket path's current entry shielded from libuv's
+ * close-time unlink.
+ *
+ * libuv unlinks the NAME a pipe was bound to when its listening handle
+ * closes - even when a takeover has renamed a DIFFERENT socket over that
+ * name, so an ordinary `server.close()` silently deletes the newer host's
+ * freshly published entry. Moving the current entry aside for the duration
+ * of the close (libuv's unlink then hits ENOENT) and restoring it afterwards
+ * keeps the filesystem exactly as it was; ownership-checked removal via
+ * `unlinkOwnedSocket` decides afterwards what may actually be deleted.
+ */
+export async function shieldSocketDuringClose(socketPath: string, close: () => Promise<void>): Promise<void> {
+	if (process.platform === "win32" || socketPath.startsWith("\0")) return close();
+	const shieldPath = `${socketPath}.shield-${process.pid}`;
+	let shielded = false;
+	try {
+		if ((await statSocketIdentity(socketPath)) !== undefined) {
+			await rename(socketPath, shieldPath);
+			shielded = true;
+		}
+	} catch {
+		// Without a shield the close degrades to today's behavior; the
+		// ownership-checked unlink still runs afterwards.
+	}
+	try {
+		await close();
+	} finally {
+		if (shielded) {
+			try {
+				await rename(shieldPath, socketPath);
+			} catch {
+				// Best effort: a failed restore leaves the entry under the shield
+				// name; startup probes treat a dead entry as replaceable.
+			}
+		}
+	}
+}
+
+function delayUnrefed(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(resolve, ms);
+		timer.unref?.();
+	});
+}
+
+function errorMessage(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause);
+}
+
+function isNodeErrorCode(cause: unknown, code: string): boolean {
+	return cause instanceof Error && "code" in cause && cause.code === code;
+}

--- a/packages/coding-agent/test/suite/rpc-socket-ownership.test.ts
+++ b/packages/coding-agent/test/suite/rpc-socket-ownership.test.ts
@@ -1,0 +1,202 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, rename, rm, stat, unlink } from "node:fs/promises";
+import { createServer, type Server, Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { hermeticProviderEnv } from "../helpers/rpc-hermetic.ts";
+
+const roots: string[] = [];
+const children = new Set<ChildProcessWithoutNullStreams>();
+const replacements: Server[] = [];
+const deadlineMs = 45_000;
+const packageRoot = resolve(import.meta.dirname, "../..");
+const testTimeoutMs = 60_000;
+
+afterEach(async () => {
+	await Promise.all([...children].map((child) => stop(child, "SIGKILL")));
+	await Promise.all(
+		replacements.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+	);
+	await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+}, testTimeoutMs);
+
+// Filesystem socket takeover is POSIX-only; Windows uses named pipes, not path entries.
+describe.skipIf(process.platform === "win32")("RPC socket shutdown ownership", () => {
+	for (const supervised of [false, true]) {
+		describe(supervised ? "lifecycle supervisor" : "direct multi-session host", () => {
+			it(
+				"leaves a replacement socket present and connectable after SIGTERM",
+				async () => {
+					const host = await startHost(supervised);
+					const replacementIdentity = await takeOver(host.socketPath);
+
+					expect(await stop(host.child, "SIGTERM")).toEqual([143, null]);
+
+					await expect(stat(host.socketPath)).resolves.toMatchObject(replacementIdentity);
+					expect(await readReplacement(host.socketPath)).toBe("replacement-host");
+				},
+				testTimeoutMs,
+			);
+
+			it(
+				"removes its own socket when no takeover occurred",
+				async () => {
+					const host = await startHost(supervised);
+					expect((await stat(host.socketPath)).isSocket()).toBe(true);
+
+					expect(await stop(host.child, "SIGTERM")).toEqual([143, null]);
+
+					await expect(stat(host.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+				},
+				testTimeoutMs,
+			);
+
+			it(
+				"tolerates an already absent socket during shutdown",
+				async () => {
+					const host = await startHost(supervised);
+					await unlink(host.socketPath);
+
+					expect(await stop(host.child, "SIGTERM")).toEqual([143, null]);
+
+					await expect(stat(host.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+				},
+				testTimeoutMs,
+			);
+		});
+	}
+
+	it(
+		"leaves a replacement socket connectable after supervisor SIGKILL and watchdog cleanup",
+		async () => {
+			const host = await startHost(true);
+			const replacementIdentity = await takeOver(host.socketPath);
+
+			// The host inherits the supervisor's stderr pipe. close waits for both
+			// processes to release it, so the watchdog cleanup has finished too.
+			expect(await stop(host.child, "SIGKILL")).toEqual([null, "SIGKILL"]);
+
+			await expect(stat(host.socketPath)).resolves.toMatchObject(replacementIdentity);
+			expect(await readReplacement(host.socketPath)).toBe("replacement-host");
+		},
+		testTimeoutMs,
+	);
+
+	it(
+		"removes the supervisor's own public socket on watchdog cleanup without a takeover",
+		async () => {
+			const host = await startHost(true);
+			expect((await stat(host.socketPath)).isSocket()).toBe(true);
+
+			expect(await stop(host.child, "SIGKILL")).toEqual([null, "SIGKILL"]);
+
+			await expect(stat(host.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+		},
+		testTimeoutMs,
+	);
+});
+
+async function startHost(supervised: boolean): Promise<{
+	child: ChildProcessWithoutNullStreams;
+	socketPath: string;
+}> {
+	const root = await mkdtemp(join(tmpdir(), "rpc-owner-"));
+	roots.push(root);
+	const agentDir = join(root, "agent");
+	await mkdir(agentDir);
+	const socketPath = join(root, "rpc.sock");
+	const args = supervised
+		? [
+				"--import",
+				"tsx",
+				join(packageRoot, "src/modes/rpc/host-lifecycle.ts"),
+				"--socket",
+				socketPath,
+				"--agent-dir",
+				agentDir,
+			]
+		: [join(packageRoot, "src/cli.ts"), "--mode", "rpc", "--listen", `unix://${socketPath}`];
+	const child = spawn(process.execPath, args, {
+		// The package root keeps `--import tsx` resolvable from node_modules for the
+		// supervisor route (the existing lifecycle suite spawns the same way); the
+		// hermetic scratch directories above carry every path the host touches.
+		cwd: packageRoot,
+		env: {
+			...process.env,
+			...hermeticProviderEnv(),
+			PI_OFFLINE: "1",
+			PI_TELEMETRY: "0",
+			SENPI_RUNTIME: "node",
+			SENPI_CODING_AGENT_DIR: agentDir,
+			SENPI_CODING_AGENT_SESSION_DIR: join(root, "sessions"),
+			SENPI_RPC_HOST_COLD_START: "persistent",
+		},
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	children.add(child);
+	child.once("close", () => children.delete(child));
+	const readiness = supervised ? `ready on unix://${socketPath}` : `listening on unix://${socketPath}`;
+	await new Promise<void>((resolve, reject) => {
+		let stderr = "";
+		const timer = setTimeout(() => fail(new Error(`Host readiness timed out: ${stderr}`)), deadlineMs);
+		const cleanup = () => {
+			clearTimeout(timer);
+			child.stderr.off("data", onData);
+			child.off("error", fail);
+			child.off("close", onClose);
+		};
+		const fail = (cause: Error) => {
+			cleanup();
+			reject(cause);
+		};
+		const onClose = () => fail(new Error(`Host exited before readiness: ${stderr}`));
+		const onData = (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+			if (!stderr.includes(readiness)) return;
+			cleanup();
+			resolve();
+		};
+		child.stderr.on("data", onData);
+		child.once("error", fail);
+		child.once("close", onClose);
+	});
+	return { child, socketPath };
+}
+
+async function stop(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): Promise<unknown[]> {
+	const closed = once(child, "close", { signal: AbortSignal.timeout(deadlineMs) });
+	child.kill(signal);
+	return closed;
+}
+
+async function takeOver(socketPath: string): Promise<{ dev: number; ino: number }> {
+	const takeoverPath = `${socketPath}.takeover`;
+	const server = createServer((socket) => socket.end("replacement-host"));
+	replacements.push(server);
+	const listening = once(server, "listening", { signal: AbortSignal.timeout(deadlineMs) });
+	server.listen(takeoverPath);
+	await listening;
+	const { dev, ino } = await stat(takeoverPath);
+	const oldIdentity = await stat(socketPath);
+	expect([dev, ino]).not.toEqual([oldIdentity.dev, oldIdentity.ino]);
+	await rename(takeoverPath, socketPath);
+	return { dev, ino };
+}
+
+async function readReplacement(socketPath: string): Promise<string> {
+	const socket = new Socket();
+	let response = "";
+	socket.on("data", (chunk: Buffer) => {
+		response += chunk.toString("utf8");
+	});
+	const ended = once(socket, "end", { signal: AbortSignal.timeout(deadlineMs) });
+	socket.connect(socketPath);
+	try {
+		await ended;
+		return response;
+	} finally {
+		socket.destroy();
+	}
+}


### PR DESCRIPTION
## Summary

Stop RPC host teardown from deleting a successor's Unix socket after a takeover.

OmO desktop replaces a socketless host by binding on `<socket>.takeover-<pid>`, renaming that entry over `rpc.sock`, then SIGTERMing the old host. The old host's `server.close()` still deleted `rpc.sock` — now the new host's entry — leaving the supervisor alive, `rpc host ready` logged, the socket absent, and every desktop session failing with `connect ENOENT rpc.sock`.

## Root cause

libuv unlinks the **name** a pipe was bound to when the listening handle closes. That unlink is path-based, not inode-based: after a takeover has renamed a **different** socket over the same path, `closeServer()` silently removes the successor's freshly published entry.

The startup path already refuses to touch a socket owned by a live server (`prepareSocketPath`). Every teardown path still removed by path only: the multi-session host's `unlink(socketPath)`, the supervisor's `rm(publicSocket)`, and the watchdog crash-path list `HOST_CLEANUP_PATHS`. A probe-if-live check does not close this; after the rename and before the new host's listen completes, a probe would also fail, and crash/signal paths reintroduce the race.

## Fix

- **Rename-aside shield** (`shieldSocketDuringClose`): move the current path entry aside for the duration of `server.close()` so libuv's close-time unlink hits ENOENT, then restore the entry. The filesystem is unchanged by the close itself.
- **Ownership-checked unlink**: capture `dev+ino` at listen time and unlink only while the path still stats as that identity. A mismatch means a newer host owns the name and is left alone.
- **`HOST_PUBLIC_SOCKET_ENV` (`SENPI_RPC_HOST_PUBLIC_SOCKET`)**: the supervisor publishes the public path (and an identity sidecar in its private scratch directory). The child uses that to ownership-check the public socket on the watchdog crash path instead of a blind `HOST_CLEANUP_PATHS` removal. Windows named pipes are unchanged (no filesystem entry to own).

## Tests

**RED** (unfixed host, `test/suite/rpc-socket-ownership.test.ts`): 3 failed / 5 passed (8). Takeover after SIGTERM and after supervisor SIGKILL both left the replacement socket missing (`ENOENT` on `rpc.sock`).

**GREEN** (this branch, box `base=1d72faac0` = `origin/main`):

```
cd packages/coding-agent && bunx vitest --run test/suite/rpc-socket-ownership.test.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
Duration  76.95s
```

```
cd packages/coding-agent && bunx vitest --run test/rpc
Test Files  34 passed (34)
     Tests  277 passed (277)
Duration  268.25s
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RPC host teardown deleting a successor's Unix socket after a takeover, which left every desktop session failing with `connect ENOENT rpc.sock`.

**Bug Fixes**
- Captures each socket's filesystem identity (`dev` + `ino`) at listen time and unlinks only while the path still matches; a renamed replacement is left in place.
- Shields the socket entry during `server.close()` because libuv unlinks the bound name when the listening handle closes.
- The supervisor publishes its public-socket identity in a scratch-directory sidecar, and the child's watchdog crash path uses the same ownership check instead of removing paths blindly.
- Windows named pipes keep the old behavior since they have no filesystem entry to own.

<sup>Written for commit d7ee02ebbf6ac7760cb0eb9dfb43e3d65f7cd7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

