### PR TITLE
fix(codemode): capture the last expression unless a top-level return exists (#1439)

### DIFF
--- a/packages/ai/test/gpt-6-astra-context-window.test.ts
+++ b/packages/ai/test/gpt-6-astra-context-window.test.ts
@@ -24,7 +24,10 @@ function collectAstraEntries(): AstraEntry[] {
 	for (const file of readdirSync(dataDirectory)
 		.filter((name) => name.endsWith(".json"))
 		.sort()) {
-		const parsed = JSON.parse(readFileSync(`${dataDirectory}${file}`, "utf8")) as Record<string, Record<string, CatalogEntry>>;
+		const parsed = JSON.parse(readFileSync(`${dataDirectory}${file}`, "utf8")) as Record<
+			string,
+			Record<string, CatalogEntry>
+		>;
 		for (const [api, models] of Object.entries(parsed)) {
 			if (!models || typeof models !== "object") continue;
 			for (const [id, model] of Object.entries(models)) {

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- JavaScript eval cells no longer lose their completion value when a nested function, callback, or try/catch helper contains `return`: the cell wrapper now skips last-expression capture only for a genuine top-level `return`, and a property named `return` no longer primes the statement scanner as the keyword (#1439).
+- Eval output truncation notices now name the real cause: a width-clamped line reports `N line(s) clamped to M columns (… dropped)`, a byte-capped tail reports the actual cap, and a notice never presents the output's own size as a limit.
+
 ### Removed
 
 ## [2026.9.7] - 2026-09-07

--- a/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
@@ -11,7 +11,7 @@ export async function awaitMaybePromise(value) {
 
 export function wrapUserCode(code) {
 	const persistentCode = persistTopLevelDeclarations(code);
-	if (/\breturn\b/u.test(persistentCode)) return `(async () => {\n${persistentCode}\n})()`;
+	if (scanTopLevelStatements(persistentCode).hasTopLevelReturn) return `(async () => {\n${persistentCode}\n})()`;
 	return `(async () => {\n${captureLastExpression(persistentCode)}\n})()`;
 }
 
@@ -705,7 +705,7 @@ function skipBlockComment(code, start) {
 }
 
 function captureLastExpression(code) {
-	const start = findLastTopLevelStatementStart(code);
+	const start = scanTopLevelStatements(code).lastStatementStart;
 	const head = code.slice(0, start);
 	const tail = code.slice(start).trim();
 	if (!tail || isStatementOnly(tail)) return code;
@@ -726,7 +726,7 @@ function isStatementOnly(source) {
 
 const CONTROL_PAREN_KEYWORDS = new Set(["catch", "for", "if", "switch", "while", "with"]);
 
-function findLastTopLevelStatementStart(code) {
+function scanTopLevelStatements(code) {
 	let start = 0;
 	let round = 0;
 	let square = 0;
@@ -734,6 +734,7 @@ function findLastTopLevelStatementStart(code) {
 	let canStartRegex = true;
 	let lastSignificant = "";
 	let pendingControlParen = false;
+	let hasTopLevelReturn = false;
 	const controlParens = [];
 	for (let index = 0; index < code.length; index += 1) {
 		const char = code[index];
@@ -763,8 +764,11 @@ function findLastTopLevelStatementStart(code) {
 		if (isIdentifierStart(char)) {
 			const end = readIdentifier(code, index);
 			const token = code.slice(index, end);
-			canStartRegex = REGEX_PREFIX_KEYWORDS.has(token);
-			pendingControlParen = CONTROL_PAREN_KEYWORDS.has(token);
+			const isPropertyName = lastSignificant === ".";
+			const atTopLevel = round === 0 && square === 0 && curly === 0;
+			if (token === "return" && atTopLevel && !isPropertyName) hasTopLevelReturn = true;
+			canStartRegex = !isPropertyName && REGEX_PREFIX_KEYWORDS.has(token);
+			pendingControlParen = !isPropertyName && CONTROL_PAREN_KEYWORDS.has(token);
 			lastSignificant = code[end - 1];
 			index = end - 1;
 			continue;
@@ -828,7 +832,7 @@ function findLastTopLevelStatementStart(code) {
 			pendingControlParen = false;
 		}
 	}
-	return start;
+	return { lastStatementStart: start, hasTopLevelReturn };
 }
 
 const STATEMENT_CONTINUATION_KEYWORDS = new Set(["catch", "else", "finally"]);

--- a/packages/senpi-codemode/src/output/output-meta.ts
+++ b/packages/senpi-codemode/src/output/output-meta.ts
@@ -28,12 +28,14 @@ export function resolveSessionArtifactsDir(sessionFile: string | undefined): Ses
 
 export interface TruncationMeta {
 	readonly direction: "head" | "tail" | "middle";
-	readonly truncatedBy: "lines" | "bytes" | "middle";
+	readonly truncatedBy: "lines" | "bytes" | "columns" | "middle";
 	readonly totalLines: number;
 	readonly totalBytes: number;
 	readonly outputLines: number;
 	readonly outputBytes: number;
 	readonly maxBytes?: number;
+	readonly maxColumns?: number;
+	readonly columnTruncatedLines?: number;
 	readonly shownRange?: { readonly start: number; readonly end: number };
 	readonly headRange?: { readonly start: number; readonly end: number };
 	readonly tailRange?: { readonly start: number; readonly end: number };
@@ -72,13 +74,35 @@ export function formatTruncationWarning(meta: TruncationMeta | undefined): strin
 				meta.shownRange !== undefined && meta.shownRange.end >= meta.shownRange.start
 					? `Showing lines ${meta.shownRange.start}-${meta.shownRange.end} of ${meta.totalLines}`
 					: `Showing ${meta.outputLines} of ${meta.totalLines} lines`;
-			if (meta.truncatedBy === "bytes") message += ` (${formatBytes(meta.maxBytes ?? meta.outputBytes)} limit)`;
+			message += formatByteLoss(meta);
 			break;
 		default:
 			return assertNever(meta.direction);
 	}
 	if (meta.artifactId !== undefined) message += `. Full output: ${meta.artifactId}`;
 	return `[${message}]`;
+}
+
+function formatByteLoss(meta: TruncationMeta): string {
+	const dropped = formatBytes(Math.max(0, meta.totalBytes - meta.outputBytes));
+	switch (meta.truncatedBy) {
+		case "columns": {
+			const clamped = meta.columnTruncatedLines ?? 0;
+			const width = meta.maxColumns === undefined ? "the column cap" : `${meta.maxColumns} columns`;
+			return `; ${clamped} line${clamped === 1 ? "" : "s"} clamped to ${width} (${dropped} dropped)`;
+		}
+		case "bytes":
+			return meta.maxBytes === undefined ? ` (${dropped} dropped)` : ` (${formatBytes(meta.maxBytes)} limit)`;
+		case "lines":
+		case "middle":
+			return "";
+		default:
+			return assertNeverCause(meta.truncatedBy);
+	}
+}
+
+function assertNeverCause(value: never): never {
+	throw new TypeError(`Unhandled truncation cause: ${String(value)}`);
 }
 
 export function stripOutputNotice(text: string, meta: TruncationMeta | undefined): string {

--- a/packages/senpi-codemode/src/tool/image.ts
+++ b/packages/senpi-codemode/src/tool/image.ts
@@ -119,7 +119,7 @@ export class EvalOutputCollector {
 	async finish(): Promise<EvalOutputResult> {
 		await this.#processImages();
 		const summary = await this.#finalSummary();
-		const meta = truncationMetaFromSummary(summary);
+		const meta = truncationMetaFromSummary(summary, this.#options.maxColumns);
 		const notice = summary.artifactId === undefined ? undefined : artifactNotice(summary.artifactId);
 		return {
 			output: summary.output.trimEnd(),
@@ -215,7 +215,7 @@ function formatDisplayJson(value: unknown): string {
 	return `${text.slice(0, MAX_DISPLAY_TEXT_BYTES)}\n[…${text.length - MAX_DISPLAY_TEXT_BYTES}ch elided…]`;
 }
 
-function truncationMetaFromSummary(summary: OutputSummary): TruncationMeta | undefined {
+function truncationMetaFromSummary(summary: OutputSummary, maxColumns: number): TruncationMeta | undefined {
 	if (!summary.truncated) return undefined;
 	const artifact = summary.artifactId === undefined ? {} : { artifactId: summary.artifactId };
 	if (summary.elidedBytes !== undefined && summary.elidedBytes > 0) {
@@ -239,9 +239,18 @@ function truncationMetaFromSummary(summary: OutputSummary): TruncationMeta | und
 			...artifact,
 		};
 	}
+	const droppedBytes = Math.max(0, summary.totalBytes - summary.outputBytes);
+	const clampedLines = summary.columnTruncatedLines ?? 0;
+	const columnOnly = clampedLines > 0 && (summary.columnDroppedBytes ?? 0) >= droppedBytes;
+	const byteCapped = summary.totalBytes - (summary.columnDroppedBytes ?? 0) > DEFAULT_MAX_BYTES;
 	return {
 		direction: "tail",
-		truncatedBy: summary.outputBytes < summary.totalBytes ? "bytes" : "lines",
+		truncatedBy: columnOnly ? "columns" : byteCapped ? "bytes" : "lines",
+		...(columnOnly
+			? { maxColumns, columnTruncatedLines: clampedLines }
+			: byteCapped
+				? { maxBytes: DEFAULT_MAX_BYTES }
+				: {}),
 		totalLines: summary.totalLines,
 		totalBytes: summary.totalBytes,
 		outputLines: summary.outputLines,

--- a/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
@@ -59,4 +59,59 @@ describe("JavaScript kernel last-expression capture", () => {
 			expect(run.result.ok).toBe(true);
 		});
 	});
+
+	it("captures the last expression when a nested function contains return", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				"const captureNestedReturn = (() => { return 1; })();\ncaptureNestedReturn + 41",
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
+
+	it("captures the last expression after a try/catch helper that returns", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				[
+					"const captureHelperReturn = async () => { try { return await Promise.resolve(21); } catch (error) { return -1; } };",
+					"(await captureHelperReturn()) * 2",
+				].join("\n"),
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
+
+	it("captures the last expression when return appears only inside a string or comment", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				'const captureReturnWord = "return"; // return here\ncaptureReturnWord.length',
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe(6);
+		});
+	});
+
+	it("treats a property named return as a plain member access", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				'const captureReturnProperty = { return: 1 };\ncaptureReturnProperty.return\n"ok"',
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe("ok");
+		});
+	});
+
+	it("keeps a genuine top-level return as the cell value", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "if (true) return 42;\n0");
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
 });

--- a/packages/senpi-codemode/test/output/eval-output-collector-meta.test.ts
+++ b/packages/senpi-codemode/test/output/eval-output-collector-meta.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MAX_BYTES } from "../../src/output/streaming-output.ts";
+import { EvalOutputCollector } from "../../src/tool/image.ts";
+
+function collector(maxColumns: number): EvalOutputCollector {
+	return new EvalOutputCollector({ headBytes: 0, maxColumns, model: undefined, onChunk: () => {} });
+}
+
+describe("eval output truncation metadata", () => {
+	it("attributes a width-clamped line to the column cap, not a byte limit", async () => {
+		// Given
+		const output = collector(8);
+		output.push(`${"x".repeat(20)}\n`);
+
+		// When
+		const result = await output.finish();
+
+		// Then
+		expect(result.meta).toMatchObject({ truncatedBy: "columns", maxColumns: 8, columnTruncatedLines: 1 });
+		expect(result.meta?.maxBytes).toBeUndefined();
+	});
+
+	it("reports the real byte cap when the tail buffer dropped output", async () => {
+		// Given
+		const output = collector(0);
+		output.push(`${"y".repeat(DEFAULT_MAX_BYTES + 10)}\n`);
+
+		// When
+		const result = await output.finish();
+
+		// Then
+		expect(result.meta).toMatchObject({ truncatedBy: "bytes", maxBytes: DEFAULT_MAX_BYTES });
+	});
+});

--- a/packages/senpi-codemode/test/output/output-meta.test.ts
+++ b/packages/senpi-codemode/test/output/output-meta.test.ts
@@ -26,6 +26,46 @@ describe("output metadata", () => {
 		expect(warning).toBe("[Showing lines 8-10 of 10 (5B limit). Full output: /tmp/full.log]");
 	});
 
+	it("reports dropped bytes instead of a limit when no byte cap is known", () => {
+		// Given
+		const meta = {
+			direction: "tail",
+			truncatedBy: "bytes",
+			totalLines: 2,
+			totalBytes: 2_000,
+			outputLines: 2,
+			outputBytes: 772,
+			shownRange: { start: 1, end: 2 },
+		} satisfies TruncationMeta;
+
+		// When
+		const warning = formatTruncationWarning(meta);
+
+		// Then
+		expect(warning).toBe("[Showing lines 1-2 of 2 (1.2KB dropped)]");
+	});
+
+	it("names the column clamp when lines were cut to a width", () => {
+		// Given
+		const meta = {
+			direction: "tail",
+			truncatedBy: "columns",
+			totalLines: 2,
+			totalBytes: 2_000,
+			outputLines: 2,
+			outputBytes: 772,
+			maxColumns: 768,
+			columnTruncatedLines: 1,
+			shownRange: { start: 1, end: 2 },
+		} satisfies TruncationMeta;
+
+		// When
+		const warning = formatTruncationWarning(meta);
+
+		// Then
+		expect(warning).toBe("[Showing lines 1-2 of 2; 1 line clamped to 768 columns (1.2KB dropped)]");
+	});
+
 	it("formats a middle-elision warning", () => {
 		// Given
 		const meta = {


### PR DESCRIPTION
## Summary

Fixes #1439.

`wrapUserCode` (`packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js:14`) tested `/\breturn\b/u` over the whole cell source to decide whether the user had written a top-level `return`. Any `return` token anywhere — inside a nested arrow, a `.map()` callback, a try/catch helper, a string, or a comment — matched, so the wrapper skipped last-expression capture and the cell settled with no `valueRepr`. The tool then rendered `(no output)` even though the cell ran and its globals persisted. Every substantial cell (anything that defines a helper) hit this.

Measured on a live session (`01a07b11`, mengmotaHost): 16 of 20 JavaScript cells lost their value; each one contained a nested `return`. Duration, output size, and the final expression's shape were all ruled out (a 12 s sleep cell and a 2000-char value both print fine).

## What changed

- `scanTopLevelStatements` (formerly `findLastTopLevelStatementStart`) now also records whether a `return` token appears at brace/paren/bracket depth 0, outside literals and comments, and `wrapUserCode` consults that instead of the whole-source regex. A genuine top-level `return` still suppresses capture, exactly as documented.
- An identifier that follows `.` is treated as a property name, so `obj.return` no longer primes the scanner as the keyword (it used to start a regex-context/continuation as if `return` had been written).
- Eval truncation notices name the real cause. Before, any byte loss — including a pure column clamp — produced `truncatedBy: "bytes"` with no `maxBytes`, and the notice printed the output's own size as a limit (`(772B limit)`). The metadata now distinguishes `columns` (width + clamped line count), `bytes` (the actual cap, `DEFAULT_MAX_BYTES`), and `lines`; a notice without a known cap reports the dropped size instead of a limit.

## Tests

`packages/senpi-codemode/test/kernel-js-last-expression.test.ts`
- captures the last expression when a nested function contains return
- captures the last expression after a try/catch helper that returns
- captures the last expression when return appears only inside a string or comment
- treats a property named return as a plain member access
- keeps a genuine top-level return as the cell value

`packages/senpi-codemode/test/output/output-meta.test.ts`
- reports dropped bytes instead of a limit when no byte cap is known
- names the column clamp when lines were cut to a width

`packages/senpi-codemode/test/output/eval-output-collector-meta.test.ts` (new)
- attributes a width-clamped line to the column cap, not a byte limit
- reports the real byte cap when the tail buffer dropped output

RED captured on an x86_64 box before the fix (workspace built, bun 1.4.0 / node 24): 7 assertion failures — `expected undefined to be 42`, `expected undefined to be 6`, `'(772B limit)'` vs `'(1.2KB dropped)'`, and the two collector `truncatedBy` mismatches. GREEN after the fix: 3 files / 21 tests pass; the full `senpi-codemode` suite, root `biome check`, and root `tsc --noEmit` results are recorded in the PR comments.

## Notes

- `senpi-codemode` is fork-only (not present in the pinned `badlogic/pi-mono` tree), so no `changes.md` coverage applies; the package `CHANGELOG.md` carries the `[Unreleased]` entries.
- Workaround for hosts on older builds until this ships: end cells with an explicit `print(...)`, and never blindly re-run a blank cell that had side effects — query the resulting state instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JavaScript eval cells in `senpi-codemode` losing their completion value whenever source contained a `return` inside a nested function, callback, try/catch helper, string, or comment: the wrapper previously matched any `return` and skipped last-expression capture, so cells settled with no value and rendered `(no output)`. Last-expression capture now runs unless there's a genuine top-level `return`, and a property named `return` is treated as member access. Also fixes eval output truncation notices to name the real cause — `columns`, `bytes`, or `lines` — instead of printing the output's own size as a byte limit.

- The statement scanner records `return` only at brace/paren/square depth 0, outside literals and comments, and treats an identifier after `.` as a property name.
- Truncation notices now distinguish width clamps (with the column cap and clamped line count), the actual byte cap, and line cuts; a notice without a known cap reports the dropped size.
- Includes a formatting fix in `packages/ai/test/gpt-6-astra-context-window.test.ts` to satisfy `biome check` without `--write`.

<sup>Written for commit 60f0c9e9fcd69b7471231a65bd87c3e180662101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

