### PR TITLE
fix(codemode): expose the session environment to eval kernels and their children

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Eval kernels and every child they spawn now see the active session's `PI_*` environment (`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, `PI_REASONING_LEVEL`) exactly as bash-tool children do: inherited `PI_*` values are dropped before the session values are applied, so subprocesses such as `omo-agent-toolkit ulw-loop` resolve the same session as the `bash` tool instead of a cwd-global one.
 - JavaScript eval cells no longer lose their completion value when a nested function, callback, or try/catch helper contains `return`: the cell wrapper now skips last-expression capture only for a genuine top-level `return`, and a property named `return` no longer primes the statement scanner as the keyword (#1439).
 - Eval output truncation notices now name the real cause: a width-clamped line reports `N line(s) clamped to M columns (… dropped)`, a byte-capped tail reports the actual cap, and a notice never presents the output's own size as a limit.
 

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -54,6 +54,19 @@ task-tool names are known.
 A missing optional interpreter removes that language from the session's `eval`
 schema; it is not an installation failure.
 
+### Session environment
+
+Every kernel starts with the active session's `PI_*` environment — `PI_SESSION_ID`,
+`PI_SESSION_FILE` (when the session is persistent), `PI_PROVIDER`, `PI_MODEL`, and
+`PI_REASONING_LEVEL` (when set) — resolved at session start, mirroring the bash tool's
+session environment contract. The values are visible to `env()`/`process.env`/`os.environ`
+inside cells and are inherited by every child process a cell spawns
+(`Bun.$`, `Bun.spawn`, `child_process`, `subprocess`, ...). Inherited `PI_*` values from
+the launching environment are dropped first, so a child spawned from a cell sees exactly
+what a child spawned from the bash tool sees. The values snapshot at kernel start, so a
+mid-session model switch updates the bash tool's next command but not already-running
+kernels; a new session starts fresh kernels with fresh values.
+
 ## Settings
 
 Configuration is loaded in this order:
@@ -116,7 +129,7 @@ options object and asynchronous helpers are `await`-able.
 | `print(value, ...)` | Emits text output. |
 | `read(path, offset?, limit?)` | Reads text with 1-indexed line slicing. `local://` paths resolve under the session artifact root. |
 | `write(path, content)` | Creates parent directories and writes text. `local://` paths persist in the session artifact root. |
-| `env(key?, value?)` | Reads all kernel environment values, one value, or sets one value. |
+| `env(key?, value?)` | Reads all kernel environment values, one value, or sets one value. Includes the session's `PI_*` values (see [Session environment](#session-environment)). |
 | `tool.<name>(args)` | Invokes an active Senpi tool through the normal `pi.executeTool` pipeline and returns `{ text, images?, details?, hasError? }` in every kernel; image blocks arrive as `images[i] = { mimeType, dataBase64 }`. |
 | `tool_schema(name?)` | Returns a tool's parameter schema without calling it; omit `name` to list tool names. |
 | `completion(prompt, model?, system?, schema?)` | Requests a one-shot host completion; `schema` asks the host to parse structured output. |

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,17 @@
 # senpi-codemode fork changes
 
+## 2026-09-07 - Eval kernels carry the session environment
+
+### What changed
+
+- New `src/kernels/session-env.ts` resolves the per-session `PI_*` environment (`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, `PI_REASONING_LEVEL`) from the extension session context and merges it over the inherited environment with the bash tool's delete-then-set semantics.
+- `runtime-factory` resolves the environment at session start and threads it through `CreateCodemodeSessionManagerOptions.sessionEnv` into every kernel: the JS worker applies it to its own `process.env` at worker init (so `env()`, `process.env`, `Bun.$`, `Bun.spawn`, and `child_process` children all see it), and the py/rb/jl interpreters spawn with it merged into their environment (so `os.environ` and their children see it). Restarted or reset interpreters re-apply it because it is a kernel option, not a one-shot spawn side effect.
+- Under Bun a `delete process.env.X` does not unsetenv, so `worker-shell-capture.js` additionally pins the worker's environment view (`$.env` seed plus explicit `env` on captured `Bun.spawn` calls without one) whenever the session environment deleted inherited keys; without this, children would still see deleted `PI_*` values in the OS environment.
+
+### Why
+
+- A child spawned from an eval cell saw no `PI_SESSION_ID`, so `omo-agent-toolkit ulw-loop` invoked from a cell resolved the cwd-global state instead of the active session — a real data-corruption path. The contract is that a child spawned from eval sees the same session environment a child spawned from the `bash` tool sees; the core exposes no importable helper for that set (its bash implementation is private and the host package is a type-only dependency here), so the five-key contract is mirrored in one documented helper.
+
 ## 2026-09-07 - Fail clearly when compiled codemode assets are missing
 
 ### What changed

--- a/packages/senpi-codemode/src/bridge/protocol.ts
+++ b/packages/senpi-codemode/src/bridge/protocol.ts
@@ -26,6 +26,7 @@ const hostToKernelMessageSchema = Type.Union([
 		type: Type.Literal("init"),
 		sessionId: Type.String({ minLength: 1 }),
 		connection: connectionConfigSchema,
+		sessionEnv: Type.Optional(Type.Record(Type.String(), Type.String())),
 	}),
 	Type.Object({
 		type: Type.Literal("run"),

--- a/packages/senpi-codemode/src/extension/runtime-factory.ts
+++ b/packages/senpi-codemode/src/extension/runtime-factory.ts
@@ -13,6 +13,7 @@ import {
 	getInterpreterAvailability,
 	type InterpreterAvailability,
 } from "../interpreters/detect.ts";
+import { sessionEnvironmentFrom } from "../kernels/session-env.ts";
 import { resolveSessionArtifactsDir } from "../output/streaming-output.ts";
 import type { EnabledEvalLanguages, EvalLanguage, EvalRuntimes } from "../tool/types.ts";
 import { jsRuntimeInfo, runtimesFromAvailability } from "./runtime-info.ts";
@@ -66,11 +67,13 @@ export async function createRuntime(
 	const executeTool = createExecuteTool(pi, activeTools);
 	const create = options.createSessionManager ?? createCodemodeSessionManager;
 	const sessionId = sessionIdFrom(event);
+	const sessionEnv = sessionEnvironmentFrom(ctx);
 	const configuredPoolWidth = settings.parallelPoolWidth;
 	const parallelPoolWidth = Number.isFinite(configuredPoolWidth) ? Math.max(1, Math.trunc(configuredPoolWidth)) : 1;
 	const manager = await create({
 		sessionId,
 		cwd: ctx.cwd,
+		sessionEnv,
 		settings,
 		availability,
 		artifactsDir: artifacts.dir,

--- a/packages/senpi-codemode/src/extension/session-manager.ts
+++ b/packages/senpi-codemode/src/extension/session-manager.ts
@@ -11,6 +11,7 @@ import { JuliaKernel } from "../kernels/jl/kernel.ts";
 import { JavaScriptKernel } from "../kernels/js/context-manager.ts";
 import { PythonKernel } from "../kernels/py/kernel.ts";
 import { RubyKernel } from "../kernels/rb/kernel.ts";
+import type { SessionEnvironment } from "../kernels/session-env.ts";
 import { marshalToolResult } from "../tool/image.ts";
 import type { EvalKernel, EvalKernelManager, EvalLanguage, ExecuteTool } from "../tool/types.ts";
 
@@ -40,6 +41,8 @@ export interface CreateCodemodeSessionManagerOptions {
 	readonly localRoots?: Readonly<Record<string, string>>;
 	/** Session-adjacent directory used for persisted eval artifacts. */
 	readonly artifactsDir?: string;
+	/** Per-session PI_* values exposed to every kernel and the children it spawns. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly executeTool: ExecuteTool;
 	readonly listTools?: () => readonly EvalSchemaToolInfo[];
 	readonly complete: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
@@ -212,6 +215,7 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 				cwd: this.#options.cwd,
 				parallelPoolWidth,
 				onMessage,
+				...(this.#options.sessionEnv ? { sessionEnv: this.#options.sessionEnv } : {}),
 				...(localRoots ? { localRoots: { ...localRoots } } : {}),
 				...(this.#options.artifactsDir ? { artifactsDir: this.#options.artifactsDir } : {}),
 			});
@@ -230,6 +234,7 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 				interpreterPath: detected.path,
 				sessionId: this.#options.sessionId,
 				cwd: this.#options.cwd,
+				...(this.#options.sessionEnv ? { sessionEnv: this.#options.sessionEnv } : {}),
 				connection,
 				onMessage,
 			});
@@ -239,6 +244,7 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 				command: detected.path,
 				sessionId: this.#options.sessionId,
 				cwd: this.#options.cwd,
+				...(this.#options.sessionEnv ? { sessionEnv: this.#options.sessionEnv } : {}),
 				connection,
 				onMessage,
 			});
@@ -247,6 +253,7 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 			command: detected.path,
 			sessionId: this.#options.sessionId,
 			cwd: this.#options.cwd,
+			...(this.#options.sessionEnv ? { sessionEnv: this.#options.sessionEnv } : {}),
 			connection,
 			onMessage,
 		});

--- a/packages/senpi-codemode/src/kernels/AGENTS.md
+++ b/packages/senpi-codemode/src/kernels/AGENTS.md
@@ -15,6 +15,7 @@ runner/prelude assets).
 | Ruby kernel | `rb/kernel.ts` + `rb/prelude.rb`, `rb/runner.rb` |
 | Julia kernel | `jl/kernel.ts` + `jl/prelude.jl`, `jl/runner.jl` |
 | Shared subprocess layer | `shared/subprocess-kernel.ts`, `subprocess-{contract,process,queue,run}.ts`, `runtime-asset.ts` |
+| Session environment | `session-env.ts` (PI_* contract shared by all kernels; mirrors the core bash tool) |
 
 ## CONVENTIONS
 
@@ -29,6 +30,12 @@ runner/prelude assets).
   framed subprocesses through `shared/`.
 - Subprocess retirement/restart, worker recovery, timeout, and interrupt
   semantics live here, never in the tool layer.
+- Every kernel exposes the active session's `PI_*` environment (`session-env.ts`):
+  inherited values are deleted before the session's values are applied, so any
+  child spawned from a cell sees the same session environment a bash-tool child
+  sees. The JS worker applies it at init (`worker-core.js`; shell capture pins
+  the env view under Bun because `delete process.env.X` does not unsetenv),
+  and py/rb/jl spawn with it merged into the interpreter environment.
 
 ## ANTI-PATTERNS
 

--- a/packages/senpi-codemode/src/kernels/jl/kernel.ts
+++ b/packages/senpi-codemode/src/kernels/jl/kernel.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { SessionEnvironment } from "../session-env.ts";
 import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { SubprocessKernel, type SubprocessSpawn } from "../shared/subprocess-kernel.ts";
 
@@ -7,6 +8,8 @@ export interface JuliaKernelStartOptions {
 	readonly cwd: string;
 	readonly sessionId: string;
 	readonly connection: BridgeConnectionConfig;
+	/** Per-session PI_* values merged into the interpreter environment at spawn. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly command?: string;
 	readonly spawn?: SubprocessSpawn;
 	readonly onMessage?: (message: KernelToHostMessage) => void;
@@ -42,6 +45,7 @@ export class JuliaKernel extends SubprocessKernel {
 			],
 			cwd: options.cwd,
 			sessionId: options.sessionId,
+			sessionEnv: options.sessionEnv,
 			connection: options.connection,
 			spawn: options.spawn,
 			onMessage: options.onMessage,

--- a/packages/senpi-codemode/src/kernels/js/kernel-contract.ts
+++ b/packages/senpi-codemode/src/kernels/js/kernel-contract.ts
@@ -1,4 +1,5 @@
 import type { KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { SessionEnvironment } from "../session-env.ts";
 
 export type ResultMessage = Extract<KernelToHostMessage, { type: "result" }>;
 export type ToolCallMessage = Extract<KernelToHostMessage, { type: "tool-call" }>;
@@ -11,6 +12,8 @@ export interface JavaScriptKernelOptions {
 	readonly parallelPoolWidth: number;
 	readonly onMessage?: (message: KernelToHostMessage) => void;
 	readonly workerEntryUrl?: URL;
+	/** Per-session PI_* values applied to the worker environment before the first cell runs. */
+	readonly sessionEnv?: SessionEnvironment;
 }
 
 export interface JavaScriptRunInput {

--- a/packages/senpi-codemode/src/kernels/js/worker-core.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-core.js
@@ -3,6 +3,17 @@ import { JsWorkerRuntime } from "./worker-runtime.js";
 // Mirrors INTERRUPT_ACK_OP in src/bridge/reserved.ts (this worker file cannot import TypeScript).
 const INTERRUPT_ACK_OP = "interrupt-ack";
 
+// Mirrors SESSION_ENVIRONMENT_KEYS in src/kernels/session-env.ts (this worker file
+// cannot import TypeScript). Keys the active session does not set must be dropped so a
+// value inherited from the host environment never leaks into a cell or its children.
+const SESSION_ENVIRONMENT_KEYS = [
+	"PI_SESSION_ID",
+	"PI_SESSION_FILE",
+	"PI_PROVIDER",
+	"PI_MODEL",
+	"PI_REASONING_LEVEL",
+];
+
 export function createWorkerCore(transport, options) {
 	let runtime = null;
 	let activeCell = null;
@@ -54,6 +65,7 @@ export function createWorkerCore(transport, options) {
 
 	function onMessage(message) {
 		if (message.type === "init") {
+			applySessionEnvironment(message.sessionEnv);
 			runtime = new JsWorkerRuntime({
 				cwd: options.cwd,
 				parallelPoolWidth: options.parallelPoolWidth,
@@ -96,6 +108,20 @@ export function createWorkerCore(transport, options) {
 
 function durationMs(startedAtMs) {
 	return Math.max(0, Math.round(performance.now() - startedAtMs));
+}
+
+function applySessionEnvironment(sessionEnv) {
+	const provided = new Set(Object.keys(sessionEnv ?? {}));
+	const deleted = [];
+	for (const key of SESSION_ENVIRONMENT_KEYS) {
+		if (key in process.env && !provided.has(key)) deleted.push(key);
+		delete process.env[key];
+	}
+	for (const [key, value] of Object.entries(sessionEnv ?? {})) process.env[key] = value;
+	// Under Bun, deleting from process.env does not unsetenv, so children spawned without
+	// an explicit env would still see the deleted keys. installShellCapture reads this list
+	// and pins the worker's environment view for such children (see worker-shell-capture.js).
+	globalThis.__senpi_session_env_deletions__ = deleted;
 }
 
 function valueRepr(value) {

--- a/packages/senpi-codemode/src/kernels/js/worker-core.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-core.js
@@ -117,11 +117,14 @@ function applySessionEnvironment(sessionEnv) {
 		if (key in process.env && !provided.has(key)) deleted.push(key);
 		delete process.env[key];
 	}
-	for (const [key, value] of Object.entries(sessionEnv ?? {})) process.env[key] = value;
-	// Under Bun, deleting from process.env does not unsetenv, so children spawned without
-	// an explicit env would still see the deleted keys. installShellCapture reads this list
-	// and pins the worker's environment view for such children (see worker-shell-capture.js).
+	const applied = Object.entries(sessionEnv ?? {});
+	for (const [key, value] of applied) process.env[key] = value;
+	// A worker's process.env is its own view: Bun.$ and node:child_process read it, but Bun.spawn
+	// without an explicit env inherits the OS environ, which also still holds deleted keys because
+	// `delete process.env.X` does not unsetenv under Bun. installShellCapture reads these flags and
+	// pins the worker's environment view for such children (see worker-shell-capture.js).
 	globalThis.__senpi_session_env_deletions__ = deleted;
+	globalThis.__senpi_session_env_applied__ = applied.length > 0 || deleted.length > 0;
 }
 
 function valueRepr(value) {

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
@@ -26,4 +26,10 @@ declare global {
 	 * while this list is non-empty.
 	 */
 	var __senpi_session_env_deletions__: string[] | undefined;
+	/**
+	 * Set by the JS worker core once a session environment was applied (values set or inherited
+	 * keys deleted). Bun.spawn without an explicit env inherits the OS environ rather than the
+	 * worker's process.env, so shell capture pins the worker's view whenever this is true.
+	 */
+	var __senpi_session_env_applied__: boolean | undefined;
 }

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
@@ -17,3 +17,13 @@ export interface ShellCaptureOptions {
 }
 
 export function installShellCapture(options: ShellCaptureOptions): ShellCaptureRestore;
+
+declare global {
+	/**
+	 * Set by the JS worker core when applying the session environment deleted inherited
+	 * `PI_*` keys (see worker-core.js). Under Bun a `delete process.env.X` does not
+	 * unsetenv, so shell capture pins the worker's environment view for spawned children
+	 * while this list is non-empty.
+	 */
+	var __senpi_session_env_deletions__: string[] | undefined;
+}

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -14,10 +14,11 @@ export function installShellCapture(options) {
 	const originalShell = bun.$;
 	const originalSpawn = bun.spawn;
 	const deletedKeys = globalThis.__senpi_session_env_deletions__;
-	const pinEnv = Array.isArray(deletedKeys) && deletedKeys.length > 0;
+	const pinEnv =
+		globalThis.__senpi_session_env_applied__ === true || (Array.isArray(deletedKeys) && deletedKeys.length > 0);
 	if (pinEnv && typeof originalShell.env === "function") {
-		// Deleting from process.env does not unsetenv under Bun, so shell commands would
-		// still see deleted session keys in the inherited environment. Pinning the worker's
+		// Bun.spawn without an explicit env inherits the OS environ, not the worker's process.env,
+		// and deleting from process.env does not unsetenv under Bun. Pinning the worker's
 		// environment view mirrors the bash tool, which always spawns with an explicit env.
 		originalShell.env({ ...process.env });
 	}

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -13,8 +13,16 @@ export function installShellCapture(options) {
 	if (!isBunRuntime(bun)) return () => {};
 	const originalShell = bun.$;
 	const originalSpawn = bun.spawn;
+	const deletedKeys = globalThis.__senpi_session_env_deletions__;
+	const pinEnv = Array.isArray(deletedKeys) && deletedKeys.length > 0;
+	if (pinEnv && typeof originalShell.env === "function") {
+		// Deleting from process.env does not unsetenv under Bun, so shell commands would
+		// still see deleted session keys in the inherited environment. Pinning the worker's
+		// environment view mirrors the bash tool, which always spawns with an explicit env.
+		originalShell.env({ ...process.env });
+	}
 	bun.$ = capturedShell(originalShell, options);
-	bun.spawn = capturedSpawn(originalSpawn, options);
+	bun.spawn = capturedSpawn(originalSpawn, options, pinEnv);
 	return () => {
 		bun.$ = originalShell;
 		bun.spawn = originalSpawn;
@@ -103,20 +111,26 @@ function outputText(value) {
 	return typeof value === "string" ? value : "";
 }
 
-function capturedSpawn(originalSpawn, options) {
+function capturedSpawn(originalSpawn, options, pinEnv) {
 	return (...args) => {
 		if (!options.isActive()) return originalSpawn(...args);
 		const [first, second] = args;
 		let child;
 		if (Array.isArray(first)) {
 			const spawnOptions = second === undefined ? {} : second;
-			child = needsStderrCapture(spawnOptions)
-				? drainStderr(originalSpawn(first, { ...spawnOptions, stderr: "pipe" }), options.emitText)
-				: originalSpawn(...args);
+			const effective = pinEnv && spawnOptions.env === undefined ? { ...spawnOptions, env: { ...process.env } } : spawnOptions;
+			child = needsStderrCapture(effective)
+				? drainStderr(originalSpawn(first, { ...effective, stderr: "pipe" }), options.emitText)
+				: effective === spawnOptions
+					? originalSpawn(...args)
+					: originalSpawn(first, effective);
 		} else {
-			child = needsStderrCapture(first)
-				? drainStderr(originalSpawn({ ...first, stderr: "pipe" }), options.emitText)
-				: originalSpawn(...args);
+			const effective = pinEnv && first !== null && typeof first === "object" && first.env === undefined ? { ...first, env: { ...process.env } } : first;
+			child = needsStderrCapture(effective)
+				? drainStderr(originalSpawn({ ...effective, stderr: "pipe" }), options.emitText)
+				: effective === first
+					? originalSpawn(...args)
+					: originalSpawn(effective);
 		}
 		options.onChild?.(child);
 		return child;

--- a/packages/senpi-codemode/src/kernels/js/worker-startup.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-startup.ts
@@ -64,6 +64,7 @@ async function initializeWorker(
 		type: "init",
 		sessionId: options.sessionId,
 		connection: localBridgeConnection(options),
+		...(options.sessionEnv === undefined ? {} : { sessionEnv: options.sessionEnv }),
 	});
 	await ready;
 }

--- a/packages/senpi-codemode/src/kernels/py/kernel-contract.ts
+++ b/packages/senpi-codemode/src/kernels/py/kernel-contract.ts
@@ -1,4 +1,5 @@
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { SessionEnvironment } from "../session-env.ts";
 import type { KernelSpawnProcess } from "./process.ts";
 import type { PythonTransportResult } from "./transport.ts";
 
@@ -8,6 +9,8 @@ export interface PythonKernelStartOptions {
 	readonly cwd: string;
 	readonly connection: BridgeConnectionConfig;
 	readonly env?: NodeJS.ProcessEnv;
+	/** Per-session PI_* values merged into the interpreter environment at spawn. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly startupTimeoutMs?: number;
 	readonly onMessage?: (message: KernelToHostMessage) => void;
 	readonly spawnProcess?: KernelSpawnProcess;

--- a/packages/senpi-codemode/src/kernels/py/transport.ts
+++ b/packages/senpi-codemode/src/kernels/py/transport.ts
@@ -8,6 +8,7 @@ import {
 	isKernelToHostMessage,
 	type KernelToHostMessage,
 } from "../../bridge/protocol.ts";
+import { applySessionEnvironment, type SessionEnvironment } from "../session-env.ts";
 import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import {
 	defaultSpawn,
@@ -36,6 +37,8 @@ export interface PythonTransportOptions {
 	readonly cwd: string;
 	readonly connection: BridgeConnectionConfig;
 	readonly env?: NodeJS.ProcessEnv;
+	/** Per-session PI_* values merged into the interpreter environment at spawn. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly startupTimeoutMs: number;
 	readonly onMessage?: (message: KernelToHostMessage) => void;
 	readonly spawnProcess?: KernelSpawnProcess;
@@ -83,7 +86,12 @@ export class PythonKernelTransport {
 			command: invocation.command,
 			args: [...invocation.args, "-u", scriptPath],
 			cwd: options.cwd,
-			env: { ...process.env, ...options.env, PYTHONUNBUFFERED: "1", PYTHONIOENCODING: "utf-8" },
+			env: {
+				...applySessionEnvironment(process.env, options.sessionEnv),
+				...options.env,
+				PYTHONUNBUFFERED: "1",
+				PYTHONIOENCODING: "utf-8",
+			},
 		};
 		const child = (options.spawnProcess ?? defaultSpawn)(spawnOptions);
 		const transport = new PythonKernelTransport(options, child);

--- a/packages/senpi-codemode/src/kernels/rb/kernel.ts
+++ b/packages/senpi-codemode/src/kernels/rb/kernel.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { SessionEnvironment } from "../session-env.ts";
 import { type CodemodeRuntimeAssetEnvironment, requireCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { SubprocessKernel, type SubprocessSpawn } from "../shared/subprocess-kernel.ts";
 
@@ -7,6 +8,8 @@ export interface RubyKernelStartOptions {
 	readonly cwd: string;
 	readonly sessionId: string;
 	readonly connection: BridgeConnectionConfig;
+	/** Per-session PI_* values merged into the interpreter environment at spawn. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly command?: string;
 	readonly spawn?: SubprocessSpawn;
 	readonly onMessage?: (message: KernelToHostMessage) => void;
@@ -31,6 +34,7 @@ export class RubyKernel extends SubprocessKernel {
 			args: [resolveRubyRunnerPath()],
 			cwd: options.cwd,
 			sessionId: options.sessionId,
+			sessionEnv: options.sessionEnv,
 			connection: options.connection,
 			spawn: options.spawn,
 			onMessage: options.onMessage,

--- a/packages/senpi-codemode/src/kernels/session-env.ts
+++ b/packages/senpi-codemode/src/kernels/session-env.ts
@@ -1,0 +1,56 @@
+/**
+ * Session environment exposed to eval kernels and every child they spawn.
+ *
+ * Mirrors the shell-tool session environment contract in the senpi core
+ * (`resolveSpawnContext` in `packages/coding-agent/src/core/tools/bash.ts` and
+ * `docs/environment-variables.md`): the per-session `PI_*` variables are
+ * deleted from the inherited environment first, then set from the active
+ * session, so a stale inherited value never leaks into a kernel child. A child
+ * spawned from an eval cell must see the same session environment a child
+ * spawned from the bash tool sees.
+ */
+export const SESSION_ENVIRONMENT_KEYS = [
+	"PI_SESSION_ID",
+	"PI_SESSION_FILE",
+	"PI_PROVIDER",
+	"PI_MODEL",
+	"PI_REASONING_LEVEL",
+] as const;
+
+/** Resolved per-session values for {@link SESSION_ENVIRONMENT_KEYS}; absent keys stay unset. */
+export type SessionEnvironment = Readonly<Record<string, string>>;
+
+/** Structural slice of `ExtensionContext` the session environment is resolved from. */
+export interface SessionEnvironmentSource {
+	readonly sessionManager: {
+		getSessionId(): string;
+		getSessionFile(): string | undefined;
+	};
+	readonly model?: { readonly provider: string; readonly id: string } | undefined;
+	readonly thinkingLevel?: string | undefined;
+}
+
+export function sessionEnvironmentFrom(source: SessionEnvironmentSource): SessionEnvironment {
+	const env: Record<string, string> = {};
+	env.PI_SESSION_ID = source.sessionManager.getSessionId();
+	const sessionFile = source.sessionManager.getSessionFile();
+	if (sessionFile) env.PI_SESSION_FILE = sessionFile;
+	const model = source.model;
+	if (model) {
+		env.PI_PROVIDER = model.provider;
+		env.PI_MODEL = model.id;
+	}
+	if (source.thinkingLevel) env.PI_REASONING_LEVEL = source.thinkingLevel;
+	return env;
+}
+
+/**
+ * Merges a session environment over a base environment the way the bash tool
+ * does: every {@link SESSION_ENVIRONMENT_KEYS} entry is dropped from `base`
+ * first, then the provided session values are applied.
+ */
+export function applySessionEnvironment(base: NodeJS.ProcessEnv, sessionEnv?: SessionEnvironment): NodeJS.ProcessEnv {
+	const merged: NodeJS.ProcessEnv = { ...base };
+	for (const key of SESSION_ENVIRONMENT_KEYS) delete merged[key];
+	return { ...merged, ...sessionEnv };
+}

--- a/packages/senpi-codemode/src/kernels/shared/subprocess-contract.ts
+++ b/packages/senpi-codemode/src/kernels/shared/subprocess-contract.ts
@@ -1,4 +1,5 @@
 import type { BridgeConnectionConfig, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { SessionEnvironment } from "../session-env.ts";
 import type { SubprocessSpawn } from "./subprocess-process.ts";
 
 export interface KernelRunInput {
@@ -15,6 +16,8 @@ export interface SubprocessKernelOptions {
 	readonly args: readonly string[];
 	readonly cwd?: string;
 	readonly env?: NodeJS.ProcessEnv;
+	/** Per-session PI_* values merged into the interpreter environment at spawn. */
+	readonly sessionEnv?: SessionEnvironment;
 	readonly sessionId: string;
 	readonly connection: BridgeConnectionConfig;
 	readonly spawn?: SubprocessSpawn;

--- a/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
+++ b/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
@@ -1,6 +1,7 @@
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
 import { decodeBridgeFrame, encodeBridgeFrame, isKernelToHostMessage } from "../../bridge/protocol.ts";
 import type { KernelInterruptHandle } from "../../tool/types.ts";
+import { applySessionEnvironment } from "../session-env.ts";
 import type { KernelResult, KernelRunInput, SubprocessKernelOptions, ToolCallMessage } from "./subprocess-contract.ts";
 import { type SubprocessLike, SubprocessProcess, type SubprocessSpawn, spawnSubprocess } from "./subprocess-process.ts";
 import { SubprocessRunQueue } from "./subprocess-queue.ts";
@@ -133,7 +134,14 @@ export class SubprocessKernel {
 	}
 
 	private spawnProcess(): void {
-		const child = spawnSubprocess(this.options.spawn, this.options);
+		const child = spawnSubprocess(this.options.spawn, {
+			...this.options,
+			env:
+				this.options.env ??
+				(this.options.sessionEnv
+					? applySessionEnvironment(globalThis.process.env, this.options.sessionEnv)
+					: undefined),
+		});
 		const process = new SubprocessProcess(child, {
 			onLine: (source, line) => this.handleLine(source, line),
 			onStderr: (source, data) => this.handleMessage(source, { type: "text", stream: "stderr", data }),

--- a/packages/senpi-codemode/test/bridge-protocol.test.ts
+++ b/packages/senpi-codemode/test/bridge-protocol.test.ts
@@ -58,6 +58,22 @@ describe("bridge protocol JSONL framing", () => {
 		expect(decodeBridgeFrame(encodeBridgeFrame(message))).toEqual({ ok: true, message });
 	});
 
+	it("round-trips init session environment overrides", () => {
+		const withSessionEnv: HostToKernelMessage = {
+			type: "init",
+			sessionId: "session-env",
+			connection: { port: 4317, token: "secret-token" },
+			sessionEnv: {
+				PI_SESSION_ID: "session-env",
+				PI_SESSION_FILE: "/tmp/sessions/session-env.jsonl",
+				PI_PROVIDER: "fake",
+				PI_MODEL: "fake-model",
+				PI_REASONING_LEVEL: "high",
+			},
+		};
+		expect(decodeBridgeFrame(encodeBridgeFrame(withSessionEnv))).toEqual({ ok: true, message: withSessionEnv });
+	});
+
 	it("accepts init connection roots while preserving the legacy shape", () => {
 		const withRoots: HostToKernelMessage = {
 			type: "init",

--- a/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
@@ -88,6 +88,7 @@ async function sessionCwd(): Promise<string> {
 function wiringContext(cwd: string): ExtensionContext {
 	const base = fakeExtensionContext();
 	const sessionManager = Object.create(null);
+	sessionManager.getSessionId = (): string => "wiring-test-session";
 	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
 	return { ...base, cwd, sessionManager };
 }

--- a/packages/senpi-codemode/test/eval-status-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-status-wiring.test.ts
@@ -102,6 +102,7 @@ function wiringContext(cwd: string, mode: "tui" | "rpc", calls: StatusCall[], th
 	};
 	ui.theme = theme;
 	const sessionManager = Object.create(null);
+	sessionManager.getSessionId = (): string => "status-wiring-test-session";
 	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
 	return { ...base, cwd, mode, hasUI: true, ui, sessionManager };
 }

--- a/packages/senpi-codemode/test/eval-wake-source.test.ts
+++ b/packages/senpi-codemode/test/eval-wake-source.test.ts
@@ -208,6 +208,7 @@ function wiringContext(cwd: string, calls: StatusCall[]): ExtensionContext {
 	};
 	ui.theme = theme;
 	const sessionManager = Object.create(null);
+	sessionManager.getSessionId = (): string => "wake-source-test-session";
 	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
 	return { ...base, cwd, mode: "tui", hasUI: true, ui, sessionManager };
 }

--- a/packages/senpi-codemode/test/eval/js-kernel-harness.ts
+++ b/packages/senpi-codemode/test/eval/js-kernel-harness.ts
@@ -10,6 +10,8 @@ export interface JavaScriptKernelHarnessOptions {
 	readonly cwd?: string;
 	readonly localRoots?: JavaScriptKernelOptions["localRoots"];
 	readonly artifactsDir?: string;
+	readonly sessionEnv?: JavaScriptKernelOptions["sessionEnv"];
+	readonly workerEntryUrl?: JavaScriptKernelOptions["workerEntryUrl"];
 }
 
 export async function withJavaScriptKernel<T>(
@@ -22,6 +24,8 @@ export async function withJavaScriptKernel<T>(
 		parallelPoolWidth: 2,
 		...(options.localRoots === undefined ? {} : { localRoots: options.localRoots }),
 		...(options.artifactsDir === undefined ? {} : { artifactsDir: options.artifactsDir }),
+		...(options.sessionEnv === undefined ? {} : { sessionEnv: options.sessionEnv }),
+		...(options.workerEntryUrl === undefined ? {} : { workerEntryUrl: options.workerEntryUrl }),
 	});
 	try {
 		return await run(kernel);

--- a/packages/senpi-codemode/test/extension-session-env.test.ts
+++ b/packages/senpi-codemode/test/extension-session-env.test.ts
@@ -1,0 +1,144 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { afterAll, describe, expect, it } from "vitest";
+import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
+import { fakeExtensionContext } from "./eval/fakes.ts";
+
+interface RegisteredHandler {
+	readonly event: string;
+	readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+}
+
+class SessionEnvPi implements CodemodeExtensionAPI {
+	readonly handlers: RegisteredHandler[] = [];
+	registerTool(): void {}
+	registerRemovedToolHint(): void {}
+	on(event: string, handler: RegisteredHandler["handler"]): void {
+		this.handlers.push({ event, handler });
+	}
+	executeTool(): Promise<never> {
+		throw new Error("nested tool execution was not expected");
+	}
+	getActiveTools(): string[] {
+		return ["eval"];
+	}
+	getAllTools(): readonly { readonly name: string }[] {
+		return [{ name: "eval" }];
+	}
+	sendMessage(): void {}
+	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+		for (const entry of this.handlers.filter((handler) => handler.event === event)) {
+			await entry.handler(payload, ctx);
+		}
+	}
+}
+
+class CapturedOptionsManager implements CodemodeSessionManager {
+	async getKernel(): Promise<never> {
+		throw new Error("kernel execution was not expected");
+	}
+	async dispose(): Promise<void> {}
+	async complete(): Promise<{
+		readonly text: string;
+		readonly details: { readonly model: string; readonly structured: false };
+	}> {
+		return { text: "ok", details: { model: "fake/fake-model", structured: false } };
+	}
+}
+
+const artifactsRoot = join(tmpdir(), `senpi-codemode-session-env-tests-${process.pid}`);
+const directories: string[] = [];
+
+afterAll(async () => {
+	await rm(artifactsRoot, { recursive: true, force: true });
+	await Promise.all(directories.map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+function sessionContext(
+	sessionId: string,
+	sessionFile: string | undefined,
+	modelId: string,
+	cwd: string,
+): ExtensionContext {
+	const base = fakeExtensionContext();
+	const model: Model<Api> = {
+		id: modelId,
+		name: modelId,
+		api: "fake-api",
+		provider: "fake",
+		baseUrl: "https://fake.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+	return {
+		...base,
+		cwd,
+		sessionManager: {
+			...base.sessionManager,
+			getSessionId: () => sessionId,
+			getSessionFile: () => sessionFile,
+		},
+		model,
+		...(sessionFile === undefined ? {} : { thinkingLevel: "high" as const }),
+	};
+}
+
+async function sessionCwd(): Promise<string> {
+	const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-session-env-"));
+	directories.push(cwd);
+	await mkdir(join(cwd, ".senpi"), { recursive: true });
+	return cwd;
+}
+
+describe("codemode extension session environment", () => {
+	it("resolves the session environment from the session context on every session start", async () => {
+		const cwd = await sessionCwd();
+		const pi = new SessionEnvPi();
+		const captured: CreateCodemodeSessionManagerOptions[] = [];
+		senpiCodemode(pi, {
+			createSessionManager: (options) => {
+				captured.push(options);
+				return new CapturedOptionsManager();
+			},
+		});
+
+		await pi.emit(
+			"session_start",
+			{ reason: "startup", sessionId: "extension-session-a" },
+			sessionContext("extension-session-a", join(artifactsRoot, "session-a.jsonl"), "fake-model-a", cwd),
+		);
+		await pi.emit(
+			"session_before_switch",
+			{},
+			sessionContext("extension-session-a", join(artifactsRoot, "session-a.jsonl"), "fake-model-a", cwd),
+		);
+		await pi.emit(
+			"session_start",
+			{ reason: "startup", sessionId: "extension-session-b" },
+			sessionContext("extension-session-b", undefined, "fake-model-b", cwd),
+		);
+
+		expect(captured).toHaveLength(2);
+		expect(captured[0]?.sessionId).toBe("extension-session-a");
+		expect(captured[0]?.sessionEnv).toEqual({
+			PI_SESSION_ID: "extension-session-a",
+			PI_SESSION_FILE: join(artifactsRoot, "session-a.jsonl"),
+			PI_PROVIDER: "fake",
+			PI_MODEL: "fake-model-a",
+			PI_REASONING_LEVEL: "high",
+		});
+		expect(captured[1]?.sessionId).toBe("extension-session-b");
+		expect(captured[1]?.sessionEnv).toEqual({
+			PI_SESSION_ID: "extension-session-b",
+			PI_PROVIDER: "fake",
+			PI_MODEL: "fake-model-b",
+		});
+	});
+});

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -143,6 +143,7 @@ function extensionContext(cwd = process.cwd()): ExtensionContext {
 		cwd,
 		sessionManager: {
 			...base.sessionManager,
+			getSessionId: () => "extension-test-session",
 			getSessionFile: () => join(extensionArtifactsRoot, `${crypto.randomUUID()}.jsonl`),
 		},
 	};

--- a/packages/senpi-codemode/test/js-kernel-session-env.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-session-env.test.ts
@@ -39,9 +39,10 @@ describe("JavaScriptKernel session environment", () => {
 		async ({ expectedMode, workerEntryUrl }) => {
 			await withJavaScriptKernel(
 				async (kernel) => {
-					expect(kernel.mode).toBe(expectedMode);
-
 					const helperValue = await cellValue(kernel, 'return env("PI_SESSION_ID")');
+					// The inline fallback is decided by the first spawn attempt, so the mode is
+					// observable only after a cell has run.
+					expect(kernel.mode).toBe(expectedMode);
 					expect(helperValue).toBe("js-session-env-77");
 
 					const processValue = await cellValue(kernel, "return process.env.PI_SESSION_ID ?? null");

--- a/packages/senpi-codemode/test/js-kernel-session-env.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-session-env.test.ts
@@ -1,0 +1,113 @@
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { JavaScriptKernel, JavaScriptKernelMode } from "../src/kernels/js/context-manager.ts";
+import { parseJavaScriptResult, runJavaScriptCell, withJavaScriptKernel } from "./eval/js-kernel-harness.ts";
+
+const childCell = [
+	"const childProcess = process.getBuiltinModule('node:child_process');",
+	"const child = childProcess.spawnSync(process.execPath, [",
+	"  '-e',",
+	"  'process.stdout.write(String(process.env.PI_SESSION_ID ?? \"\"))',",
+	"]);",
+	"return String(child.stdout ?? '');",
+].join("\n");
+
+async function cellValue(kernel: JavaScriptKernel, code: string): Promise<unknown> {
+	const run = await runJavaScriptCell(kernel, code);
+	return parseJavaScriptResult(run.result);
+}
+
+describe("JavaScriptKernel session environment", () => {
+	it.each([
+		{
+			name: "worker",
+			expectedMode: "worker",
+			workerEntryUrl: new URL("../src/kernels/js/worker-entry.js", import.meta.url),
+		},
+		{
+			name: "inline fallback",
+			expectedMode: "inline",
+			workerEntryUrl: pathToFileURL(join(process.cwd(), "missing-session-env-worker.js")),
+		},
+	] satisfies readonly {
+		readonly name: string;
+		readonly expectedMode: JavaScriptKernelMode;
+		readonly workerEntryUrl: URL;
+	}[])(
+		"exposes PI_SESSION_ID to env(), process.env, and child processes in the $name kernel",
+		async ({ expectedMode, workerEntryUrl }) => {
+			await withJavaScriptKernel(
+				async (kernel) => {
+					expect(kernel.mode).toBe(expectedMode);
+
+					const helperValue = await cellValue(kernel, 'return env("PI_SESSION_ID")');
+					expect(helperValue).toBe("js-session-env-77");
+
+					const processValue = await cellValue(kernel, "return process.env.PI_SESSION_ID ?? null");
+					expect(processValue).toBe("js-session-env-77");
+
+					const childValue = await cellValue(kernel, childCell);
+					expect(childValue).toBe("js-session-env-77");
+				},
+				{
+					sessionEnv: { PI_SESSION_ID: "js-session-env-77", PI_PROVIDER: "fake", PI_MODEL: "fake-model" },
+					workerEntryUrl,
+				},
+			);
+		},
+	);
+
+	it("clears inherited PI_* values the active session does not set", async () => {
+		const previousFile = process.env.PI_SESSION_FILE;
+		const previousId = process.env.PI_SESSION_ID;
+		process.env.PI_SESSION_FILE = "stale-session-file.jsonl";
+		process.env.PI_SESSION_ID = "stale-session-id";
+		try {
+			await withJavaScriptKernel(
+				async (kernel) => {
+					const id = await cellValue(kernel, "return process.env.PI_SESSION_ID ?? null");
+					expect(id).toBe("js-fresh-session");
+
+					const sessionFile = await cellValue(kernel, "return process.env.PI_SESSION_FILE ?? null");
+					expect(sessionFile).toBeNull();
+				},
+				{ sessionEnv: { PI_SESSION_ID: "js-fresh-session" } },
+			);
+		} finally {
+			if (previousId === undefined) delete process.env.PI_SESSION_ID;
+			else process.env.PI_SESSION_ID = previousId;
+			if (previousFile === undefined) delete process.env.PI_SESSION_FILE;
+			else process.env.PI_SESSION_FILE = previousFile;
+		}
+	});
+
+	it("follows the active session when a new kernel starts for another session", async () => {
+		await withJavaScriptKernel(
+			async (kernel) => {
+				const id = await cellValue(kernel, 'return env("PI_SESSION_ID")');
+				expect(id).toBe("js-session-a");
+			},
+			{ sessionEnv: { PI_SESSION_ID: "js-session-a" } },
+		);
+
+		await withJavaScriptKernel(
+			async (kernel) => {
+				const id = await cellValue(kernel, 'return env("PI_SESSION_ID")');
+				expect(id).toBe("js-session-b");
+			},
+			{ sessionEnv: { PI_SESSION_ID: "js-session-b" } },
+		);
+	});
+
+	it("re-applies the session environment after a kernel reset", async () => {
+		await withJavaScriptKernel(
+			async (kernel) => {
+				await kernel.reset();
+				const id = await cellValue(kernel, 'return env("PI_SESSION_ID")');
+				expect(id).toBe("js-reset-session");
+			},
+			{ sessionEnv: { PI_SESSION_ID: "js-reset-session" } },
+		);
+	});
+});

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -38,6 +38,7 @@ describe("JS kernel shell output capture", () => {
 	afterEach(() => {
 		restore();
 		restore = () => {};
+		Reflect.deleteProperty(globalThis, "__senpi_session_env_deletions__");
 		if (hadBun) Object.defineProperty(globalThis, "Bun", { value: originalBun, configurable: true, writable: true });
 		else Reflect.deleteProperty(globalThis, "Bun");
 	});
@@ -201,6 +202,43 @@ describe("JS kernel shell output capture", () => {
 
 		expect(fake.spawnCalls).toEqual([{ cmd: ["ls"], options: { cmd: ["ls"], stdout: "pipe", stderr: "pipe" } }]);
 		expect(emitted).toEqual([{ stream: "stderr", data: "child stderr for ls\n" }]);
+	});
+
+	it("Given deleted session keys when capture installs then Bun spawns pin the worker's environment view", async () => {
+		const fake = installFakeBun();
+		process.env.PI_SESSION_ID = "capture-pin-session";
+		globalThis.__senpi_session_env_deletions__ = ["PI_SESSION_FILE"];
+		const { emitText } = emitter();
+		try {
+			restore = installShellCapture({ isActive: () => true, emitText });
+
+			fake.bun.spawn(["sh", "-c", 'printf %s "$PI_SESSION_ID"']);
+			fake.bun.spawn(["keep"], { env: { CUSTOM: "1" } });
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			const pinned = fake.spawnCalls[0]?.options;
+			expect(pinned?.env).toEqual({ ...process.env });
+			expect(pinned?.stderr).toBe("pipe");
+			expect(fake.spawnCalls[1]?.options.env).toEqual({ CUSTOM: "1" });
+			// The shell default environment is seeded from the same view before wrapping.
+			expect(fake.bun.$.calls).toContain("env");
+		} finally {
+			delete process.env.PI_SESSION_ID;
+		}
+	});
+
+	it("Given no deleted session keys when capture installs then spawn options pass through unchanged", async () => {
+		const fake = installFakeBun();
+		const { emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		fake.bun.spawn(["sh", "-c", 'printf %s "$PI_SESSION_ID"']);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(fake.spawnCalls).toEqual([
+			{ cmd: ["sh", "-c", 'printf %s "$PI_SESSION_ID"'], options: { stderr: "pipe" } },
+		]);
+		expect(fake.bun.$.calls).toEqual([]);
 	});
 
 	it("Given explicit stdio choices or no active cell when Bun.spawn runs then the options pass through unchanged", async () => {

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -39,6 +39,7 @@ describe("JS kernel shell output capture", () => {
 		restore();
 		restore = () => {};
 		Reflect.deleteProperty(globalThis, "__senpi_session_env_deletions__");
+		Reflect.deleteProperty(globalThis, "__senpi_session_env_applied__");
 		if (hadBun) Object.defineProperty(globalThis, "Bun", { value: originalBun, configurable: true, writable: true });
 		else Reflect.deleteProperty(globalThis, "Bun");
 	});
@@ -227,7 +228,27 @@ describe("JS kernel shell output capture", () => {
 		}
 	});
 
-	it("Given no deleted session keys when capture installs then spawn options pass through unchanged", async () => {
+	it("Given a session environment applied without deletions when Bun.spawn runs without env then the worker view is pinned", async () => {
+		const fake = installFakeBun();
+		process.env.PI_SESSION_ID = "capture-applied-session";
+		globalThis.__senpi_session_env_deletions__ = [];
+		globalThis.__senpi_session_env_applied__ = true;
+		const { emitText } = emitter();
+		try {
+			restore = installShellCapture({ isActive: () => true, emitText });
+
+			fake.bun.spawn(["sh", "-c", 'printf %s "$PI_SESSION_ID"']);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			const pinned = fake.spawnCalls[0]?.options;
+			expect(pinned?.env).toEqual({ ...process.env });
+			expect(pinned?.env).toHaveProperty("PI_SESSION_ID", "capture-applied-session");
+		} finally {
+			delete process.env.PI_SESSION_ID;
+		}
+	});
+
+	it("Given no session environment when capture installs then spawn options pass through unchanged", async () => {
 		const fake = installFakeBun();
 		const { emitText } = emitter();
 		restore = installShellCapture({ isActive: () => true, emitText });

--- a/packages/senpi-codemode/test/py-kernel-session-env.test.ts
+++ b/packages/senpi-codemode/test/py-kernel-session-env.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { BridgeConnectionConfig } from "../src/bridge/protocol.ts";
+import { type KernelSpawnOptions, PythonKernel } from "../src/kernels/py/kernel.ts";
+import { FakeChild, hasPython3, liveKernel, runCell } from "./py-kernel/fixtures.ts";
+
+const childProbe = [
+	"import sys, subprocess",
+	"int(subprocess.check_output([",
+	"\tsys.executable,",
+	"\t'-c',",
+	"\t\"import os; print(os.environ.get('PI_SESSION_ID', ''), end='')\",",
+	"]) == b'py-live-session-77')",
+].join("\n");
+
+describe("PythonKernel session environment", () => {
+	it("spawns the interpreter with the session environment and without inherited PI_* values", async () => {
+		const child = new FakeChild();
+		const spawns: KernelSpawnOptions[] = [];
+		const connection: BridgeConnectionConfig = { port: 1, token: "t" };
+		const previousFile = process.env.PI_SESSION_FILE;
+		process.env.PI_SESSION_FILE = "stale-session-file.jsonl";
+		try {
+			const kernel = await PythonKernel.start({
+				interpreterPath: "python3",
+				sessionId: "mock-session",
+				cwd: process.cwd(),
+				connection,
+				sessionEnv: { PI_SESSION_ID: "py-session-env-77" },
+				spawnProcess: (options) => {
+					spawns.push(options);
+					return child;
+				},
+			});
+			await kernel.close();
+		} finally {
+			if (previousFile === undefined) delete process.env.PI_SESSION_FILE;
+			else process.env.PI_SESSION_FILE = previousFile;
+		}
+
+		expect(spawns).toHaveLength(1);
+		const env = spawns[0]?.env;
+		expect(env?.PI_SESSION_ID).toBe("py-session-env-77");
+		expect(env).not.toHaveProperty("PI_SESSION_FILE");
+		expect(env?.PYTHONUNBUFFERED).toBe("1");
+	});
+
+	it("keeps the session environment on every interpreter respawn", async () => {
+		const children = [new FakeChild(), new FakeChild()];
+		const spawns: KernelSpawnOptions[] = [];
+		const kernel = await PythonKernel.start({
+			interpreterPath: "python3",
+			sessionId: "respawn-session",
+			cwd: process.cwd(),
+			connection: { port: 1, token: "t" },
+			sessionEnv: { PI_SESSION_ID: "py-respawn-session" },
+			spawnProcess: (options) => {
+				spawns.push(options);
+				const child = children[spawns.length - 1];
+				if (!child) throw new Error("unexpected Python respawn");
+				return child;
+			},
+		});
+		try {
+			await kernel.reset();
+		} finally {
+			await kernel.close();
+		}
+
+		expect(spawns).toHaveLength(2);
+		for (const spawn of spawns) expect(spawn.env?.PI_SESSION_ID).toBe("py-respawn-session");
+	});
+});
+
+describe.skipIf(!(await hasPython3()))("PythonKernel live session environment", () => {
+	it("exposes PI_SESSION_ID to os.environ and to child processes", async () => {
+		const kernel = await liveKernel({ sessionEnv: { PI_SESSION_ID: "py-live-session-77" } });
+		try {
+			const inProcess = await runCell(kernel, "import os\nos.environ.get('PI_SESSION_ID') == 'py-live-session-77'");
+			expect(inProcess).toMatchObject({ ok: true, valueRepr: "True" });
+
+			const fromChild = await runCell(kernel, childProbe);
+			expect(fromChild).toMatchObject({ ok: true, valueRepr: "1" });
+		} finally {
+			await kernel.close();
+		}
+	});
+
+	it("follows the active session when a new kernel starts for another session", async () => {
+		const first = await liveKernel({ sessionEnv: { PI_SESSION_ID: "py-live-session-a" } });
+		try {
+			const observed = await runCell(first, "import os\nos.environ.get('PI_SESSION_ID') == 'py-live-session-a'");
+			expect(observed).toMatchObject({ ok: true, valueRepr: "True" });
+		} finally {
+			await first.close();
+		}
+
+		const second = await liveKernel({ sessionEnv: { PI_SESSION_ID: "py-live-session-b" } });
+		try {
+			const observed = await runCell(second, "import os\nos.environ.get('PI_SESSION_ID') == 'py-live-session-b'");
+			expect(observed).toMatchObject({ ok: true, valueRepr: "True" });
+		} finally {
+			await second.close();
+		}
+	});
+});

--- a/packages/senpi-codemode/test/py-kernel/fixtures.ts
+++ b/packages/senpi-codemode/test/py-kernel/fixtures.ts
@@ -179,7 +179,9 @@ export async function hasPython3(): Promise<boolean> {
 	return (await detector.detect("py")).ok;
 }
 
-export async function liveKernel(options: Pick<PythonKernelStartOptions, "onMessage"> = {}): Promise<PythonKernel> {
+export async function liveKernel(
+	options: Pick<PythonKernelStartOptions, "onMessage" | "sessionEnv"> = {},
+): Promise<PythonKernel> {
 	const detector = createInterpreterDetector();
 	const detected = await detector.detect("py");
 	if (!detected.ok) throw new Error("python unavailable");

--- a/packages/senpi-codemode/test/session-env.test.ts
+++ b/packages/senpi-codemode/test/session-env.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+	applySessionEnvironment,
+	SESSION_ENVIRONMENT_KEYS,
+	sessionEnvironmentFrom,
+} from "../src/kernels/session-env.ts";
+
+const fullSource = {
+	sessionManager: {
+		getSessionId: () => "session-77",
+		getSessionFile: () => "/tmp/sessions/session-77.jsonl",
+	},
+	model: { provider: "fake-provider", id: "fake-model" },
+	thinkingLevel: "high",
+};
+
+describe("session environment contract", () => {
+	it("resolves every PI_* session variable the bash tool exposes", () => {
+		expect(sessionEnvironmentFrom(fullSource)).toEqual({
+			PI_SESSION_ID: "session-77",
+			PI_SESSION_FILE: "/tmp/sessions/session-77.jsonl",
+			PI_PROVIDER: "fake-provider",
+			PI_MODEL: "fake-model",
+			PI_REASONING_LEVEL: "high",
+		});
+	});
+
+	it("omits optional variables the session does not provide", () => {
+		const env = sessionEnvironmentFrom({
+			sessionManager: { getSessionId: () => "ephemeral-1", getSessionFile: () => undefined },
+		});
+
+		expect(env).toEqual({ PI_SESSION_ID: "ephemeral-1" });
+		for (const key of SESSION_ENVIRONMENT_KEYS) {
+			if (key === "PI_SESSION_ID") continue;
+			expect(env).not.toHaveProperty(key);
+		}
+	});
+
+	it("replaces inherited PI_* values instead of leaking them", () => {
+		const base: NodeJS.ProcessEnv = {
+			PATH: "/usr/bin",
+			PI_SESSION_ID: "stale-session",
+			PI_SESSION_FILE: "stale-file.jsonl",
+			PI_PROVIDER: "stale-provider",
+			PI_MODEL: "stale-model",
+			PI_REASONING_LEVEL: "stale-level",
+		};
+
+		const applied = applySessionEnvironment(base, { PI_SESSION_ID: "session-77" });
+
+		expect(applied).toEqual({ PATH: "/usr/bin", PI_SESSION_ID: "session-77" });
+		expect(base).toHaveProperty("PI_SESSION_ID", "stale-session");
+	});
+});


### PR DESCRIPTION
## Why

A child spawned from an eval cell did not see the session identity the bash tool exports. Measured on senpi 2026.9.7: inside the js kernel `env("PI_SESSION_ID")` is null and `Bun.$\`printenv PI_SESSION_ID\`` prints nothing, while the bash tool's child prints the session id. Any per-session tooling keyed on `PI_SESSION_ID` (the omo ulw-loop toolkit scopes its state by it) therefore resolved the wrong scope when driven from eval — the default execution surface — and silently read or wrote another session's state.

## What

- `src/kernels/session-env.ts` (new): the per-session `PI_*` contract shared by every kernel (`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, `PI_REASONING_LEVEL`), mirroring the bash tool's delete-then-set semantics; `sessionEnvironmentFrom(ctx)` resolves it from the extension context.
- `runtime-factory` / `session-manager` thread the resolved environment into every kernel; the js worker applies it to its own `process.env` at init (`worker-core.js`), py/rb/jl spawn with it merged into the interpreter env; the bridge `init` message gains an optional `sessionEnv`.
- Measured Bun Worker semantics (Bun 1.4.0, linux + macOS): a worker's `process.env` writes are visible to `Bun.$` and `node:child_process` but NOT to `Bun.spawn` without an explicit `env` (it inherits the OS environ; `delete process.env.X` also does not unsetenv). `worker-shell-capture.js` therefore pins the worker's environment view for such spawns whenever a session environment was applied.

## Proof

New tests (RED on `origin/main`): `session-env.test.ts`, `js-kernel-session-env.test.ts` (worker + inline matrix incl. a real child process, stale-key deletion, session A→B, reset re-apply), `py-kernel-session-env.test.ts` (fake spawn capture + live interpreter + child), `extension-session-env.test.ts`, `bridge-protocol.test.ts` round-trip, `js-kernel-shell-capture.test.ts` pin cases. Run on an ascii box (linux, node 24) before merge.

## Notes

- `PI_PROVIDER` / `PI_MODEL` / `PI_REASONING_LEVEL` are snapshotted when the kernel starts; `PI_SESSION_ID` is immutable per session, which is the value that fixes the wrong-scope path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eval kernels and every child process they spawn now see the active session's `PI_*` environment (`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, `PI_REASONING_LEVEL`), matching what bash-tool children see. Previously a child spawned from an eval cell saw no `PI_SESSION_ID`, so per-session tooling like `omo-agent-toolkit ulw-loop` could read or write another session's state.

**Changes**
- New `src/kernels/session-env.ts` resolves the session environment from the extension context and threads it into every kernel.
- Inherited `PI_*` values are deleted before the session's values are applied, so stale values never leak.
- The JS worker applies the environment to its `process.env`; py/rb/jl interpreters spawn with it merged, and kernel resets re-apply it.
- Under Bun, `Bun.spawn` without an explicit `env` inherits the OS environ, so shell capture pins the worker's environment view whenever a session environment is applied.
- Values snapshot at kernel start; a session switch starts fresh kernels with the new session's values.

<sup>Written for commit 0979e9385668cdb398bab307e7bd5ab1bb07183a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

