### PR TITLE
fix(release): refresh bun.lock in the release lock refresh

### DIFF
--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -1,13 +1,21 @@
+// Every lockfile the repository ships must move with the version bump: the
+// version:* scripts refresh bun.lock next to package-lock.json (b0ce15391), but
+// releases go through this function, so bun.lock kept the previous release's
+// workspace versions and a plain `bun install` on main rewrote it (2026.9.5-3
+// through 2026.9.7 all shipped that way).
 export function runPackageLockRefresh(dryRun, runCommand, log, dryRunLog) {
 	if (dryRun) {
 		dryRunLog("npm install --package-lock-only --ignore-scripts");
 		dryRunLog("npm install --ignore-scripts --no-audit --no-fund");
+		dryRunLog("bun install --lockfile-only");
 		return;
 	}
 	log("npm install --package-lock-only --ignore-scripts");
 	runCommand("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
 	log("npm install --ignore-scripts --no-audit --no-fund");
 	runCommand("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"]);
+	log("bun install --lockfile-only");
+	runCommand("bun", ["install", "--lockfile-only"]);
 }
 
 export function runGenerateModels(dryRun, runCommand, log, dryRunLog) {

--- a/scripts/release-artifacts.test.mjs
+++ b/scripts/release-artifacts.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import { runPackageLockRefresh } from "./release-artifacts.mjs";
 
 describe("release package-lock refresh", () => {
-	it("reconciles native optional packages after the host-specific lock refresh", () => {
+	it("refreshes package-lock.json, reconciles native optionals, then refreshes bun.lock", () => {
 		const commands = [];
 		runPackageLockRefresh(
 			false,
@@ -15,10 +15,11 @@ describe("release package-lock refresh", () => {
 		assert.deepEqual(commands, [
 			["npm", ["install", "--package-lock-only", "--ignore-scripts"]],
 			["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"]],
+			["bun", ["install", "--lockfile-only"]],
 		]);
 	});
 
-	it("previews both lock refresh and native optional reconciliation", () => {
+	it("previews the npm lock refresh, the native optional reconciliation, and the bun.lock refresh", () => {
 		const previews = [];
 		runPackageLockRefresh(
 			true,
@@ -30,6 +31,7 @@ describe("release package-lock refresh", () => {
 		assert.deepEqual(previews, [
 			"npm install --package-lock-only --ignore-scripts",
 			"npm install --ignore-scripts --no-audit --no-fund",
+			"bun install --lockfile-only",
 		]);
 	});
 });


### PR DESCRIPTION
## Summary

b0ce15391 made `version:patch|minor|major` and `refresh-lock` regenerate `bun.lock` next to `package-lock.json`, but releases do not go through those scripts: `scripts/release.mjs` bumps the workspace versions itself and refreshes the lockfile through `runPackageLockRefresh`, which only knew npm. Every release since (2026.9.5-3, 2026.9.6, 2026.9.7) committed a `bun.lock` whose ten workspace entries still carried the previous version.

Measured on `8dd4880e9`: `bun.lock` records `2026.9.4-2` for every workspace entry — that value and nothing else — and its last commit is `b7ee9a311` (2026-09-04, a `fix(deps)`), never a release commit, while 2026.9.5-x, 2026.9.6 and 2026.9.7 shipped in between; so the published 2026.9.7 carries a lockfile claiming 2026.9.4-2. With bun 1.4.0 on a clean Linux box: a plain `bun install --ignore-scripts` rewrites 46 lines of `bun.lock` (10 x `"version": "2026.9.4-2"` -> `"2026.9.7"`) before a contributor has changed anything. `bun install --frozen-lockfile` still passes because bun compares resolutions, not workspace version stamps, so nothing in CI observes the drift — the symptom is a dirty lockfile in every fresh bun checkout.

## What changed

- `scripts/release-artifacts.mjs`: `runPackageLockRefresh` ends with `bun install --lockfile-only` (dry-run preview included), so the release commit carries a `bun.lock` that matches the versions it ships. `publish-npm.yml` already installs bun 1.4.0 before the release step.
- `scripts/release-artifacts.test.mjs`: pins the three-command sequence and the preview. Written first: both cases failed against the two-command implementation.

Found while proving #1447 on a fresh clone.
