### PR TITLE
test(coding-agent): attribute the realpathSync oracle divergence to Node, not Bun

### DIFF
--- a/packages/coding-agent/test/canonical-path-identity.test.ts
+++ b/packages/coding-agent/test/canonical-path-identity.test.ts
@@ -43,9 +43,10 @@ function createSymlinkEscapeFixture(dir: string): { readonly requested: string; 
 }
 
 describe("open-free resolution agrees with realpath(3)", () => {
-	// The oracle here is the file the I/O opens, not `realpathSync`: Bun's realpath collapses this
-	// `..` lexically on Linux and answers allowed/secret, disagreeing with the kernel's own
-	// resolution of the same path (measured). Pinning it to realpathSync would pin that bug.
+	// The oracle here is the file the I/O opens, not `realpathSync`: Node's JS `fs.realpathSync`
+	// collapses this `..` lexically and answers allowed/secret (measured on node v24 and v26), while
+	// `realpathSync.native` and Bun agree with the kernel. Vitest runs under Node, so pinning the
+	// walker to `realpathSync` would pin that bug into the suite.
 	it.skipIf(isWindows)("applies `..` in a symlink target after following that target's symlinks", () => {
 		// given
 		const dir = createRoot();


### PR DESCRIPTION
## Correction

The comment above the escape-fixture test in `test/canonical-path-identity.test.ts` (merged in #1449) said **Bun's** `realpathSync` collapses a link-target `..` lexically. That attribution was wrong.

Re-measured on the identical fixture under both runtimes on macOS (`entry -> "jump/../secret"`, `jump -> <abs>/outside/subdir`, distinct bytes in `allowed/secret/f.txt` vs `outside/secret/f.txt`):

| runtime | `realpathSync` | `realpathSync.native` | kernel reads |
| --- | --- | --- | --- |
| Bun 1.4.0 | `outside/secret` (correct) | `outside/secret` | `outside` |
| Node v26.7.0 | **`allowed/secret`** | `outside/secret` | `outside` |

So it is **Node's JS-implemented `fs.realpathSync`** that diverges from the kernel (also observed on node v24.18.1 on the Linux CI-equivalent box); `realpathSync.native` (libuv) and Bun agree with it. The suite showed the divergence because vitest runs under Node regardless of being launched via `bunx`.

The test's oracle choice (assert against the bytes `readFileSync(requested)` opens) was already right for the wrong stated reason; this PR fixes only the stated reason. Comment-only change, no behavior delta.

Refs #1449.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the test comment in `packages/coding-agent/test/canonical-path-identity.test.ts` to attribute the `realpathSync` divergence to Node's JS implementation instead of Bun, with no behavior change.

- Re-measured on the same fixture: Node's `fs.realpathSync` (v24 and v26) collapses the link-target `..` lexically, while `realpathSync.native` and Bun agree with the kernel.
- The suite runs under Node via vitest, which is why the divergence surfaced there; the oracle choice stays correct for the right reason.

<sup>Written for commit 051eb6346437114566d684f519a54f2aa9d814a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

