### PR TITLE
test(scripts): publish the signal fixture pid marker atomically

### DIFF
--- a/scripts/run-workspaces.test-support.mjs
+++ b/scripts/run-workspaces.test-support.mjs
@@ -20,11 +20,16 @@ process.exit(Number(exitCode));
 
 // A long-running fixture script: records its pid once running, then waits until
 // SIGTERM arrives and records that too. Ten seconds is only the safety net for a
-// driver that never forwards the signal.
+// driver that never forwards the signal. The pid marker is written to a temp
+// name and renamed into place: a directory watcher fires on creation, before
+// writeFileSync has written the content, and a reader that raced it saw an
+// empty file (CI, 'Script tests (bun)', 2026-09-07). rename is atomic, so the
+// marker never exists without its content.
 export const WAITER_SOURCE = `
 const fs = require("node:fs");
 const marker = process.env.RUN_WORKSPACES_MARKER_FILE;
-fs.writeFileSync(marker + ".started", String(process.pid));
+fs.writeFileSync(marker + ".started.tmp", String(process.pid));
+fs.renameSync(marker + ".started.tmp", marker + ".started");
 process.on("SIGTERM", () => { fs.writeFileSync(marker + ".terminated", ""); process.exit(0); });
 setTimeout(() => process.exit(9), 10_000);
 `;


### PR DESCRIPTION
## Summary

`scripts/run-workspaces.signals.test.mjs` (from #1447) raced its own fixture: the waiter script wrote its pid with `writeFileSync`, and the test's `fs.watch` directory watcher fired on the file's creation before the content was written. On a fast runner the test read an empty marker and failed with `the fixture recorded the pid of the script that observed SIGTERM` — CI run 34117207028, step `Script tests (bun)`, 109 ms into the test, on a PR (#1450) that does not touch these files.

## What changed

- `scripts/run-workspaces.test-support.mjs`: the fixture writes the pid to `markers.jsonl.started.tmp` and renames it into place. `rename` is atomic, so the `.started` marker never exists without its content; the watcher ignores the `.tmp` creation because it only resolves when the target path exists.

Test-only change; the runner itself is unchanged. Local: 20/20 signal-test loops green (macOS), plus the bun-launch environment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in the signal fixture where the pid marker could be read empty, causing flaky test failures on fast runners. The fixture now writes to a temp file and atomically renames it into place, so the marker never exists without its content. Test-only change; the runner is unchanged.

<sup>Written for commit 6c36a4b5c16290a8515cb3a551f006828cf4b234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

