### PR TITLE
fix(codemode): pin the worker environment for Bun.spawnSync as well

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- The JS kernel's shell capture now pins the worker's environment view for `Bun.spawnSync` as well as `Bun.spawn`, so a cell calling it without an explicit `env` sees the session's `PI_*` values instead of the inherited OS environ.
 - Eval kernels and every child they spawn now see the active session's `PI_*` environment (`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, `PI_REASONING_LEVEL`) exactly as bash-tool children do: inherited `PI_*` values are dropped before the session values are applied, so subprocesses such as `omo-agent-toolkit ulw-loop` resolve the same session as the `bash` tool instead of a cwd-global one.
 - JavaScript eval cells no longer lose their completion value when a nested function, callback, or try/catch helper contains `return`: the cell wrapper now skips last-expression capture only for a genuine top-level `return`, and a property named `return` no longer primes the statement scanner as the keyword (#1439).
 - Eval output truncation notices now name the real cause: a width-clamped line reports `N line(s) clamped to M columns (… dropped)`, a byte-capped tail reports the actual cap, and a notice never presents the output's own size as a limit.

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,21 @@
 # senpi-codemode fork changes
 
+## 2026-09-07 - Bun.spawnSync inherits the pinned session environment
+
+### What changed
+
+- `src/kernels/js/worker-shell-capture.js` wraps `Bun.spawnSync` under the same environment pin gate as `Bun.spawn`: when a session environment was applied and the call passes no explicit `env`, the worker's `process.env` view is injected (array and object call forms); explicit `env` is left untouched and the original is restored on uninstall.
+
+### Why
+
+- Measured on Bun 1.4.0: a Worker's `process.env` writes are visible to `Bun. and `node:child_process` but not to `Bun.spawn`/`Bun.spawnSync` without an explicit `env`, which inherit the OS environ. The 2026-09-07 session-environment change covered `Bun.spawn` only, so a cell using `Bun.spawnSync` could still route per-session tooling (e.g. the omo ulw-loop toolkit keyed on `PI_SESSION_ID`) to the wrong scope.
+
+### Tests
+
+- `test/js-kernel-shell-capture.test.ts`: pinned / explicit-env / object-form `spawnSync` cases and a no-session pass-through plus restore case (fake Bun records `spawnSync` calls).
+- `test/js-kernel-session-env.test.ts`: the worker + inline matrix runs a real `Bun.spawnSync` child when the cell runtime is Bun.
+
+
 ## 2026-09-07 - Eval kernels carry the session environment
 
 ### What changed

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -13,6 +13,7 @@ export function installShellCapture(options) {
 	if (!isBunRuntime(bun)) return () => {};
 	const originalShell = bun.$;
 	const originalSpawn = bun.spawn;
+	const originalSpawnSync = typeof bun.spawnSync === "function" ? bun.spawnSync : null;
 	const deletedKeys = globalThis.__senpi_session_env_deletions__;
 	const pinEnv =
 		globalThis.__senpi_session_env_applied__ === true || (Array.isArray(deletedKeys) && deletedKeys.length > 0);
@@ -24,9 +25,11 @@ export function installShellCapture(options) {
 	}
 	bun.$ = capturedShell(originalShell, options);
 	bun.spawn = capturedSpawn(originalSpawn, options, pinEnv);
+	if (originalSpawnSync !== null) bun.spawnSync = capturedSpawnSync(originalSpawnSync, pinEnv);
 	return () => {
 		bun.$ = originalShell;
 		bun.spawn = originalSpawn;
+		if (originalSpawnSync !== null) bun.spawnSync = originalSpawnSync;
 	};
 }
 
@@ -110,6 +113,24 @@ function emitShellOutput(output, emitText) {
 function outputText(value) {
 	if (value instanceof Uint8Array) return new TextDecoder().decode(value);
 	return typeof value === "string" ? value : "";
+}
+
+// Bun.spawnSync inherits the OS environ the same way Bun.spawn does, so a cell calling it
+// without an explicit env must get the worker's view pinned too (measured on Bun 1.4.0).
+function capturedSpawnSync(originalSpawnSync, pinEnv) {
+	return (...args) => {
+		if (!pinEnv) return originalSpawnSync(...args);
+		const [first, second] = args;
+		if (Array.isArray(first)) {
+			const spawnOptions = second === undefined ? {} : second;
+			if (spawnOptions === null || typeof spawnOptions !== "object" || spawnOptions.env !== undefined)
+				return originalSpawnSync(...args);
+			return originalSpawnSync(first, { ...spawnOptions, env: { ...process.env } });
+		}
+		if (first !== null && typeof first === "object" && first.env === undefined)
+			return originalSpawnSync({ ...first, env: { ...process.env } });
+		return originalSpawnSync(...args);
+	};
 }
 
 function capturedSpawn(originalSpawn, options, pinEnv) {

--- a/packages/senpi-codemode/test/eval/fake-bun-shell.ts
+++ b/packages/senpi-codemode/test/eval/fake-bun-shell.ts
@@ -132,10 +132,12 @@ export function createFakeBun(): {
 	bun: FakeBun;
 	printed: string[];
 	spawnCalls: FakeSpawnCall[];
+	spawnSyncCalls: FakeSpawnCall[];
 	outputs: Map<string, FakeShellOutput>;
 } {
 	const printed: string[] = [];
 	const spawnCalls: FakeSpawnCall[] = [];
+	const spawnSyncCalls: FakeSpawnCall[] = [];
 	const outputs = new Map<string, FakeShellOutput>();
 	const shell = ((strings: TemplateStringsArray) => {
 		const joined = strings.join("");
@@ -185,8 +187,17 @@ export function createFakeBun(): {
 				: undefined;
 		return { stderr, exited: Promise.resolve(0) };
 	};
-	const bun: FakeBun = { $: shell, spawn, spawnSync: () => ({}) };
-	return { bun, printed, spawnCalls, outputs };
+	const spawnSync = (...args: unknown[]): unknown => {
+		const [first, second] = args;
+		const options: Record<string, unknown> = Array.isArray(first)
+			? { ...(second as Record<string, unknown> | undefined) }
+			: { ...(first as Record<string, unknown>) };
+		const cmd = Array.isArray(first) ? (first as string[]) : (options.cmd as string[]);
+		spawnSyncCalls.push({ cmd, options });
+		return { stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 };
+	};
+	const bun: FakeBun = { $: shell, spawn, spawnSync };
+	return { bun, printed, spawnCalls, spawnSyncCalls, outputs };
 }
 
 export function installFakeBun(): ReturnType<typeof createFakeBun> {

--- a/packages/senpi-codemode/test/js-kernel-session-env.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-session-env.test.ts
@@ -13,6 +13,14 @@ const childCell = [
 	"return String(child.stdout ?? '');",
 ].join("\n");
 
+// Bun.spawnSync without an explicit env inherits the OS environ, not the worker's process.env;
+// the shell capture must pin the worker view for it. Skipped where the cell runtime is not Bun.
+const bunSpawnSyncCell = [
+	"if (typeof Bun === 'undefined' || typeof Bun.spawnSync !== 'function') return 'not-bun';",
+	"const child = Bun.spawnSync([process.execPath, '-e', 'process.stdout.write(String(process.env.PI_SESSION_ID ?? \"\"))']);",
+	"return new TextDecoder().decode(child.stdout);",
+].join("\n");
+
 async function cellValue(kernel: JavaScriptKernel, code: string): Promise<unknown> {
 	const run = await runJavaScriptCell(kernel, code);
 	return parseJavaScriptResult(run.result);
@@ -50,6 +58,10 @@ describe("JavaScriptKernel session environment", () => {
 
 					const childValue = await cellValue(kernel, childCell);
 					expect(childValue).toBe("js-session-env-77");
+
+					const bunSyncValue = await cellValue(kernel, bunSpawnSyncCell);
+					expect(bunSyncValue === "not-bun" || bunSyncValue === "js-session-env-77").toBe(true);
+					if (Object.hasOwn(globalThis, "Bun")) expect(bunSyncValue).toBe("js-session-env-77");
 				},
 				{
 					sessionEnv: { PI_SESSION_ID: "js-session-env-77", PI_PROVIDER: "fake", PI_MODEL: "fake-model" },

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -248,6 +248,40 @@ describe("JS kernel shell output capture", () => {
 		}
 	});
 
+	it("Given a session environment when Bun.spawnSync runs without env then the worker view is pinned and explicit env is kept", () => {
+		const fake = installFakeBun();
+		process.env.PI_SESSION_ID = "capture-sync-session";
+		globalThis.__senpi_session_env_applied__ = true;
+		try {
+			restore = installShellCapture({ isActive: () => true, emitText: emitter().emitText });
+
+			fake.bun.spawnSync(["sh", "-c", 'printf %s "$PI_SESSION_ID"']);
+			fake.bun.spawnSync(["keep"], { env: { CUSTOM: "1" } });
+			fake.bun.spawnSync({ cmd: ["obj"] });
+
+			expect(fake.spawnSyncCalls[0]?.options.env).toEqual({ ...process.env });
+			expect(fake.spawnSyncCalls[0]?.options.env).toHaveProperty("PI_SESSION_ID", "capture-sync-session");
+			expect(fake.spawnSyncCalls[1]?.options.env).toEqual({ CUSTOM: "1" });
+			expect(fake.spawnSyncCalls[2]?.options.env).toEqual({ ...process.env });
+		} finally {
+			delete process.env.PI_SESSION_ID;
+		}
+	});
+
+	it("Given no session environment when Bun.spawnSync runs then it passes through unchanged and restore reinstates it", () => {
+		const fake = installFakeBun();
+		const originalSpawnSync = fake.bun.spawnSync;
+		restore = installShellCapture({ isActive: () => true, emitText: emitter().emitText });
+		expect(fake.bun.spawnSync).not.toBe(originalSpawnSync);
+
+		fake.bun.spawnSync(["sh", "-c", "true"]);
+		expect(fake.spawnSyncCalls).toEqual([{ cmd: ["sh", "-c", "true"], options: {} }]);
+
+		restore();
+		restore = () => {};
+		expect(fake.bun.spawnSync).toBe(originalSpawnSync);
+	});
+
 	it("Given no session environment when capture installs then spawn options pass through unchanged", async () => {
 		const fake = installFakeBun();
 		const { emitText } = emitter();


### PR DESCRIPTION
## Why

Gate review of #1448 found that `Bun.spawnSync` was left out: it inherits the OS environ exactly like `Bun.spawn` (measured on Bun 1.4.0), so a cell calling it without an explicit `env` still missed `PI_SESSION_ID` and could route per-session tooling to the wrong scope.

## What

- `worker-shell-capture.js`: wrap `Bun.spawnSync` under the same pin gate as `Bun.spawn` (array and object call forms); explicit `env` is left untouched; the original is restored on uninstall.
- `test/eval/fake-bun-shell.ts`: the fake Bun records `spawnSync` calls.
- `js-kernel-shell-capture.test.ts`: pinned / explicit-env / object-form cases and a no-session pass-through + restore case.
- `js-kernel-session-env.test.ts`: the worker + inline matrix also runs a real `Bun.spawnSync` child when the cell runtime is Bun (asserts `not-bun` otherwise, so the vitest-under-node run stays meaningful without pretending).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Bun.spawnSync` calls missing the session's `PI_*` environment values when no explicit `env` is passed, matching the pinning already applied to `Bun.spawn`. Cells that call `Bun.spawnSync` without `env` now get the worker's pinned environment; explicit `env` is left untouched and the original is restored on uninstall.

**Bug Fixes**
- Wraps `Bun.spawnSync` under the same pin gate as `Bun.spawn` for array and object call forms.
- Adds fake-Bun recording for `spawnSync` and test cases for pinned, explicit-env, object-form, and pass-through/restore.
- Runs a real `Bun.spawnSync` child in the kernel session-env matrix when the cell runtime is Bun.

<sup>Written for commit 47f48e2b69a59aae4433bcb8916b78c5f6804181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

