### PR TITLE
test(codemode): cover the non-firing top-level return

### DIFF
--- a/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
@@ -114,4 +114,12 @@ describe("JavaScript kernel last-expression capture", () => {
 			expect(parseJavaScriptResult(run.result)).toBe(42);
 		});
 	});
+
+	it("suppresses capture for a top-level return even when that return does not fire", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, 'if (false) return 1;\n"tail"');
+
+			expect(parseJavaScriptResult(run.result)).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #1441 (senpi #1439). Adds one regression case and keeps the existing one.

The shipped case `keeps a genuine top-level return as the cell value` (`if (true) return 42;\n0` -> 42) pins the documented contract, but it cannot detect the top-level-return guard being removed: without the guard, `captureLastExpression` appends `return 0;` *after* the firing `return 42;`, so the cell still yields 42.

The new case `suppresses capture for a top-level return even when that return does not fire` (`if (false) return 1;\n"tail"` -> `undefined`) covers that direction: with the guard the cell yields `undefined`; without it the injected capture yields `"tail"`.

## Why both cases stay

Mutation matrix run on the merged tree against `wrapUserCode` (predictions stated before running, both held):

| mutation | existing case (expects 42) | new case (expects undefined) |
|---|---|---|
| baseline | 42 pass | undefined pass |
| guard removed (always capture) | 42 pass | `"tail"` **FAIL** |
| guarded path forced to lose its value | undefined **FAIL** | undefined pass |
| restored | 42 pass | undefined pass |

Each mutation fails exactly one case; the pair is complementary, not redundant. A single-mutation audit made the existing case look dead — it is the only guard against the second defect.

## Notes

- Test-only; no runtime source changed. The mutation runs above executed `wrapUserCode` under Bun; CI's vitest executes the same cases under Node through `JavaScriptKernel`.
- No CHANGELOG entry: no user-visible behaviour changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test to `senpi-codemode` covering the case where a top-level return does not fire, ensuring the cell yields `undefined` instead of the tail expression.

The existing test only covers a firing top-level return, which can't detect removal of the guard. The new test (`if (false) return 1; "tail"` → `undefined`) fails without the guard. Test-only; no runtime changes.

<sup>Written for commit c968ff69fa905c8dc98be13ff1892a6dd7b31149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

