### PR TITLE
test(coding-agent): stub the platform so the key-folding contract runs on every CI runner

### DIFF
--- a/packages/coding-agent/test/bounded-realpath.test.ts
+++ b/packages/coding-agent/test/bounded-realpath.test.ts
@@ -117,15 +117,39 @@ describe("bounded resolution", () => {
 });
 
 describe("case-insensitive identity folding", () => {
-	it("folds only on filesystems that ignore case", () => {
-		// given
-		const spelled = "/Volumes/Data/Notes.txt";
+	// The platform is stubbed so both branches run on every CI runner: asserted against the host's own
+	// platform, the Linux branch reduces to "unchanged", which a deleted fold also satisfies.
+	function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+		const original = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: platform, configurable: true });
+		try {
+			return run();
+		} finally {
+			if (original) Object.defineProperty(process, "platform", original);
+		}
+	}
+
+	it("lowercases and NFC-normalizes the key where the filesystem ignores case", () => {
+		// given: "e" + combining acute (NFD) spelled with capitals
+		const spelled = "/Volumes/Data/Cafe\u0301/Notes.txt";
 
 		// when
-		const folded = foldPathForCaseInsensitiveFilesystem(spelled);
+		const folded = withPlatform("darwin", () => foldPathForCaseInsensitiveFilesystem(spelled));
+
+		// then: precomposed \u00e9, all lowercase
+		expect(folded).toBe("/volumes/data/caf\u00e9/notes.txt");
+		expect(folded).not.toBe(spelled);
+	});
+
+	it("leaves the key untouched where the filesystem is case-sensitive", () => {
+		// given
+		const spelled = "/home/user/Cafe\u0301/Notes.txt";
+
+		// when
+		const folded = withPlatform("linux", () => foldPathForCaseInsensitiveFilesystem(spelled));
 
 		// then
-		expect(folded).toBe(isCaseSensitiveFilesystem ? spelled : spelled.toLowerCase());
+		expect(folded).toBe(spelled);
 	});
 
 	it.skipIf(isCaseSensitiveFilesystem || isWindows)(


### PR DESCRIPTION
Follow-up to #1454: one shipped test was a tautology on the only CI runner that executes it.

`bounded-realpath.test.ts` "folds only on filesystems that ignore case" asserted `toBe(isLinux ? spelled : lowercased)` against the host's own platform. On Linux — the only platform that runs this file in CI — that reduces to "the path is unchanged", which a deleted fold also satisfies. Confirmed by mutation on a Linux box: deleting the fold body left that test **passing**.

Both branches now run on every runner by stubbing `process.platform` inside the test (restored in `finally`): a darwin case that also pins NFC normalization with a decomposed accent, and a linux case that pins no-fold. No production code changed.

**Regression coverage, proven in both directions** (branch head `31e622e83`, predictions written before running, PASSED dropping by exactly the failure count each time):

| mutation | predicted | actual |
| --- | --- | --- |
| `realpathWithoutOpenStrict` never throws | 2 | 2 (ELOOP, EACCES) |
| fold deleted | 1 | 1 (darwin case — the old test would have passed) |
| fold always | 1 | 1 (linux case) |
| strict throws on ENOENT too | 2 | 3 (a second consumer of the fallback I had not predicted — same defect, separate tests) |

Refs #1449, #1454.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the case-insensitive folding test so it actually tests the folding contract on every CI runner instead of only on macOS.

**Bug Fixes**
- Stubs `process.platform` to exercise both darwin and linux branches, restoring the original in `finally`.
- The darwin case now also verifies NFC normalization using a decomposed accent.
- Mutation testing confirms the new tests catch a deleted fold, an always-fold, and a never-throw regression.

<sup>Written for commit 31e622e83a38fb813a41c4068b2cd1b219c6aa7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

