### PR TITLE
test(scripts): run both platform branches of signalGroup on every runner

### DIFF
--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -95,15 +95,23 @@ const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
  * signals (npm -> sh -> node leaves node running), so signalling only the
  * direct child orphans the real work. The child is spawned as its own group
  * leader (`detached`), so the negative-pid kill reaches every descendant at
- * once with no dependence on process-listing timing.
+ * once with no dependence on process-listing timing. Windows has no process
+ * groups or catchable SIGTERM, so the tree is terminated through taskkill.
+ *
+ * The process primitives are parameters so both platform branches run under
+ * test on every runner; production callers pass nothing.
  */
-function signalGroup(child, signal) {
+export function signalGroup(
+	child,
+	signal,
+	{ platform = process.platform, kill = process.kill, spawnSync: spawnSyncImpl = spawnSync } = {},
+) {
 	if (child.pid === undefined) return;
 	try {
-		if (process.platform === "win32") {
-			spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+		if (platform === "win32") {
+			spawnSyncImpl("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
 		} else {
-			process.kill(-child.pid, signal);
+			kill(-child.pid, signal);
 		}
 	} catch {
 		// the group is already gone

--- a/scripts/package-manager.test.mjs
+++ b/scripts/package-manager.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import * as packageManager from "./package-manager.mjs";
 import {
 	cleanEnv,
 	detectPackageManager,
@@ -69,6 +70,56 @@ describe("package-manager", () => {
 		assert.deepEqual(runScriptArguments({ cmd: "bun" }, "test", ["--grep", "x"]), ["run", "test", "--", "--grep", "x"]);
 		assert.deepEqual(runScriptArguments({ cmd: "pnpm" }, "test", ["--grep", "x"]), ["run", "test", "--grep", "x"]);
 		assert.deepEqual(runScriptArguments({ cmd: "pnpm" }, "test", []), ["run", "test"]);
+	});
+
+	// signalGroup takes its process primitives as parameters so BOTH platform
+	// branches run on every runner: CI executes scripts tests on ubuntu only and
+	// Windows delivers no catchable SIGTERM, so without injection the taskkill
+	// branch would never execute under test anywhere.
+	function recordingPrimitives(platform, { killError } = {}) {
+		const calls = { kill: [], spawnSync: [] };
+		const primitives = {
+			platform,
+			kill: (pid, signal) => {
+				calls.kill.push([pid, signal]);
+				if (killError) throw killError;
+			},
+			spawnSync: (command, args) => {
+				calls.spawnSync.push([command, args]);
+				return { status: 0 };
+			},
+		};
+		return { calls, primitives };
+	}
+
+	it("signals the whole process group on POSIX and never shells out", () => {
+		const { calls, primitives } = recordingPrimitives("linux");
+
+		packageManager.signalGroup({ pid: 4242 }, "SIGTERM", primitives);
+
+		assert.deepEqual(calls.kill, [[-4242, "SIGTERM"]]);
+		assert.deepEqual(calls.spawnSync, []);
+	});
+
+	it("terminates the process tree through taskkill on win32 and never sends a POSIX signal", () => {
+		const { calls, primitives } = recordingPrimitives("win32");
+
+		packageManager.signalGroup({ pid: 4242 }, "SIGTERM", primitives);
+
+		assert.deepEqual(calls.spawnSync, [["taskkill", ["/pid", "4242", "/T", "/F"]]]);
+		assert.deepEqual(calls.kill, []);
+	});
+
+	it("treats a group that is already gone as success and does nothing without a pid", () => {
+		const gone = Object.assign(new Error("kill ESRCH"), { code: "ESRCH" });
+		const { calls, primitives } = recordingPrimitives("darwin", { killError: gone });
+
+		assert.doesNotThrow(() => packageManager.signalGroup({ pid: 7 }, "SIGINT", primitives));
+		assert.equal(calls.kill.length, 1, "the signal was attempted exactly once before the error was swallowed");
+
+		const idle = recordingPrimitives("linux");
+		packageManager.signalGroup({ pid: undefined }, "SIGTERM", idle.primitives);
+		assert.deepEqual(idle.calls, { kill: [], spawnSync: [] });
 	});
 
 	it("strips pnpm-only npm_config keys without touching the rest of the environment", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1447. `signalGroup` in `scripts/package-manager.mjs` chose its primitive from `process.platform`, so its win32 branch (`taskkill /pid <pid> /T /F`) had **never executed under test on any runner**: the scripts tests run on ubuntu only, the signals test is skipped on win32, and Windows delivers no catchable SIGTERM to a node process (the branch is reachable there only from console Ctrl+C / close events, which `node --test` cannot generate). A Windows CI step would not have exercised it either — it would have been a check incapable of failing.

## What changed

- `scripts/package-manager.mjs`: `signalGroup(child, signal, { platform, kill, spawnSync })` — primitives are an optional trailing parameter and the function is exported. `spawnPackageManager` passes nothing; production behavior is unchanged.
- `scripts/package-manager.test.mjs`: four cases drive both branches with recording primitives on whichever runner they are on. Written first: the file loads and exactly the three new cases fail with `signalGroup is not a function` (assertion-level RED, not a red file).

## Coverage (mutation matrix, predictions stated before running)

| mutation | predicted failing cases | actual |
|---|---|---|
| win32 argv drops `/T` | 1 (win32) | 1 |
| POSIX kills `pid` instead of `-pid` | 1 (POSIX) | 2 -> 1 after fixing the test (below) |
| platform check inverted | 3 | 3 |
| ESRCH swallow removed | 1 (already-gone) | 1 |
| pid guard removed | 1 (already-gone) | 1 |

The positive-pid mutation first failed two cases because the already-gone case re-asserted the kill argv — an entangled assertion in the new test, not a second production consumer. It now asserts only that one attempt was made; the mutation then isolates to the POSIX case. Restored: 24/24 across the scripts test files touched by #1447, under plain and bun launch environments.

## Behavior (separate claim)

Unchanged from #1447: process-group forwarding 40/40 plain, 20/20 npm, 10/10 bun on Linux. **The win32 branch's runtime effect (taskkill ending the tree) is still unobserved in CI**, for the reason above; this PR covers its shape, not its effect.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports `signalGroup` and makes its process primitives injectable so both platform branches run under test on every runner. Previously only the POSIX branch executed in CI; the win32 taskkill path was never tested because scripts tests run on ubuntu and Windows can't generate a catchable SIGTERM. Production behavior is unchanged.

**Testing**
- Adds tests that drive the POSIX and win32 branches with recording primitives.
- Covers the already-gone and missing-pid cases.

<sup>Written for commit 606abdcf6da190230906eea4cce14fec7d6d3aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

