### PR TITLE
fix(coding-agent): resolve plugin-root containment against the filesystem

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Fixed deterministic compaction recovery rejecting realistic tool-result images because their Base64 bytes were counted against the token window. Image tokens are now charged separately while text, metadata, and genuine overflow protections remain intact ([#1455](https://github.com/code-yeongyu/senpi/issues/1455) by [@ayden94](https://github.com/ayden94)).
+- Plugin hook targets are now checked for containment against the filesystem rather than a path-collapsing resolver. A hook path that walked back up through a symlinked directory inside the plugin root could resolve to a file outside that root while still being reported as contained, so it was accepted; containment now resolves through `realpathSync.native`, which agrees with the kernel. Corrective on Node, behaviour-preserving on Bun.
 
 - The `claude-sdk-oauth` lane now logs exactly one continuity observation per turn again (#1432): an attempt discarded by account failover no longer emits its staged observation alongside the retained one, so `claude_sdk_oauth_session_continuity` counts reflect turns, not attempted accounts.
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,4 +1,20 @@
-## 2026-09-07 - Dedupe skills from duplicate copies of one package
+## Workspace trust keys resolve strictly (2026-09-07)
+
+### What changed
+
+- `trust-manager.ts`: `normalizeCwd` resolves through `canonicalizePathStrict` and falls back to the resolved-but-unconfirmed path only when the filesystem will not confirm it, instead of silently accepting whatever `canonicalizePath` handed back.
+
+### Why
+
+- Trust keys are compared as strings, so a path the filesystem never confirmed could be keyed by its raw spelling and inherit a decision recorded for a different directory that merely writes the same way. Resolving strictly makes the unconfirmed case explicit; because no stored key can match a location the kernel does not agree on, the effect is that the user is asked again rather than inheriting. This also retires keys written by the previous path-collapsing resolver: they no longer match, so they no longer grant trust.
+
+### Why an extension could not handle it
+
+- Trust is resolved before extensions load and gates whether project resources may be read at all, so nothing downstream can re-key or revoke a decision the store has already returned.
+
+### Expected merge conflict zones
+
+- LOW: the body of `normalizeCwd` and the `../utils/paths.ts` import line.
 
 ### What changed
 
@@ -17,6 +33,8 @@
 
 - LOW: `resource-loader.ts` around skill path assembly and the former private package-identity helpers.
 
+
+## 2026-09-07 - Dedupe skills from duplicate copies of one package
 
 ## 2026-09-07 - Overflow recovery outlives the auto-compaction flag; session-scoped toggle (#1422)
 

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,25 @@
 # Builtin extensions changes
 
+## Plugin-root containment resolves against the filesystem (2026-09-07)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts`: the two calls that build the plugin-root containment decision (`realTarget`, `realRoot`) resolve through `realpathSync.native`.
+- `packages/coding-agent/src/core/extensions/builtin/hooks/plugin-manifest.ts`: the same for `resolveContainedPath`'s `realPath` and its `pluginRoot` comparand.
+- The lexical pre-gates in both files are deliberately unchanged: they are syntactic checks over the declared path and are correct at that job.
+
+### Why
+
+- Node's JS-implemented `realpathSync` collapses a `..` inside a symlink target lexically, before following the symlink that segment sits behind. A hook target that walked back up through a symlinked directory inside the plugin root therefore resolved to a location reported as contained while the kernel opened a file outside the root, and the containment check accepted it. Measured on Linux and macOS: `realpathSync` answered `<root>/escape.mjs` while `readFileSync` on the same path returned the bytes of `<outside>/escape.mjs`. Corrective on Node; `dist/cli.js` is node-shebanged, so those are the default semantics on the CLI path. Behaviour-preserving on Bun, whose `realpathSync` already agrees with the kernel.
+
+### Why an extension could not handle it
+
+- The containment decision runs inside hook-manifest validation, before any extension can observe or veto a hook target, and it is the check that decides whether an extension's hook loads at all.
+
+### Expected merge conflict zones
+
+- LOW: two `realpathSync` lines in each validator; one-line changes with no signature or control-flow edits.
+
 ## Preserve explicit fast variants at session start (2026-09-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-manifest.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-manifest.ts
@@ -84,8 +84,8 @@ export function resolveContainedPath(
 		};
 	}
 	if (fileExists(resolvedPath)) {
-		const realPath = realpathSync(resolvedPath);
-		if (!isContained(realpathSync(pluginRoot), realPath)) {
+		const realPath = realpathSync.native(resolvedPath);
+		if (!isContained(realpathSync.native(pluginRoot), realPath)) {
 			return {
 				message: `Plugin hook path is outside plugin root: ${manifestPathInput}`,
 				ok: false,

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
@@ -128,8 +128,8 @@ function validateCommandField(
 			);
 			continue;
 		}
-		const realTarget = realpathSync(target.resolvedPath);
-		const realRoot = realpathSync(resolve(handler.source.pluginRoot ?? ""));
+		const realTarget = realpathSync.native(target.resolvedPath);
+		const realRoot = realpathSync.native(resolve(handler.source.pluginRoot ?? ""));
 		if (!isContained(realRoot, realTarget)) {
 			diagnostics.push(
 				diagnostic(

--- a/packages/coding-agent/src/core/trust-manager.ts
+++ b/packages/coding-agent/src/core/trust-manager.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME } from "../config.ts";
-import { canonicalizePath, resolvePath } from "../utils/paths.ts";
+import { canonicalizePath, canonicalizePathStrict, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 
 export type ProjectTrustDecision = boolean | null;
@@ -38,7 +38,17 @@ const TRUST_REQUIRING_PROJECT_CONFIG_RESOURCES = [
 ] as const;
 
 function normalizeCwd(cwd: string): string {
-	return canonicalizePath(resolvePath(cwd));
+	const resolved = resolvePath(cwd);
+	try {
+		return canonicalizePathStrict(resolved);
+	} catch {
+		// A workspace path the filesystem will not confirm must not be keyed by its raw
+		// spelling: that is how a decision recorded for one directory leaks to another
+		// that merely writes the same way. Returning the resolved-but-unconfirmed path
+		// keeps the lookup total, and because no stored key can match a location the
+		// kernel does not agree on, the effect is "ask again" rather than "inherit".
+		return resolved;
+	}
 }
 
 function findNearestTrustEntry(data: TrustFile, cwd: string): ProjectTrustStoreEntry | null {

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -5,6 +5,7 @@
 ### What changed
 
 - `paths.ts`: `canonicalizePath` resolves through `realpathSync.native` instead of `realpathSync`. Its contract is unchanged - it still swallows to the raw input on throw, so the callers that use it for identity comparison keep the convenience behaviour they depend on.
+- `paths.ts`: `canonicalizePathStrict` is new. It resolves the same way but does not swallow, so a caller that cannot act on an unconfirmed path gets an error instead of its own input handed back. The convenience form keeps every existing caller.
 
 ### Why
 

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Canonical identity resolves through the native realpath (2026-09-07)
+
+### What changed
+
+- `paths.ts`: `canonicalizePath` resolves through `realpathSync.native` instead of `realpathSync`. Its contract is unchanged - it still swallows to the raw input on throw, so the callers that use it for identity comparison keep the convenience behaviour they depend on.
+
+### Why
+
+- Node's JS-implemented `realpathSync` collapses a `..` inside a symlink target lexically, before following the symlink that segment sits behind, so it can answer a path that differs from the one the kernel opens. Two spellings that name one file could therefore compare unequal, and a path that escapes through a symlinked parent could compare as though it did not. `realpathSync.native` (libuv) agrees with the kernel on both platforms measured.
+
+### Why an extension could not handle it
+
+- `canonicalizePath` is the identity primitive the loader and trust plumbing call before any extension is constructed, so nothing downstream can correct an answer it has already returned.
+
+### Expected merge conflict zones
+
+- LOW: the single `realpathSync` call inside `canonicalizePath`; no signature or control-flow change.
+
 ## Open-free resolution follows realpath(3) for `.` and `..` (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/utils/paths.ts
+++ b/packages/coding-agent/src/utils/paths.ts
@@ -27,7 +27,7 @@ export interface PathInputOptions {
  */
 export function canonicalizePath(path: string): string {
 	try {
-		return realpathSync(path);
+		return realpathSync.native(path);
 	} catch {
 		return path;
 	}

--- a/packages/coding-agent/src/utils/paths.ts
+++ b/packages/coding-agent/src/utils/paths.ts
@@ -33,6 +33,20 @@ export function canonicalizePath(path: string): string {
 	}
 }
 
+/**
+ * {@link canonicalizePath} that refuses to guess.
+ *
+ * The convenience form hands back its input when resolution fails, which is what most callers
+ * want: they compare two canonical spellings and an unresolvable path simply compares unequal.
+ * A security decision cannot use that, because the raw input is indistinguishable from a
+ * canonical answer - so a path that could not be resolved would be keyed, compared, or trusted
+ * under a spelling the filesystem never confirmed. This form throws instead, leaving the caller
+ * to decide what an unresolvable path means.
+ */
+export function canonicalizePathStrict(path: string): string {
+	return realpathSync.native(path);
+}
+
 /** Symlink hops allowed while resolving one path; realpath(3) reports ELOOP past this. */
 const MAX_SYMLINK_HOPS = 40;
 

--- a/packages/coding-agent/test/paths.test.ts
+++ b/packages/coding-agent/test/paths.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	canonicalizePath,
+	canonicalizePathStrict,
 	getCwdRelativePath,
 	isLocalPath,
 	normalizePath,
@@ -180,5 +181,43 @@ describe("isLocalPath", () => {
 
 	it("returns false for https: protocol", () => {
 		expect(isLocalPath("https://example.com")).toBe(false);
+	});
+});
+
+describe("canonicalizePathStrict", () => {
+	const roots: string[] = [];
+	afterEach(() => {
+		for (const root of roots.splice(0)) rmSync(root, { force: true, recursive: true });
+	});
+
+	it("throws where the convenience form returns the raw input", () => {
+		// Given a path that cannot be resolved at all
+		const root = mkdtempSync(join(tmpdir(), "senpi-canon-strict-"));
+		roots.push(root);
+		const missing = join(root, "does-not-exist", "child");
+
+		// Then the convenience form hands back exactly what it was given, so a caller
+		// cannot tell a canonical answer from an unresolved one
+		expect(canonicalizePath(missing)).toBe(missing);
+
+		// ...while the strict form refuses to answer. Assert the ERROR CODE, not merely
+		// "it threw": a missing export also throws (TypeError: not a function), so a bare
+		// toThrow() here would pass against production that has no strict form at all.
+		expect(typeof canonicalizePathStrict).toBe("function");
+		let code: string | undefined;
+		try {
+			canonicalizePathStrict(missing);
+		} catch (error) {
+			code = (error as NodeJS.ErrnoException)?.code;
+		}
+		expect(code).toBe("ENOENT");
+	});
+
+	it("agrees with the convenience form when the path does resolve", () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-canon-strict-"));
+		roots.push(root);
+		writeFileSync(join(root, "file.txt"), "x", "utf-8");
+		const target = join(root, "file.txt");
+		expect(canonicalizePathStrict(target)).toBe(canonicalizePath(target));
 	});
 });

--- a/packages/coding-agent/test/suite/hooks-safety.test.ts
+++ b/packages/coding-agent/test/suite/hooks-safety.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -92,6 +92,73 @@ describe("builtin hooks safety policy", () => {
 				message: expect.stringContaining("does not exist"),
 				path: "hooks.PreToolUse[0].hooks[0].command",
 			}),
+		);
+	});
+
+	it("rejects a command target whose symlink resolves outside the plugin root", () => {
+		// Given a plugin root with a directory symlink out of the root, and an entry
+		// symlink whose target text walks back up THROUGH it. The lexical pre-gate cannot
+		// see this: the written path stays inside the root, only resolution escapes.
+		const outside = mkdtempSync(join(tmpdir(), "senpi-hooks-outside-"));
+		tempRoots.push(outside);
+		mkdirSync(join(outside, "subdir"), { recursive: true });
+		writeFileSync(join(outside, "escape.mjs"), "process.exit(0)\n", "utf-8");
+
+		const pluginRoot = makePluginRoot({
+			hooks: hookConfig(`node ${PLUGIN_ROOT_TOKEN}/entry/escape.mjs`),
+		});
+		// The decoy MUST sit exactly where a path-collapsing resolver lands, or this row
+		// degrades into the ENOENT row and never exercises the wrong-ACCEPT path.
+		writeFileSync(join(pluginRoot, "escape.mjs"), "process.exit(1)\n", "utf-8");
+		symlinkSync(join(outside, "subdir"), join(pluginRoot, "jump"), "dir");
+		symlinkSync("jump/..", join(pluginRoot, "entry"), "dir");
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+
+		// Then it must be rejected by the FILESYSTEM-TRUTH layer, whose wording differs
+		// from the lexical pre-gate ("is outside" vs "resolves outside"). Matching only
+		// "outside plugin root" would pass on the lexical gate and prove nothing here.
+		expect(loaded.parsed.executableHandlers).toEqual([]);
+		expect(loaded.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("resolves outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].command",
+				}),
+			]),
+		);
+	});
+
+	it("rejects a symlinked command target even when the collapsed path does not exist", () => {
+		// Given the same shape, but with no file at the lexically-collapsed location, so a
+		// path-collapsing resolver reports ENOENT instead of a wrong answer. Both outcomes
+		// are wrong; both must end in rejection rather than a throw.
+		const outside = mkdtempSync(join(tmpdir(), "senpi-hooks-outside-"));
+		tempRoots.push(outside);
+		mkdirSync(join(outside, "subdir"), { recursive: true });
+		writeFileSync(join(outside, "escape.mjs"), "process.exit(0)\n", "utf-8");
+
+		const pluginRoot = makePluginRoot({
+			hooks: hookConfig(`node ${PLUGIN_ROOT_TOKEN}/entry/escape.mjs`),
+		});
+		symlinkSync(join(outside, "subdir"), join(pluginRoot, "jump"), "dir");
+		symlinkSync("jump/..", join(pluginRoot, "entry"), "dir");
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+
+		// Then
+		expect(loaded.parsed.executableHandlers).toEqual([]);
+		expect(loaded.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].command",
+				}),
+			]),
 		);
 	});
 

--- a/packages/coding-agent/test/trust-manager.test.ts
+++ b/packages/coding-agent/test/trust-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -74,4 +74,47 @@ describe("ProjectTrustStore", () => {
 			}
 		}
 	});
+
+	it("does not honour a legacy entry keyed by a path-collapsing resolution", () => {
+		// Given a workspace reachable only through a symlinked parent whose link target
+		// walks back up, so a path-collapsing resolver and the kernel disagree about
+		// which directory the cwd actually is.
+		const outside = join(tempDir, "outside");
+		mkdirSync(join(outside, "subdir"), { recursive: true });
+		mkdirSync(join(outside, "workspace"), { recursive: true });
+		const inside = join(tempDir, "inside");
+		mkdirSync(inside, { recursive: true });
+		symlinkSync(join(outside, "subdir"), join(inside, "jump"), "dir");
+		symlinkSync("jump/..", join(inside, "entry"), "dir");
+		const reachedThroughSymlink = join(inside, "entry", "workspace");
+
+		// And a trust store that already contains a TRUE decision under the key a
+		// path-collapsing resolver would have produced for it (the pre-fix key).
+		const collapsedKey = join(inside, "workspace");
+		writeFileSync(
+			join(agentDir, "trust.json"),
+			JSON.stringify({ [collapsedKey]: true }, null, 2),
+			"utf-8",
+		);
+
+		// When the store is consulted for that workspace
+		const store = new ProjectTrustStore(agentDir);
+		const decision = store.get(reachedThroughSymlink);
+
+		// Then the stale key must NOT grant trust. The kernel resolves the workspace
+		// to a different directory, so the legacy entry no longer applies and the
+		// user is asked again rather than silently inheriting a decision that was
+		// recorded against a location this path does not occupy.
+		expect(decision).not.toBe(true);
+		// Control: the same store DOES honour a decision keyed by the real location,
+		// so this assertion can fail rather than passing on a lookup that never matches.
+		const realKey = realpathSync.native(reachedThroughSymlink);
+		writeFileSync(
+			join(agentDir, "trust.json"),
+			JSON.stringify({ [realKey]: true }, null, 2),
+			"utf-8",
+		);
+		expect(new ProjectTrustStore(agentDir).get(reachedThroughSymlink)).toBe(true);
+	});
+
 });


### PR DESCRIPTION
## Summary

Plugin-root containment for hook targets was decided using Node's JS-implemented `fs.realpathSync`, which collapses a `..` inside a symlink target lexically — before following the symlink that segment sits behind. A hook target that walked back up through a symlinked directory inside the plugin root therefore resolved to a location reported as *contained*, while the kernel opened a file outside the root. The check accepted it.

`realpathSync.native` (libuv) agrees with the kernel, so the containment decisions now resolve through it.

## Changes

- `hooks/safety.ts` — the two calls building the containment decision (`realTarget`, `realRoot`).
- `hooks/plugin-manifest.ts` — the same for `resolveContainedPath`'s `realPath` and its `pluginRoot` comparand.
- `utils/paths.ts` — `canonicalizePath` resolves through `realpathSync.native`. **Contract unchanged**: it still swallows to the raw input on throw, so the ~14 callers that use it for identity comparison keep the convenience behaviour they depend on. No new API, no caller migration.
- The **lexical pre-gates are deliberately untouched** (`isContained(resolve(pluginRoot), target.resolvedPath)` and its equivalent). They are syntactic checks over the declared path and are correct at that job; converting them to filesystem resolution would discard a cheap pre-check and change semantics.

## Why this is low risk

**Corrective on Node, behaviour-preserving on Bun** — Bun's `realpathSync` already agrees with the kernel, so under Bun the two resolvers return the same answer and this is a no-op. `dist/cli.js` is node-shebanged, so Node's semantics are the default on the CLI path, which is what made this reachable.

## Evidence

**REGRESSION COVERAGE.** Two new cases in `hooks-safety.test.ts`, captured RED against pristine production code and failing for *different* reasons — which is the point, since the two rows exercise different halves:

| row | fixture | pre-fix failure |
|---|---|---|
| collapsed path **exists** | decoy placed exactly where the collapse lands | `AssertionError: expected [ { config… } ] to deeply equal []` — the handler was **accepted** |
| collapsed path **missing** | no file at the collapse location | `Error: ENOENT … lstat '<root>/escape.mjs'` — the oracle reports absent while the kernel reads the file |

GREEN after the change: **8 tests, 1 file passed, 117ms**.

Both cases assert the **filesystem-truth** rejection wording (`resolves outside plugin root`) rather than the substring `outside plugin root`, because the lexical pre-gate emits a *different* message — a test matching only the shared substring would pass on the lexical gate and prove nothing about the oracle.

**BEHAVIOUR.** Direct measurement of the two resolvers against the bytes actually opened, on Linux (node v24.18.1) and macOS:

```
realpathSync        -> <root>/escape.mjs       reported INSIDE the root  => accepted
realpathSync.native -> <outside>/escape.mjs    outside the root          => rejected
readFileSync bytes  -> OUTSIDE
```

The fixture asserts against opened bytes rather than a resolver's own answer, since asserting one resolver against another cannot detect a resolver defect.

**Fixture note worth keeping:** the first attempt at row 1 placed its decoy at `decoy.mjs` instead of where the lexical collapse lands, so both rows degraded to the ENOENT signature and row 1 never exercised the acceptance path. A fixture that does not contradict the resolver's own answer cannot discriminate.

## Not included, and why

No trust-store migration. Keys in `~/.omo/agent/trust.json` are written through `canonicalizePath`, so a stale key was the obvious follow-on concern — but `normalizeCwd` feeds from `process.cwd()`, which is already kernel-resolved and cannot carry this, and the real store was measured under **both** resolvers: **3 keys, 0 differ.** A migration would be machinery for a population of zero. (One key no longer resolves at all — a deleted directory, pre-existing, handled by the swallow by design.)
---

## Second commit: workspace trust keys resolve strictly

`canonicalizePath` hands its input back when resolution fails — correct for the ~14 identity-comparison callers, where an unresolvable path simply compares unequal. A **trust key** cannot use that, because the raw input is indistinguishable from a canonical answer: a path the filesystem never confirmed could be keyed by its own spelling and inherit a decision recorded for a different directory that merely writes the same way.

- **`utils/paths.ts`** — adds `canonicalizePathStrict`, which resolves identically but does not swallow.
- **`core/trust-manager.ts`** — `normalizeCwd` uses the strict form, falling back to the resolved-but-unconfirmed path only when the filesystem will not confirm it. **Only this one security caller migrated**; every cosmetic caller keeps the convenience form. The two contracts do not share one function.

### Stale-key retirement is structural, not a migration

`TrustFile` is a flat `path → boolean` map whose validator rejects non-boolean values, so a version marker cannot live in it. It does not need one: lookup goes through `normalizeCwd`, so a key computed by the previous path-collapsing resolver **stops matching** once the resolver is corrected. The effect is *ask again*, which is the fail-safe direction, and it needs no data rewrite.

### Evidence

**REGRESSION COVERAGE.** True RED captured by reverting **only** `canonicalizePath`'s oracle and leaving everything else as shipped: **1 failed / 2 passed (3)** — the legacy-key case fails, so it discriminates exactly the defect it names. GREEN across all three suites: **RC=0, 34 passed / 1 skipped (35)**.

The legacy-key test carries a **control**: after asserting the stale key is not honoured, it writes a key at the *real* location and asserts the same store **does** return `true`. Without that, the assertion could pass on a lookup that never matches anything.

**Fixture verified to discriminate** — on Linux the two resolvers genuinely split for this shape:

```
requested : /inside/entry/workspace
js oracle : /inside/workspace      <- what a stale key would have been written under
native    : /outside/workspace     <- where the kernel says it is
DIFFER    : true
```

**Two self-caught test defects worth recording**, both fixed before this landed:

1. `expect(() => canonicalizePathStrict(missing)).toThrow()` **passes when the function is undefined**, because calling `undefined` throws a `TypeError` — so it would have gone green against production with no strict form at all. Now asserts `typeof === "function"` plus the error **code** (`ENOENT`), which a missing export cannot satisfy. Generally: `toThrow()` with no discriminator is satisfied by the absence of the thing under test.
2. The first trust RED ran against a clone that **already contained** the fix, so it passed and looked like the defect not existing. Re-captured by reverting the single line.