### PR TITLE
test(credential-rotation): close the runtime stream before temp-dir teardown

### DIFF
--- a/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
+import type { AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { fauxAssistantMessage, fauxProvider } from "@earendil-works/pi-ai";
 import { rendezvousOrder } from "@earendil-works/pi-ai/auth/pool/select";
 import type { PooledCredential } from "@earendil-works/pi-ai/auth/pool/slots";
@@ -88,6 +88,26 @@ async function collect(source: AsyncGenerator<AssistantMessageEvent>): Promise<A
 	return seen;
 }
 
+/**
+ * Consumes a runtime event stream to its terminal event and then CLOSES it.
+ *
+ * The stream reports completion at the terminal event, but the credential
+ * rotation generator behind `ModelRuntime.stream` still has to run its final
+ * pool-state persistence write after yielding that event. Removing the
+ * runtime's temp dir while that write is in flight fails with ENOTEMPTY
+ * (issue #1457), so teardown must not race it: breaking out of the loop
+ * invokes the lazy stream's cancellation handler, which awaits the inner
+ * generator's completion before returning.
+ */
+async function collectClosedRuntimeEvents(stream: AssistantMessageEventStream): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+		if (event.type === "done" || event.type === "error") break;
+	}
+	return events;
+}
+
 describe("credential rotation over a pooled provider", () => {
 	test("runtime admission runs an expired stored probe once", async () => {
 		const faux = fauxProvider();
@@ -99,7 +119,7 @@ describe("credential rotation over a pooled provider", () => {
 			agentDir: dir,
 			allowModelNetwork: false,
 		});
-		runtime.registerNativeProvider(faux.provider);
+		await runtime.registerNativeProvider(faux.provider);
 		await runtime.refresh({ allowNetwork: false, providers: ["faux"] });
 		const pool = (await (runtime as any).loadCredentialPool()).repository as CredentialSlotRepository;
 		await pool.mutateSlotState("faux", "stored", "default", () => ({
@@ -111,13 +131,9 @@ describe("credential rotation over a pooled provider", () => {
 			blockReason: "rate_limit",
 		}));
 		faux.setResponses([fauxAssistantMessage("probe")]);
-		const events: AssistantMessageEvent[] = [];
-		for await (const event of runtime.stream(
-			faux.getModel(),
-			{ messages: [], tools: [] },
-			{ sessionId: "runtime-probe" },
-		))
-			events.push(event);
+		const events = await collectClosedRuntimeEvents(
+			runtime.stream(faux.getModel(), { messages: [], tools: [] }, { sessionId: "runtime-probe" }),
+		);
 		expect(events.some((event) => event.type === "done")).toBe(true);
 		expect(faux.getCallLog()).toHaveLength(1);
 	});
@@ -139,11 +155,12 @@ describe("credential rotation over a pooled provider", () => {
 			agentDir: dir,
 			allowModelNetwork: false,
 		});
-		runtime.registerNativeProvider(faux.provider);
+		await runtime.registerNativeProvider(faux.provider);
 		await runtime.refresh({ allowNetwork: false, providers: ["policy-only"] });
 		faux.setResponses([fauxAssistantMessage("policy-ok")]);
-		const events: AssistantMessageEvent[] = [];
-		for await (const event of runtime.stream(faux.getModel(), { messages: [], tools: [] })) events.push(event);
+		const events = await collectClosedRuntimeEvents(
+			runtime.stream(faux.getModel(), { messages: [], tools: [] }),
+		);
 		expect(events.some((event) => event.type === "done")).toBe(true);
 		expect(faux.getCallLog()).toHaveLength(1);
 		rmSync(dir, { recursive: true, force: true });
@@ -162,7 +179,7 @@ describe("credential rotation over a pooled provider", () => {
 			agentDir: configDir,
 			allowModelNetwork: false,
 		});
-		runtime.registerNativeProvider(faux.provider);
+		await runtime.registerNativeProvider(faux.provider);
 		await runtime.refresh({ allowNetwork: false, providers: ["anthropic"] });
 		faux.setResponses([
 			() => {
@@ -170,15 +187,15 @@ describe("credential rotation over a pooled provider", () => {
 			},
 			fauxAssistantMessage("combined-ok"),
 		]);
-		const events: AssistantMessageEvent[] = [];
-		for await (const event of runtime.stream(
-			faux.getModel(),
-			{ messages: [], tools: [] },
-			{
-				env: { ANTHROPIC_API_KEY: "key-env" },
-			},
-		))
-			events.push(event);
+		const events = await collectClosedRuntimeEvents(
+			runtime.stream(
+				faux.getModel(),
+				{ messages: [], tools: [] },
+				{
+					env: { ANTHROPIC_API_KEY: "key-env" },
+				},
+			),
+		);
 		expect(events.some((event) => event.type === "done")).toBe(true);
 		expect(faux.getCallLog()).toHaveLength(2);
 		expect(


### PR DESCRIPTION
Fixes #1457 (the ENOTEMPTY race; the interactive-host-runtime footer observation appended to the issue is unrelated and not addressed here).

## Mechanism

`ModelRuntime.stream` wraps the credential-rotation generator in a `lazyStream`. `AssistantMessageEventStream` reports completion **at the terminal event** (`push` sets `done`), so the test's `for await` loop exits while the rotation generator is still suspended after its final yield, with `onSuccess`'s pool-state persistence write (`credential-pool-state.json`, inside the test's temp dir, plus a proper-lockfile `.lock` create/release in the same directory) still pending. The test then runs `rmSync(dir, { recursive: true })` (in-test for `policy-only-runtime-*`/`combined-runtime-*`, or `afterEach` for `rotation-stream-*`) into the middle of that write cycle -> intermittent `ENOTEMPTY`. A loaded machine widens the scheduling window, which is why it appeared on 4-vCPU gating boxes and never in CI.

A second, smaller straggler: the tests called `registerNativeProvider` without awaiting it, leaving its refresh chain running into teardown. The sibling `model-runtime-registration-refresh.test.ts` already awaits it.

## Fix (test-only; no production behavior change)

- `collectClosedRuntimeEvents`: consume the runtime stream to its terminal event, then break — the lazy stream's cancellation handler awaits the inner generator's completion, so the pool-state write lands **before** teardown. This is the "close the stream before teardown" step; it also covers the error path (for-await teardown runs the same handler).
- `await runtime.registerNativeProvider(...)` in the three ModelRuntime tests.
- No force-removal, no retries, no sleeps. Temp dirs remain per-test (`mkdtemp` in `beforeEach` / in-test).

## Reproduction (failing-first, pre-fix `main`)

8-core linux x86_64 box, node v24.20.0 (CI-matched), bun 1.4.0 first in PATH, 6 parallel vitest processes over 6 copies of this test file x 40 rounds, 8 CPU spinners (load ~17). Positive control first: a clean run must print `Tests 17 passed`.

    FAIL test/repro-race-2.test.ts > credential rotation over a pooled provider > runtime admission runs an expired stored probe once
    Error: ENOTEMPTY, Directory not empty: /tmp/rotation-stream-bTkIlj '/tmp/rotation-stream-bTkIlj'
      at rmSync(dir, { recursive: true, force: true })   (afterEach site)

    FAIL test/repro-race-5.test.ts > credential rotation over a pooled provider > runtime admits policy-only credential slots
    Error: ENOTEMPTY, Directory not empty: /tmp/policy-only-runtime-zNMcxz '/tmp/policy-only-runtime-zNMcxz'
      at rmSync(dir, { recursive: true, force: true })   (in-test site, same shape as /tmp/combined-runtime-*)

4 independent hits within the first ~8 rounds per proc. Post-fix, the identical loop (same parameters, same box) runs clean; loop counts are posted below before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the intermittent ENOTEMPTY teardown race in the credential-rotation ModelRuntime tests by consuming the runtime stream to its terminal event before temp-dir cleanup, and awaiting provider registration.

- The stream's terminal event fires before the inner generator's final pool-state write completes; closing the stream after that event ensures the write lands before `rmSync` runs.
- Awaiting `registerNativeProvider` prevents its refresh chain from racing teardown.
- Test-only change; no production behavior affected.
- Reproduced under CPU oversubscription on 4-vCPU boxes, never in CI.

<sup>Written for commit 7b50db54d2192c40b8d5e440c4f13125467f788f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

