### PR TITLE
feat(coding-agent): add the memory Aha-moment tip

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- A memory tip now explains the `Aha moment!` line: memory can surface a stored fact on its own when it would change the next step, and silence means nothing relevant was found (`memory.aha-moment`, shown when the `memory` command is available) ([#1465](https://github.com/code-yeongyu/senpi/pull/1465)).
+
 ### Changed
 
 - The GPT-6 Astra series now declares a 600,000-token context window on every provider that serves it. The effective prompt budget no longer depends on the route: the first-party OpenAI catalogs and the opencode, openrouter, github-copilot, and vercel-ai-gateway passthrough catalogs all agree. Set a different budget through model overrides if you want one.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-07 - Add the memory Aha-moment tip
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts` gains `memory.aha-moment`, gated on the `memory` command like its siblings: memory can surface a stored fact on its own as an `Aha moment!` line when it would change the next step, and silence means nothing relevant was found.
+
+### Why
+
+- The memorian recall notice (omo-senpi `memorian-notice.ts`, oh-my-openagent #7906) had no tip in the rotation, so the one memory feature that acts without a command was the only one never explained.
+
+### Why an extension could not handle it
+
+- The tip catalog is a core interactive-mode registry with no extension registration surface.
+
+### Expected merge conflict zones
+
+- LOW: the tail of `MEMORY_TIPS` in `memory-tips.ts` and `test/suite/list-tips.test.ts`.
+
 ## 2026-09-06 - Preserve inline skill anchors in composed prompts
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts
@@ -97,6 +97,13 @@ export const MEMORY_TIPS = [
 		render: () => "Edited memory files by hand? Run /recompile so this session picks the changes up right away.",
 	},
 	{
+		id: "memory.aha-moment",
+		bindings: [],
+		requiresCommand: "memory",
+		render: () =>
+			"Memory speaks up on its own: when something remembered would change the next step, an Aha moment! line surfaces it mid-task. Silence means nothing relevant was found.",
+	},
+	{
 		id: "memory.stop-repeating",
 		bindings: [],
 		requiresCommand: "memory",

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -13,6 +13,16 @@ describe("collectTips", () => {
 		}
 	});
 
+	it("includes the memory aha-moment tip", () => {
+		const tips = collectTips();
+
+		expect(tips.find((tip) => tip.id === "memory.aha-moment")).toEqual({
+			id: "memory.aha-moment",
+			text: "Memory speaks up on its own: when something remembered would change the next step, an Aha moment! line surfaces it mid-task. Silence means nothing relevant was found.",
+			requiresCommand: "memory",
+		});
+	});
+
 	it("includes the fallback-chains-setting tip", () => {
 		const tips = collectTips();
 


### PR DESCRIPTION
## Problem

The memorian recall notice (oh-my-openagent #7906) is the one memory feature that acts without a command, and it was the only one missing from the tip rotation: users saw an `Aha moment!` line with nothing explaining it.

## Fix

- `packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts`: new `memory.aha-moment` tip, gated on the `memory` command like its siblings
- `packages/coding-agent/test/suite/list-tips.test.ts`: pins the tip id, text, and gate (RED before the catalog change, GREEN after)
- `packages/coding-agent/src/changes.md`: tracker entry

Companion docs in oh-my-openagent: code-yeongyu/oh-my-openagent#7918.

## Verification

- `npx vitest --run test/suite/list-tips.test.ts`: 7 passed
- `bun src/cli.ts --list-tips` lists `memory.aha-moment` with the exact text and `requiresCommand: "memory"`
- root `bun run check`: exit 0

Written by Claude (OmO ultrawork session).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `memory.aha-moment` tip to the tip rotation so the memorian recall notice no longer appears unexplained. Previously the `Aha moment!` line surfaced mid-task with no tip covering it; now the tip is gated on the `memory` command like its siblings.

- The test suite pins the tip id, text, and gate.
- Adds `changes.md` tracker and `CHANGELOG.md` entries.

<sup>Written for commit 27956cafef7d763f268a6d3b9a4924885fbbc07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

