### PR TITLE
fix(ai): classify OpenAI context-window overflow and token rate limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed context-overflow classification so OpenAI's "exceeds the model's context window" wording is detected and token-quota / rate-limit messages that mention tokens are not treated as overflow (code-yeongyu/oh-my-openagent#7921).
+
 ### Removed
 
 ## [2026.9.7] - 2026-09-07

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,4 +1,22 @@
 
+## 2026-09-07 - Classify OpenAI context-window overflow and token rate limits (code-yeongyu/oh-my-openagent#7921)
+
+### What changed
+
+- `packages/ai/src/utils/overflow.ts`: widen the OpenAI overflow pattern so "exceeds the model's context window" and "exceeds this model's context window" match, and add NON_OVERFLOW exclusions for tokens-per-window quota wording, TPM/RPM, quota exceeded, retry-after, HTTP 429 prefixes, and overloaded providers so those stay on the rate-limit path (code-yeongyu/oh-my-openagent#7921).
+
+### Why
+
+- OpenAI's current overflow text does not contain "exceeds the context window" as a contiguous phrase, so compaction recovery missed real overflows. Generic overflow fallbacks also matched token-quota 429s ("too many tokens per minute", "exceeds the limit of N tokens per minute"), so the agent showed a context-overflow error instead of the provider rate-limit error.
+
+### Why an extension could not handle it
+
+- `isContextOverflow` is the shared pi-ai classifier that compaction and overflow recovery consult before any extension hook runs; only a core pattern change can correct both the miss and the false positive.
+
+### Expected merge conflict zones
+
+- LOW: `packages/ai/src/utils/overflow.ts` OVERFLOW_PATTERNS OpenAI entry and NON_OVERFLOW_PATTERNS.
+
 ## 2026-09-05 - Project Astra configuration updates at the Responses wire
 
 ### What changed

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -11,6 +11,7 @@ import type { AssistantMessage } from "../types.ts";
  * - Anthropic: "prompt is too long: 213462 tokens > 200000 maximum"
  * - Anthropic: "413 {\"error\":{\"type\":\"request_too_large\",\"message\":\"Request exceeds the maximum size\"}}"
  * - OpenAI: "Your input exceeds the context window of this model"
+ * - OpenAI: "Your input exceeds the model's context window" / "exceeds this model's context window"
  * - OpenAI/LiteLLM: "Requested token count exceeds the model's maximum context length of 131072 tokens"
  * - OpenAI-compatible: "Input length (265330) exceeds model's maximum context length (262144)."
  * - Google: "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)"
@@ -43,7 +44,7 @@ const OVERFLOW_PATTERNS = [
 	/prompt is too long/i, // Anthropic token overflow
 	/request_too_large/i, // Anthropic request byte-size overflow (HTTP 413)
 	/input is too long for requested model/i, // Amazon Bedrock
-	/exceeds the context window/i, // OpenAI (Completions & Responses API)
+	/exceeds (?:(?:the|this) )?(?:model'?s )?context window/i, // OpenAI (Completions & Responses API)
 	/exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i, // OpenAI-compatible proxies (LiteLLM)
 	/input token count.*exceeds the maximum/i, // Google (Gemini)
 	/maximum prompt length is \d+/i, // xAI (Grok)
@@ -77,12 +78,22 @@ const OVERFLOW_PATTERNS = [
  *
  * Example: Bedrock formats throttling errors as "ThrottlingException: Too many tokens,
  * please wait before trying again." which would match the /too many tokens/i overflow
- * pattern without this exclusion.
+ * pattern without this exclusion. Token-quota / TPM messages such as "Too many tokens
+ * per minute" or "This request exceeds the limit of 30000 tokens per minute" similarly
+ * match generic overflow fallbacks and must stay on the rate-limit path.
  */
 const NON_OVERFLOW_PATTERNS = [
 	/^(Throttling error|Service unavailable):/i, // AWS Bedrock non-overflow errors (human-readable prefixes from formatBedrockError)
 	/rate limit/i, // Generic rate limiting
 	/too many requests/i, // Generic HTTP 429 style
+	/tokens per (?:min|minute|hour|day)/i, // Token-quota windows (TPM/TPH/TPD), not context size
+	/\bTPM\b/i, // Tokens-per-minute abbreviation
+	/\bRPM\b/i, // Requests-per-minute abbreviation
+	/quota exceeded/i, // Provider quota, not context window
+	/retry (?:after|in) \d/i, // Retry-after rate-limit wording
+	/^429\b/, // HTTP 429 prefix
+	/status code 429/i, // HTTP 429 mentioned mid-message
+	/overloaded/i, // Provider capacity, not context size
 ];
 
 /**
@@ -111,7 +122,7 @@ const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
  *
  * **Reliable detection (returns error with detectable message):**
  * - Anthropic: "prompt is too long: X tokens > Y maximum" or "request_too_large"
- * - OpenAI (Completions & Responses): "exceeds the context window", "exceeds the model's maximum context length of X tokens", or "exceeds model's maximum context length (X)"
+ * - OpenAI (Completions & Responses): "exceeds the context window", "exceeds the model's context window", "exceeds this model's context window", "exceeds the model's maximum context length of X tokens", or "exceeds model's maximum context length (X)"
  * - Google Gemini: "input token count exceeds the maximum"
  * - xAI (Grok): "maximum prompt length is X but request contains Y"
  * - Groq: "reduce the length of the messages"

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -63,6 +63,21 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(message, 262144)).toBe(true);
 	});
 
+	it("detects OpenAI exceeds the model's context window wording", () => {
+		const message = createErrorMessage("Your input exceeds the model's context window");
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("detects OpenAI exceeds this model's context window wording", () => {
+		const message = createErrorMessage("Your input exceeds this model's context window");
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("detects OpenAI exceeds the context window wording", () => {
+		const message = createErrorMessage("Your input exceeds the context window of this model");
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
 	it("detects OpenRouter Poolside maximum allowed input length errors", () => {
 		const message = createErrorMessage(
 			"Provider returned error: Input length 131393 exceeds the maximum allowed input length of 131040 tokens.",
@@ -206,6 +221,51 @@ describe("isContextOverflow", () => {
 
 	it("does not treat HTTP 429 style errors as overflow", () => {
 		const message = createErrorMessage("Too many requests. Please slow down.");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat tokens-per-minute rate limits as overflow", () => {
+		const message = createErrorMessage("Too many tokens per minute for this model. Retry in 20s");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat exceeds-the-limit tokens-per-minute messages as overflow", () => {
+		const message = createErrorMessage("This request exceeds the limit of 30000 tokens per minute");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat TPM quota wording as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("TPM limit exceeded: too many tokens");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat RPM quota wording as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("RPM limit exceeded: too many tokens");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat quota exceeded as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("Quota exceeded: too many tokens in the last minute");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat retry-after token quota wording as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("Too many tokens. Retry after 10 seconds");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat HTTP 429 prefixes as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("429 Too many tokens");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat status code 429 as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("Request failed with status code 429: too many tokens");
+		expect(isContextOverflow(message, 200000)).toBe(false);
+	});
+
+	it("does not treat overloaded errors as overflow even with overflow-looking phrasing", () => {
+		const message = createErrorMessage("The model is overloaded. Too many tokens.");
 		expect(isContextOverflow(message, 200000)).toBe(false);
 	});
 


### PR DESCRIPTION
OpenAI now reports context overflow as "Your input exceeds the model's context window" (and "exceeds this model's context window"). The classifier only looked for "exceeds the context window", so compaction recovery missed those errors. Separately, token-quota 429s such as "Too many tokens per minute" and "This request exceeds the limit of 30000 tokens per minute" matched generic overflow fallbacks, so the agent showed a context-overflow error instead of the provider rate-limit error.

This change widens the OpenAI overflow pattern to accept the model's / this model's wording, and adds NON_OVERFLOW exclusions for tokens-per-window quota wording, TPM/RPM, quota exceeded, retry-after, HTTP 429 prefixes, and overloaded providers.

Verification:
- RED (before the production change): detects OpenAI exceeds the model's context window wording; detects OpenAI exceeds this model's context window wording; does not treat tokens-per-minute rate limits as overflow; does not treat exceeds-the-limit tokens-per-minute messages as overflow. First assertion: expected false to be true (Object.is equality) for the OpenAI model-context-window wording.
- GREEN: npx vitest run test/overflow.test.ts — Tests 41 passed (41).

Refs code-yeongyu/oh-my-openagent#7921

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI context-overflow detection so compaction recovery catches the new "exceeds the model's context window" wording and token-quota rate limits no longer surface as context overflows.

- Widens the OpenAI overflow pattern to match "exceeds the model's context window" and "exceeds this model's context window".
- Adds NON_OVERFLOW exclusions for tokens-per-window quota, TPM/RPM, quota exceeded, retry-after, HTTP 429 prefixes, and overloaded providers.
- `isContextOverflow` runs before extension hooks, so only a core pattern change can fix both the miss and the false positive.

<sup>Written for commit e4bc059950872666d60fc88f48180b28b22c9723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

