### PR TITLE
test(coding-agent): wait for the mirrored service tier before asserting fast mode

### DIFF
--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -525,7 +525,23 @@ describe("interactive host runtime", () => {
 			expect(runtime.session.isFastModeActive()).toBe(false);
 			expect(runtime.session.serviceTier).toBeUndefined();
 
+			// The host acknowledges setFastMode before the service_tier_changed wire
+			// event reaches the attached session, so subscribe first and wait for the
+			// mirrored state instead of asserting on the RPC reply alone.
+			const tierChanged = new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(() => {
+					unsubscribe();
+					reject(new Error("timed out waiting for service_tier_changed with fastMode=true"));
+				}, 10_000);
+				const unsubscribe = runtime.session.subscribe((event) => {
+					if (event.type !== "service_tier_changed" || !event.fastMode) return;
+					clearTimeout(timer);
+					unsubscribe();
+					resolve();
+				});
+			});
 			await observer.setFastMode(true);
+			await tierChanged;
 
 			expect(runtime.session.isFastModeActive()).toBe(true);
 			expect(runtime.session.serviceTier).toBe("priority");


### PR DESCRIPTION
## Problem

`test/interactive-host-runtime.test.ts` "reflects host service-tier changes in the attached session and footer state" asserted `isFastModeActive()` right after `await observer.setFastMode(true)`. The host acknowledges the RPC before the `service_tier_changed` wire event reaches the attached session, so the assertion raced the event. Observed: 2/5 local failures on unchanged main (d196698a8) and two consecutive CI failures on #1466 (Test coding-agent 1/3), each `expected false to be true`.

## Fix

Subscribe to `runtime.session` for `service_tier_changed` with `fastMode: true` before issuing `setFastMode`, await it with a bounded 10s timeout, then assert - the same pattern the neighbouring settings-sync test already uses.

## Verification

- 5/5 consecutive passes of the single test on the fixed file (2/5 failed before the change on the same machine).
- `npx biome check` clean; root `tsc --noEmit` clean.

Test-only change: no changelog entry (label `no-changelog`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in `packages/coding-agent/test/interactive-host-runtime.test.ts` where asserting fast mode right after `setFastMode` raced the mirrored `service_tier_changed` event. The test now subscribes to the session for the mirrored event before calling `setFastMode` and waits for it with a 10s timeout before asserting.

<sup>Written for commit 0308f8e19830c3125ccf2785fa0b7db589f26bd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

