### PR TITLE
fix(core): carry the session's effective service tier on the request without an extension

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `streamSimple` on the OpenAI Responses and Codex Responses adapters forwards the new `SimpleStreamOptions.serviceTier` into the request (`service_tier`) and tier-aware usage pricing; the simple path previously dropped it (code-yeongyu/oh-my-openagent#6795).
+
 ### Removed
 
 ## [2026.9.7-2] - 2026-09-07

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -531,6 +531,7 @@ export const streamSimple: StreamFunction<"openai-codex-responses", SimpleStream
 	const base = {
 		...buildBaseOptions(model, context, options, apiKey),
 		toolChoice: options?.toolChoice,
+		serviceTier: options?.serviceTier,
 	} satisfies OpenAICodexResponsesOptions;
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	const reasoningEffort =

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -340,6 +340,7 @@ export const streamSimple: StreamFunction<"openai-responses", SimpleStreamOption
 	const base = {
 		...buildBaseOptions(model, context, options, options?.apiKey),
 		toolChoice: options?.toolChoice,
+		serviceTier: options?.serviceTier,
 	} satisfies OpenAIResponsesOptions;
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	const reasoningEffort =

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,4 +1,23 @@
 
+## 2026-09-08 - Simple stream options carry the requested service tier (code-yeongyu/oh-my-openagent#6795)
+
+### What changed
+
+- `packages/ai/src/types.ts`: `SimpleStreamOptions.serviceTier` (`ServiceTierPreference`: `"auto" | "flex" | "priority"`) names the processing tier a caller requests.
+- `packages/ai/src/api/openai-responses.ts`, `packages/ai/src/api/openai-codex-responses.ts`: `streamSimple` forwards that option into the provider options, so it reaches `service_tier` on the wire and the tier-aware usage pricing, exactly like a full `stream()` call. Azure is unchanged (it does not sell Priority processing).
+
+### Why
+
+- The simple path dropped `serviceTier` in `buildBaseOptions`, so the only way to send the field was to mutate the request payload from an extension hook. A session that loads no extensions (SDK embedders, oh-my-openagent's in-process delegated children) could therefore never run at the priority tier even when its model was a `-fast` catalog variant.
+
+### Why this lives in the fork
+
+- `streamSimple` is the provider-neutral entry every host goes through; the field has to be threaded there.
+
+### Expected merge conflict zones
+
+- LOW: `SimpleStreamOptions` in `types.ts`; the `streamSimple` option literals in both Responses adapters.
+
 ## 2026-09-07 - Classify OpenAI context-window overflow and token rate limits (code-yeongyu/oh-my-openagent#7921)
 
 ### What changed

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -390,7 +390,15 @@ export interface SimpleStreamOptions extends StreamOptions {
 	deferred?: boolean | { window?: "15m" | "1h" | "24h" };
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
+	/**
+	 * Requested processing tier for providers that price and schedule by tier (OpenAI Responses and
+	 * the ChatGPT Codex backend send it as `service_tier`). Adapters without the concept ignore it.
+	 */
+	serviceTier?: ServiceTierPreference;
 }
+
+/** Tier preferences a caller can express; providers map `"auto"` to their default lane. */
+export type ServiceTierPreference = "auto" | "flex" | "priority";
 
 // Generic StreamFunction with typed options.
 //

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Sessions created without builtin extensions (SDK embedders, oh-my-openagent's in-process delegated children) now send the priority service tier of a `-fast` catalog model, a scoped `:priority` pin, or session fast mode on the wire; previously only the interactive service-tier extension's payload hook wrote `service_tier`, so a delegated task displayed a fast model but ran at the standard tier (code-yeongyu/oh-my-openagent#6795). Extensions can read the session's `effectiveServiceTier` from their context.
+
 ### Removed
 
 ## [2026.9.7-2] - 2026-09-07

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7119,6 +7119,7 @@ export class AgentSession {
 			{
 				getModel: () => this.model,
 				getServiceTier: () => this.serviceTier,
+				getEffectiveServiceTier: () => this.effectiveServiceTier,
 				getScopedModels: () => this._scopedModels,
 				isIdle: () => this.isIdle,
 				getAgentDir: () => this._agentDir,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,22 @@
+## The session request carries its effective service tier without an extension (2026-09-08, code-yeongyu/oh-my-openagent#6795)
+
+### What changed
+
+- `packages/coding-agent/src/core/sdk.ts`: the Agent `streamFn` sets `serviceTier` on the stream options when the caller did not: the session's `effectiveServiceTier` for the active model (catalog `-fast` variant, scoped `:priority` pin, or session fast mode), else the request model's own catalog tier for side requests (title/branch summaries). Only APIs that accept `service_tier` (`supportsServiceTier`) receive it. The late-bound session ref used by the Cursor exec bridge is now the shared `sessionRef`.
+- `packages/coding-agent/src/core/agent-session.ts`: hands `getEffectiveServiceTier` to the extension runner.
+
+### Why
+
+- A `-fast` catalog variant (`openai-codex/gpt-5.6-luna-fast`) declares `serviceTier: "priority"`, and `ModelRuntime.prepareRequest` already honors its sibling field `upstreamModelId`, yet the tier itself reached the wire only through the builtin service-tier extension's payload hook. Sessions created without builtin extensions - SDK embedders, oh-my-openagent's in-process delegated children - silently ran at the standard tier while displaying a fast model. The extension keeps its per-model memory role; its hook only fills a missing field, so both paths agree.
+
+### Why an extension could not handle it
+
+- The affected sessions load no extensions by construction; the request-side default has to live in the session's own stream function.
+
+### Expected merge conflict zones
+
+- LOW: the `streamFn` option literal and the session ref in `sdk.ts`; the runner context-actions literal in `agent-session.ts`.
+
 ## Insufficient accepted compaction keeps its blocked state, #7921 case 6 (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,6 +1,8 @@
-## The session request carries its effective service tier without an extension (2026-09-08, code-yeongyu/oh-my-openagent#6795)
+## The session request carries its effective service tier without an extension (2026-09-08)
 
 ### What changed
+
+- Tracks code-yeongyu/oh-my-openagent#6795.
 
 - `packages/coding-agent/src/core/sdk.ts`: the Agent `streamFn` sets `serviceTier` on the stream options when the caller did not: the session's `effectiveServiceTier` for the active model (catalog `-fast` variant, scoped `:priority` pin, or session fast mode), else the request model's own catalog tier for side requests (title/branch summaries). Only APIs that accept `service_tier` (`supportsServiceTier`) receive it. The late-bound session ref used by the Cursor exec bridge is now the shared `sessionRef`.
 - `packages/coding-agent/src/core/agent-session.ts`: hands `getEffectiveServiceTier` to the extension runner.

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -22,8 +22,13 @@ function isRecord(value: unknown): value is ProviderPayload {
 	return typeof value === "object" && value !== null;
 }
 
+/** Whether requests for this API accept the OpenAI `service_tier` field. */
+export function supportsServiceTier(api: Api | undefined): boolean {
+	return api !== undefined && SERVICE_TIER_APIS.has(api);
+}
+
 export function addServiceTierToPayload(api: Api | undefined, payload: unknown, serviceTier?: ServiceTier): unknown {
-	if (!api || !SERVICE_TIER_APIS.has(api) || !serviceTier) {
+	if (!supportsServiceTier(api) || !serviceTier) {
 		return payload;
 	}
 
@@ -284,6 +289,21 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		// "auto" is honored on the wire by `liveMemoryTier` below, not by clearing the flag here.
 		if (sessionFastMode && event.model.api !== OPENAI_CODEX_RESPONSES_API) {
 			sessionFastMode = false;
+			pi.setSessionFastMode(false);
+			return;
+		}
+
+		// The session's own request path now carries `effectiveServiceTier` (sdk streamFn), which the
+		// switch just re-resolved from the incoming model's catalog. A remembered "auto" for a Codex
+		// model whose catalog says priority therefore has to reach SESSION state, not only this
+		// extension's payload hook: `setSessionFastMode(false)` clears exactly a catalog-inherited
+		// Codex priority (never a scoped/favorite `:priority` pin), so both writers agree.
+		if (
+			!sessionFastMode &&
+			liveMemoryTier === "auto" &&
+			event.model.api === OPENAI_CODEX_RESPONSES_API &&
+			ctx.modelRegistry.getServiceTier(event.model) === PRIORITY_TIER
+		) {
 			pi.setSessionFastMode(false);
 		}
 	});

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,25 @@
 # Core Extensions Changes
 
+## 2026-09-08 - Expose the effective service tier and let core carry it (code-yeongyu/oh-my-openagent#6795)
+
+### What changed
+
+- `types.ts`: `ExtensionContext.effectiveServiceTier` (optional) reports the tier the session's requests carry right now - `serviceTier` promoted to `"priority"` while session fast mode is on. `ExtensionContextActions.getEffectiveServiceTier` (optional) feeds it; `runner.ts` falls back to `getServiceTier` when a host omits it.
+- `builtin/service-tier.ts`: exports `supportsServiceTier(api)`. On `model_select`, a remembered `"auto"` for a Codex model whose catalog says priority now also clears the SESSION's cached tier (`setSessionFastMode(false)`, which only touches a catalog-inherited Codex priority), instead of suppressing the tier in the payload hook alone.
+
+### Why
+
+- The session itself now puts `effectiveServiceTier` on the request (`core/sdk.ts`), so the extension's memory decision has to reach session state or the two writers would disagree after a mid-session switch. Hosts that delegate work (oh-my-openagent tasks) need the effective tier, not the catalog tier, to inherit a parent's `/fast`.
+
+### Why an extension could not handle it
+
+- Both are context surface: what the runner exposes to extensions, and how the builtin keeps the session's request-side tier honest.
+
+### Expected merge conflict zones
+
+- LOW: `ExtensionContext`/`ExtensionContextActions` in `types.ts`, the context getters in `runner.ts`, the `model_select` handler in `builtin/service-tier.ts`.
+
+
 ## 2026-09-04 - UI prompt lifecycle events
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -378,6 +378,7 @@ export class ExtensionRunner {
 	private errorListeners: Set<ExtensionErrorListener> = new Set();
 	private getModel: () => Model<any> | undefined = () => undefined;
 	private getServiceTier: () => ServiceTier | undefined = () => undefined;
+	private getEffectiveServiceTier: () => ServiceTier | undefined = () => this.getServiceTier();
 	private getScopedModels: () => readonly ScopedModel[] = () => [];
 	private isIdleFn: () => boolean = () => true;
 	private isProjectTrustedFn: () => boolean = () => true;
@@ -494,6 +495,7 @@ export class ExtensionRunner {
 		// Context actions (required)
 		this.getModel = contextActions.getModel;
 		this.getServiceTier = contextActions.getServiceTier;
+		this.getEffectiveServiceTier = contextActions.getEffectiveServiceTier ?? contextActions.getServiceTier;
 		this.getScopedModels = contextActions.getScopedModels;
 		this.isIdleFn = contextActions.isIdle;
 		this.isProjectTrustedFn = contextActions.isProjectTrusted;
@@ -1055,6 +1057,7 @@ export class ExtensionRunner {
 		const runner = this;
 		const getModel = this.getModel;
 		const getServiceTier = this.getServiceTier;
+		const getEffectiveServiceTier = this.getEffectiveServiceTier;
 		const getScopedModels = this.getScopedModels;
 		let compactionSignal: AbortSignal | undefined;
 		return {
@@ -1093,6 +1096,10 @@ export class ExtensionRunner {
 			get serviceTier() {
 				runner.assertActive();
 				return getServiceTier();
+			},
+			get effectiveServiceTier() {
+				runner.assertActive();
+				return getEffectiveServiceTier();
 			},
 			get scopedModels() {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -424,6 +424,13 @@ export interface ExtensionContext {
 	model: Model<any> | undefined;
 	/** Current service tier for the active model (from -fast suffix or scoped model config) */
 	serviceTier: ServiceTier | undefined;
+	/**
+	 * The tier the session's requests carry right now: `serviceTier`, promoted to `"priority"`
+	 * while session fast mode is on. Hosts that spawn delegated sessions read this to inherit the
+	 * parent's effective execution tier. Optional so hand-built contexts stay valid; readers fall
+	 * back to `serviceTier`.
+	 */
+	effectiveServiceTier?: ServiceTier | undefined;
 	/** Models scoped to this session. Empty when all available models are usable. */
 	scopedModels: readonly ScopedModel[];
 	/** Current thinking level, when provided by the session runtime. */
@@ -2276,6 +2283,8 @@ export interface ExtensionActions {
 export interface ExtensionContextActions {
 	getModel: () => Model<any> | undefined;
 	getServiceTier: () => ServiceTier | undefined;
+	/** Effective request tier (fast mode included). Defaults to `getServiceTier` when omitted. */
+	getEffectiveServiceTier?: () => ServiceTier | undefined;
 	getScopedModels: () => readonly ScopedModel[];
 	getAgentDir?: () => string;
 	isIdle: () => boolean;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, setDefaultStreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ThinkingSelection } from "@earendil-works/pi-ai";
-import { type Message, type Model, streamSimple } from "@earendil-works/pi-ai/compat";
+import { type Api, type Message, type Model, modelsAreEqual, streamSimple } from "@earendil-works/pi-ai/compat";
 import { getAgentDir } from "../config.ts";
 import { resolvePath } from "../utils/paths.ts";
 import { AgentSession } from "./agent-session.ts";
@@ -10,7 +10,7 @@ import { AuthStorage } from "./auth-storage.ts";
 import { estimateTokens } from "./compaction/compaction.ts";
 import { createSessionCursorExecBridge } from "./cursor-exec-bridge-session.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
-import type { ServiceTier } from "./extensions/builtin/service-tier.ts";
+import { type ServiceTier, supportsServiceTier } from "./extensions/builtin/service-tier.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlmForTransport, TRANSPORT_IMAGE_BUDGET_BYTES } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
@@ -388,9 +388,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
-	// The session (and its tool registry) is constructed after the Agent, so
-	// the Cursor exec bridge resolves tools through this late-bound ref.
-	const cursorBridgeSessionRef: { current?: AgentSession } = {};
+	// The session (and its tool registry) is constructed after the Agent, so the Cursor exec
+	// bridge and the request-tier resolver below reach it through this late-bound ref.
+	const sessionRef: { current?: AgentSession } = {};
+
+	// The `service_tier` a request carries when the caller did not pin one. The session's
+	// effective tier is the single source: a `-fast` catalog variant, a scoped `:priority` pin, or
+	// session fast mode all land here, so an SDK/embedded session honors the tier without the
+	// interactive service-tier extension being loaded (its payload hook only fills a missing
+	// field and stays consistent). A request for another model (title/branch summaries) falls
+	// back to that model's own catalog tier. Only the OpenAI Responses family accepts the field.
+	const resolveRequestServiceTier = (requestModel: Model<Api>): ServiceTier | undefined => {
+		if (!supportsServiceTier(requestModel.api)) return undefined;
+		const session = sessionRef.current;
+		const activeModel = session?.model;
+		if (session && activeModel && modelsAreEqual(activeModel, requestModel)) {
+			return session.effectiveServiceTier;
+		}
+		return modelRuntime.getCompatibilityRequestConfig(requestModel).serviceTier;
+	};
 
 	agent = new Agent({
 		initialState: {
@@ -423,8 +439,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					: declaredPolicy.providerRequest.enabled
 						? declaredPolicy.providerRequest.maxRetries
 						: 0;
+			const serviceTier = options?.serviceTier ?? resolveRequestServiceTier(model);
 			return modelRuntime.streamSimple(model, context, {
 				...options,
+				...(serviceTier !== undefined ? { serviceTier } : {}),
 				timeoutMs,
 				websocketConnectTimeoutMs,
 				maxRetries: options?.maxRetries ?? profileMaxRetries,
@@ -473,8 +491,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		timeoutMs: settingsManager.getAgentStreamIdleTimeoutMs(),
 		streamStartTimeoutMs: settingsManager.getAgentStreamStartTimeoutMs(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
-		cursorExecHandlers: (runSignal: AbortSignal) =>
-			createSessionCursorExecBridge(cursorBridgeSessionRef, () => agent, runSignal),
+		cursorExecHandlers: (runSignal: AbortSignal) => createSessionCursorExecBridge(sessionRef, () => agent, runSignal),
 	});
 	// Agent core accepts the field in AgentState but older constructors may not copy it
 	// from initialState; assign the separately computed provenance explicitly.
@@ -529,7 +546,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		liveContextTokens,
 		hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
 	);
-	cursorBridgeSessionRef.current = session;
+	sessionRef.current = session;
 	const extensionsResult = resourceLoader.getExtensions();
 
 	return {

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,22 @@
 
+## 2026-09-08 - Shortcut context exposes the effective service tier
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the extension shortcut context built by `setupExtensionShortcuts` sets the new optional `effectiveServiceTier` field from `session.effectiveServiceTier`, next to `serviceTier`.
+
+### Why
+
+- `ExtensionContext.effectiveServiceTier` (code-yeongyu/oh-my-openagent#6795) is what delegating hosts read to inherit a parent's fast mode; the hand-built shortcut context must report the same value the runner's contexts do.
+
+### Why an extension could not handle it
+
+- The shortcut context literal is host code; extensions only receive it.
+
+### Expected merge conflict zones
+
+- LOW: the `createContext` literal in `setupExtensionShortcuts`.
+
 ## 2026-09-07 - Add a workflow tip for the report-bug skill
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2744,6 +2744,7 @@ export class InteractiveMode {
 			modelRegistry: extensionRunner.getModelRegistry(),
 			model: this.session.model,
 			serviceTier: this.session.serviceTier,
+			effectiveServiceTier: this.session.effectiveServiceTier,
 			scopedModels: this.session.scopedModels,
 			thinkingLevel: this.session.thinkingLevel,
 			isIdle: () => this.session.isIdle,

--- a/packages/coding-agent/test/agent-session-auto-title-routing.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-title-routing.test.ts
@@ -40,7 +40,7 @@ describe("agent session auto title routing", () => {
 		harness.session.agent.streamFunction = (model, context, options) => {
 			const streamOptions = {
 				...options,
-				serviceTier: "priority",
+				serviceTier: "priority" as const,
 			};
 			return streamSimple({ ...model, id: "upstream-model" }, context, streamOptions);
 		};

--- a/packages/coding-agent/test/sdk-service-tier-wire.test.ts
+++ b/packages/coding-agent/test/sdk-service-tier-wire.test.ts
@@ -1,0 +1,214 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type Api,
+	type AssistantMessage,
+	createAssistantMessageEventStream,
+	type Model,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import type { ServiceTier } from "../src/core/extensions/builtin/service-tier.ts";
+import type { ProviderConfigInput } from "../src/core/model-registry.ts";
+import { createAgentSession } from "../src/core/sdk.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+type RegisteredModel = NonNullable<ProviderConfigInput["models"]>[number];
+
+const PROVIDER = "tier-provider";
+const BASE_MODEL_ID = "tier-base";
+const FAST_MODEL_ID = `${BASE_MODEL_ID}-fast`;
+
+/**
+ * The request tier is a SESSION property, not an extension feature: an embedded/SDK session that
+ * loads no builtin extensions (a delegated child, an app-server host) must still send the tier a
+ * `-fast` catalog variant or session fast mode asks for. Every session here is extension-less.
+ */
+describe("createAgentSession request service tier without extensions", () => {
+	let tempDir: string;
+	let cwd: string;
+	let agentDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-sdk-service-tier-wire-"));
+		cwd = join(tempDir, "project");
+		agentDir = join(tempDir, "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	type Captured = {
+		readonly options: SimpleStreamOptions | undefined;
+	};
+
+	async function withSession(
+		api: Api,
+		run: (
+			session: Awaited<ReturnType<typeof createAgentSession>>["session"],
+			models: { readonly base: Model<Api>; readonly fast: Model<Api> },
+			captured: Captured,
+		) => Promise<void>,
+	): Promise<void> {
+		const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+		await authStorage.modify(PROVIDER, async () => ({ type: "api_key", key: "test-api-key" }));
+		const modelRegistry = await createModelRegistry(authStorage, join(agentDir, "models.json"));
+		const captured: { options: SimpleStreamOptions | undefined } = { options: undefined };
+		const modelShape = {
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		} satisfies Omit<RegisteredModel, "id" | "name">;
+		modelRegistry.registerProvider(PROVIDER, {
+			api,
+			baseUrl: "https://tier.invalid/v1",
+			models: [
+				{ id: BASE_MODEL_ID, name: "Tier Base", ...modelShape },
+				{
+					id: FAST_MODEL_ID,
+					name: "Tier Base Fast",
+					upstreamModelId: BASE_MODEL_ID,
+					serviceTier: "priority",
+					...modelShape,
+				},
+			],
+			streamSimple: (_model, _context, providerOptions) => {
+				captured.options = providerOptions;
+				return doneStream(api);
+			},
+		});
+		const base = modelRegistry.find(PROVIDER, BASE_MODEL_ID);
+		const fast = modelRegistry.find(PROVIDER, FAST_MODEL_ID);
+		if (!base || !fast) throw new Error("test provider models did not register");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			model: base,
+			modelRuntime: getModelRuntime(modelRegistry),
+			settingsManager: SettingsManager.inMemory({}),
+			sessionManager: SessionManager.inMemory(cwd),
+			resourceLoader: createTestResourceLoader(),
+		});
+		try {
+			await run(session, { base, fast }, captured);
+		} finally {
+			session.dispose();
+			modelRegistry.unregisterProvider(PROVIDER);
+		}
+	}
+
+	async function requestTier(
+		session: Awaited<ReturnType<typeof createAgentSession>>["session"],
+		model: Model<Api>,
+		captured: Captured,
+		requestOptions: SimpleStreamOptions = {},
+	): Promise<ServiceTier | undefined> {
+		const stream = await session.agent.streamFunction(model, { messages: [] }, requestOptions);
+		await stream.result();
+		return captured.options?.serviceTier;
+	}
+
+	it("sends the catalog priority tier of a -fast variant selected on an extension-less session", async () => {
+		await withSession("openai-codex-responses", async (session, models, captured) => {
+			// given: no service-tier extension is loaded, only the catalog says priority
+			await session.setSessionModel(models.fast);
+			expect(session.serviceTier).toBe("priority");
+
+			// when
+			const tier = await requestTier(session, models.fast, captured);
+
+			// then
+			expect(tier).toBe("priority");
+		});
+	});
+
+	it("sends priority once session fast mode is turned on for a Codex base model", async () => {
+		await withSession("openai-codex-responses", async (session, models, captured) => {
+			// given
+			expect(await requestTier(session, models.base, captured)).toBeUndefined();
+
+			// when
+			session.setSessionFastMode(true);
+
+			// then
+			expect(await requestTier(session, models.base, captured)).toBe("priority");
+
+			session.setSessionFastMode(false);
+			expect(await requestTier(session, models.base, captured)).toBeUndefined();
+		});
+	});
+
+	it("never sends a tier to an API that has no service_tier field", async () => {
+		await withSession("anthropic-messages", async (session, models, captured) => {
+			// given
+			session.setSessionFastMode(true);
+			expect(session.isFastModeActive()).toBe(true);
+
+			// when
+			const tier = await requestTier(session, models.base, captured);
+
+			// then
+			expect(tier).toBeUndefined();
+		});
+	});
+
+	it("lets an explicit request tier outrank the session tier", async () => {
+		await withSession("openai-responses", async (session, models, captured) => {
+			// given
+			session.setSessionFastMode(true);
+
+			// when
+			const tier = await requestTier(session, models.base, captured, { serviceTier: "flex" });
+
+			// then
+			expect(tier).toBe("flex");
+		});
+	});
+
+	it("uses the request model's own catalog tier when it is not the session model", async () => {
+		await withSession("openai-responses", async (session, models, captured) => {
+			// given: the session sits on the base model with fast mode off
+			expect(session.effectiveServiceTier).toBeUndefined();
+
+			// when: a side request (summaries use the same stream function) names the -fast variant
+			const tier = await requestTier(session, models.fast, captured);
+
+			// then
+			expect(tier).toBe("priority");
+		});
+	});
+});
+
+function doneStream(api: Api) {
+	const stream = createAssistantMessageEventStream();
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		api,
+		provider: PROVIDER,
+		model: BASE_MODEL_ID,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+	stream.end(message);
+	return stream;
+}

--- a/packages/coding-agent/test/suite/fast-mode-persistence.test.ts
+++ b/packages/coding-agent/test/suite/fast-mode-persistence.test.ts
@@ -308,8 +308,10 @@ describe("/fast per-model service-tier persistence", () => {
 		await harness.session.setSessionModel(other!);
 		await harness.session.setSessionModel(harness.getModel());
 
-		// then: the model's own memory is back in force, so nothing reaches the wire
-		expect(harness.session.serviceTier).toBe("priority");
+		// then: the model's own memory is back in force, so nothing reaches the wire - and the
+		// session's own request-side tier agrees with it instead of caching the catalog priority
+		expect(harness.session.serviceTier).toBeUndefined();
+		expect(harness.session.effectiveServiceTier).toBeUndefined();
 		const afterSwitch = { model: BASE_MODEL_ID };
 		expect(await runner.emitBeforeProviderRequest(afterSwitch)).toBe(afterSwitch);
 	});


### PR DESCRIPTION
## Summary

Fixes the engine half of code-yeongyu/oh-my-openagent#6795: a `-fast` catalog variant (`openai-codex/gpt-5.6-luna-fast`) declares `serviceTier: "priority"`, and `ModelRuntime.prepareRequest` already honors its sibling field `upstreamModelId`, yet the tier itself reached the wire ONLY through the builtin service-tier extension's `before_provider_request` payload hook. Any session created without builtin extensions - SDK embedders, oh-my-openagent's in-process delegated children (which deliberately load an empty extension set) - silently ran at the standard tier while displaying a fast model. Even `session.setSessionFastMode(true)` had no wire effect there.

Ideal state: the request tier is a property of the SESSION, honored by the session's own stream function, and the interactive extension only owns the per-model `/fast` memory on top of it.

## Changes

- **pi-ai**: `SimpleStreamOptions.serviceTier` (`"auto" | "flex" | "priority"`), forwarded by the OpenAI Responses and Codex Responses `streamSimple` adapters. `buildBaseOptions` dropped it before, so the simple path could never request a tier. Azure is unchanged (no Priority processing).
- **sdk `streamFn`**: when the caller did not pin a tier, default it to the session's `effectiveServiceTier` for the active model (catalog `-fast` variant, scoped `:priority` pin, or session fast mode); a side request for another model (title/branch summaries) uses that model's own catalog tier. Only APIs that accept `service_tier` receive it. The Cursor bridge's late-bound session ref becomes the shared `sessionRef`.
- **service-tier extension**: on `model_select`, a remembered `"auto"` for a catalog-priority Codex model now also clears the session's cached tier via `setSessionFastMode(false)` (which only ever clears a catalog-inherited Codex priority, never a `:priority` pin), so the core writer and the payload hook agree. `supportsServiceTier(api)` is exported.
- **ExtensionContext.effectiveServiceTier** (optional) + `ExtensionContextActions.getEffectiveServiceTier` (optional, falls back to `getServiceTier`), so hosts that delegate work can inherit the parent's effective tier. Wired in `AgentSession` and the interactive shortcut context.
- `changes.md` entries in `packages/ai/src`, `core`, and `core/extensions`.

Behavior note: the Codex adapter's tier-aware usage pricing now sees the requested tier on the options (it previously only saw the payload the extension mutated), so a priority Codex request is costed with the adapter's existing priority multiplier.

## Tests

- New `test/sdk-service-tier-wire.test.ts`: an extension-less `createAgentSession` sends the catalog priority tier of a `-fast` variant, sends priority once `setSessionFastMode(true)` is on and stops when it is off, never sends a tier to an API without the field, lets an explicit request tier win, and uses the request model's own catalog tier for side requests.
- `fast-mode-persistence.test.ts` "keeps the remembered auto after switching away from the model and back": the session's cached tier is now expected to agree with the memory (`undefined`) instead of caching the catalog priority while the hook suppresses it.
- Ran on mengmotaMac (SHA 3246bcb): `packages/ai` openai-fast-models (9 passed); `packages/coding-agent` service-tier/fast-mode/rpc/footer/sdk/extension-runner/compaction/permission suites - 14 files, 234 passed, 0 failed. `tsc --noEmit` and `biome` green via the pre-commit hook.

Companion: code-yeongyu/oh-my-openagent#7938 (delegated children inherit the parent's fast mode through the `-fast` catalog sibling).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the session's effective service tier on the request itself, so an extension-less session (`-fast` catalog model or session fast mode) no longer silently runs at the standard tier while displaying a fast model.

**Changes**
- `streamSimple` now forwards `serviceTier` to the OpenAI Responses and Codex Responses adapters; `buildBaseOptions` previously dropped it.
- The SDK `streamFn` defaults the request tier to the session's `effectiveServiceTier` (fast-mode promotion included); side requests for another model use that model's own catalog tier, and APIs without `service_tier` never receive it.
- The builtin service-tier extension clears the session's cached tier when a remembered `"auto"` maps to a catalog-priority Codex model, so its payload hook and the session-side writer stay consistent.
- `ExtensionContext.effectiveServiceTier` and `getEffectiveServiceTier` let delegating hosts inherit the parent's effective tier.
- The Codex adapter's tier-aware usage pricing now sees the requested tier and applies its existing priority multiplier, where it previously only saw the extension-mutated payload.
- `changes.md` and release `CHANGELOG.md` entries document the change across `packages/ai`, `core`, and `core/extensions`.

<sup>Written for commit 9528acc4bb5eba6a8607ed55a605ac6e84dfdd41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

