### PR TITLE
fix(terminal): keep foreground git commands non-interactive (GIT_EDITOR, GIT_TERMINAL_PROMPT)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Sessions created without builtin extensions (SDK embedders, oh-my-openagent's in-process delegated children) now send the priority service tier of a `-fast` catalog model, a scoped `:priority` pin, or session fast mode on the wire; previously only the interactive service-tier extension's payload hook wrote `service_tier`, so a delegated task displayed a fast model but ran at the standard tier (code-yeongyu/oh-my-openagent#6795). Extensions can read the session's `effectiveServiceTier` from their context.
 
+- Foreground `bash` commands now run git with `GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0`, so a `git commit` without `-m`, an interactive rebase, or a terminal credential prompt on the captured foreground PTY fails fast (`Aborting commit due to empty commit message` / `could not read Username`) instead of blocking the agent until the command timeout kills it. Background PTY sessions keep the user's real git settings.
+
 ### Removed
 
 ## [2026.9.7-2] - 2026-09-07

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,23 @@
 # terminal builtin extension — fork surface
 
+## Foreground git commands stay non-interactive (2026-09-08)
+
+### What changed
+
+- `shared.ts`: `FOREGROUND_ENV_OVERRIDES` gains two keys. `GIT_EDITOR: "true"` makes git spawn `/usr/bin/true` as the editor for foreground one-shot commands — git treats a zero-exit editor as accepted, so a `git commit` without `-m` aborts with `Aborting commit due to empty commit message` and a `git rebase -i` takes the todo list as-is instead of parking the captured PTY inside nvim on COMMIT_EDITMSG. `GIT_TERMINAL_PROMPT: "0"` makes git fail fast on credential prompts (exit 128, `could not read Username`) — the same opt-out `package-manager.ts` uses for its own git calls. Background PTY sessions still spawn with only `sessionEnvOverrides` (`runBackground` in `tools/bash.ts`), so interactive git in a background session keeps the user's real settings.
+
+### Why
+
+- Child agents and foreground one-shot commands run with a captured PTY: when git opens an editor or asks for credentials on that terminal nobody can type, and the tool blocks until the timeout kills the command. The existing foreground overrides already removed color/pager interactivity; the editor and credential prompts were the two remaining terminal-input paths.
+
+### Why an extension could not handle it
+
+- The overrides are injected by this builtin's own `runForeground` spawn path from its shared constants; an outside extension cannot alter the environment of a PTY the terminal manager spawns.
+
+### Expected merge conflict zones
+
+- LOW: the `FOREGROUND_ENV_OVERRIDES` constant and its doc comment in `shared.ts`, plus the foreground/background env assertions in `test/terminal-bash-tool-output.test.ts`.
+
 ## File monitors resolve parent identity without realpath and gate `fs.watch` behind a bounded open (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
@@ -63,8 +63,19 @@ export const FIRE_BUDGET_AUTO_MUTE_SUMMARY = `auto-muted: fire budget (${DEFAULT
 /**
  * Non-interactive environment for foreground one-shot commands (codex-style):
  * cooperative tools (`gh`, `git`, pagers, color libs) skip spinners/colors at
- * the source instead of flooding the captured stream with redraw frames.
- * Background sessions keep the user's real TERM for interactive apps.
+ * the source instead of flooding the captured stream with redraw frames, and
+ * `git` never blocks the captured foreground PTY on interactive input.
+ * - `GIT_EDITOR: "true"`: git spawns `/usr/bin/true` as the editor, which exits 0
+ *   immediately (git treats a zero-exit editor as accepted), so a `git commit`
+ *   without `-m` aborts with "Aborting commit due to empty commit message" and a
+ *   `git rebase -i` accepts the todo list instead of parking the tool inside
+ *   nvim on COMMIT_EDITMSG until the timeout kills it.
+ * - `GIT_TERMINAL_PROMPT: "0"`: git fails fast ("could not read Username",
+ *   exit 128) instead of prompting for credentials on the captured PTY where
+ *   nobody can type (same opt-out `package-manager.ts` already uses for its own
+ *   git calls).
+ * Background sessions keep the user's real TERM and git settings for
+ * interactive apps.
  */
 export const FOREGROUND_ENV_OVERRIDES: Readonly<Record<string, string>> = {
 	NO_COLOR: "1",
@@ -73,6 +84,8 @@ export const FOREGROUND_ENV_OVERRIDES: Readonly<Record<string, string>> = {
 	PAGER: "cat",
 	GIT_PAGER: "cat",
 	GH_PAGER: "cat",
+	GIT_EDITOR: "true",
+	GIT_TERMINAL_PROMPT: "0",
 };
 
 /**

--- a/packages/coding-agent/test/terminal-bash-tool-output.test.ts
+++ b/packages/coding-agent/test/terminal-bash-tool-output.test.ts
@@ -12,9 +12,10 @@ import type { TerminalToolContext, TerminalToolResult } from "../src/core/extens
  * raw 1 MB scrollback dumps and ANSI spinner floods used to go straight into
  * the conversation, instantly blowing the context past the compaction
  * threshold. Foreground spawns also inject a non-interactive environment
- * (NO_COLOR / TERM=dumb / cat pagers) so cooperative tools never emit the
- * escape soup in the first place; background interactive sessions keep the
- * user's real TERM.
+ * (NO_COLOR / TERM=dumb / cat pagers / git editor + prompt opt-outs) so
+ * cooperative tools never emit the escape soup — and git never opens an
+ * editor or credential prompt — in the first place; background interactive
+ * sessions keep the user's real TERM and git settings.
  */
 
 function resultText(result: TerminalToolResult): string {
@@ -97,7 +98,10 @@ describe.skipIf(process.platform === "win32")("PTY bash tool model-facing output
 		const result = await withTimeout(
 			tool.execute(
 				"call-env",
-				{ command: 'printf \'%s|%s|%s|%s\' "$NO_COLOR" "$TERM" "$PAGER" "$GH_PAGER"' },
+				{
+					command:
+						'printf \'%s|%s|%s|%s|%s|%s\' "$NO_COLOR" "$TERM" "$PAGER" "$GH_PAGER" "$GIT_EDITOR" "$GIT_TERMINAL_PROMPT"',
+				},
 				undefined,
 				undefined,
 				undefined,
@@ -105,15 +109,27 @@ describe.skipIf(process.platform === "win32")("PTY bash tool model-facing output
 			30000,
 			"env probe",
 		);
-		expect(resultText(result)).toContain("1|dumb|cat|cat");
+		expect(resultText(result)).toContain("1|dumb|cat|cat|true|0");
 	});
 
 	it("does not inject the non-interactive environment into background sessions", async () => {
-		const tool = createPtyBashTool({ ...ctx, getEnv: () => ({ ...process.env, TERM: "xterm-256color" }) });
+		const tool = createPtyBashTool({
+			...ctx,
+			getEnv: () => ({
+				...process.env,
+				TERM: "xterm-256color",
+				GIT_EDITOR: "nvim",
+				GIT_TERMINAL_PROMPT: "1",
+			}),
+		});
 		const result = await withTimeout(
 			tool.execute(
 				"call-bg",
-				{ command: "printf 'TERM=%s\n' \"$TERM\"", run_in_background: true },
+				{
+					command:
+						'printf \'TERM=%s GIT_EDITOR=%s GIT_TERMINAL_PROMPT=%s\' "$TERM" "$GIT_EDITOR" "$GIT_TERMINAL_PROMPT"',
+					run_in_background: true,
+				},
 				undefined,
 				undefined,
 				undefined,
@@ -122,5 +138,7 @@ describe.skipIf(process.platform === "win32")("PTY bash tool model-facing output
 			"background env probe",
 		);
 		expect(resultText(result)).toContain("TERM=xterm-256color");
+		expect(resultText(result)).toContain("GIT_EDITOR=nvim");
+		expect(resultText(result)).toContain("GIT_TERMINAL_PROMPT=1");
 	});
 });


### PR DESCRIPTION
## Summary

Foreground one-shot `bash` commands run with a captured PTY. When `git` decides it needs interactive input there — `git commit` without `-m`, `git rebase -i`, a merge message prompt (editor on `COMMIT_EDITMSG`), or a terminal credential prompt — nobody can type, so the tool blocks until the command timeout kills it. The foreground spawn environment already opts out of colors and pagers; this PR closes the two remaining terminal-input paths by adding `GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0` to `FOREGROUND_ENV_OVERRIDES`.

- `GIT_EDITOR: "true"` — git spawns `/usr/bin/true` as the editor; git treats a zero-exit editor as accepted, so `git commit` without `-m` aborts cleanly with `Aborting commit due to empty commit message` and an interactive rebase takes the todo list as-is, instead of parking the captured PTY inside nvim.
- `GIT_TERMINAL_PROMPT: "0"` — git fails fast (exit 128, `could not read Username`) instead of prompting for credentials; the same opt-out `package-manager.ts` already uses for its own git calls.

Background PTY sessions are untouched: `runBackground` spawns with only `sessionEnvOverrides`, so interactive git in a background session keeps the user's real editor and prompt settings.

## Changes

- `packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts` — `FOREGROUND_ENV_OVERRIDES` gains `GIT_EDITOR: "true"` and `GIT_TERMINAL_PROMPT: "0"`; the doc comment above the constant now names both keys and why.
- `packages/coding-agent/test/terminal-bash-tool-output.test.ts` — the foreground env probe now also asserts `GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0`; the background contrast probe pins the user's own `GIT_EDITOR`/`GIT_TERMINAL_PROMPT` surviving the spawn (background must NOT receive the overrides).
- `packages/coding-agent/src/core/extensions/builtin/terminal/changes.md` — new entry (2026-09-08) with all four canonical sections.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased]` → `Fixed` bullet.

## QA & Evidence

Test-first, run remotely on gorky (Linux x86_64, node 24) through `bun remote-test.mjs --machine gorky --repo senpi --lane gitenv`:

1. RED (commit `371a6feb2`, test only): `cd packages/coding-agent && bun run test -- terminal-bash-tool-output` → `__EXIT=1`, failure exactly on the missing keys: `expected '1|dumb|cat|cat||' to contain '1|dumb|cat|cat|true|0'` (other 3 tests in the file passed, including the extended background contrast). Evidence: `/tmp/ulw-fix-20260908/evidence/gitenv/red-foreground-git-env.txt`
2. GREEN (commit `0fd171ff9`, fix + docs): same command → `__EXIT=0`, 4/4 passed. Evidence: `/tmp/ulw-fix-20260908/evidence/gitenv/green-foreground-git-env.txt`
3. Terminal extension scope (commit `0fd171ff9`): `cd packages/coding-agent && bun run test -- terminal-` → `__EXIT=0`, 30 test files / 239 tests passed. Evidence: `/tmp/ulw-fix-20260908/evidence/gitenv/green-package.txt`
4. Local: full pre-commit `bun run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser-smoke) passed on both commits; `node scripts/check-pr-changelog.mjs --base 4adba7afb` → `PASS`.

Note on the remote runs: gorky's shared `senpi.base` is a `--filter=blob:none` partial clone, so the branch's new blobs were absent from the lane clone's object chain and the helper's `checkout ... 2>/dev/null` silently skipped those files (`git status` showed ` D`). The `--cmd` therefore prepends a repair step that materializes any ` D` path via base's promisor lazy fetch (`git -C ../senpi.base cat-file -p <blob>`) before running vitest; the evidence files show `dirty: 0` before each run. This is checkout plumbing only — it does not touch the code under test.

## Risks & Residuals

- `GIT_EDITOR=true` applies to every foreground command, git or not — for non-git commands the variable is inert. A foreground `git rebase -i` now accepts the default todo instead of hanging; an agent that genuinely wants to edit the plan must do it non-interactively (e.g. write the todo with `GIT_SEQUENCE_EDITOR` explicitly set per-command or use `--onto`-style flags), same as it already must for `-m`-less commits.
- `GIT_TERMINAL_PROMPT=0` turns a would-be credential prompt into an immediate failure. Foreground commands that rely on interactively-typed credentials now fail fast with git's `could not read Username` message — the intended behavior for an unattended captured PTY; agents needing auth should use a credential helper or `gh`.
- Monitor/background paths are unchanged (`FOREGROUND_ENV_OVERRIDES` is consumed only by `runForeground`).
- Root `CONTRIBUTING.md` says "Do not edit CHANGELOG.md. Changelog entries are added by maintainers", but `scripts/check-pr-changelog.mjs` requires an `[Unreleased]` entry for runtime-source changes and recent fix PRs ship one (`e78233bd9`); this PR follows the gate.

## Related Issues

None referenced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0` to `FOREGROUND_ENV_OVERRIDES` so foreground git commands never block on interactive input. Previously a `git commit` without `-m`, an interactive rebase, or a credential prompt parked the captured PTY until the timeout killed the command; now the zero-exit editor aborts empty commits and accepts default rebase todos, and credential prompts fail fast with exit 128.

**Side effects**

- Background PTY sessions still keep the user's real git settings.
- Foreground interactive rebases now take the default todo list; explicit `GIT_SEQUENCE_EDITOR` is needed for custom plans.
- Foreground commands relying on typed credentials now fail with `could not read Username`; use a credential helper or `gh`.

<sup>Written for commit 7472d791c4f6a24a2e0e4a3f924976d965a770aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

