### PR TITLE
fix(session): reject oversized resumes before runtime teardown

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## 2026-09-08 - Preflight same-cwd configured resume models without loading extensions
+
+### What changed
+
+- `packages/coding-agent/src/main.ts`: add a read-only resume admission hook using target settings, read-only credentials, an in-memory model catalog store, no model network refresh, and the same CLI/launch-profile plus SDK initial-model selection as normal creation. Preflight is limited to same-cwd targets with resolved trust; the active effective same-id model must corroborate the configured window and output budget for every provider, including cached catalog and extension overrides.
+
+### Why
+
+- The reproduced saved transcript has more estimated tokens than the model's newly reduced catalog window. Rejecting that lower-bound mismatch before loading any target extension preserves the current TUI without mutating history or relaxing full model admission.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/main.ts` supplies the runtime factory and controls model selection before resource loading; an extension cannot safely run this preflight before its own registration.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/main.ts` runtime factory setup and launch-profile argument resolution.
+
+### Scope
+
+- This is a conservative configured-catalog check for the classic TUI, not general rollback. Different cwd, unresolved trust, speculative default fallbacks, nonpositive windows, and missing or mismatched active model geometry are deferred to the existing creation path. Extra prompt/tool overhead can still fail full admission after teardown. Arbitrary extensions changing model registration on reload and experimental shared-host typed-error serialization are not covered. No broader target-history immutability guarantee is added: legacy missing-thinking metadata behavior is unchanged.
+
+
 ## 2026-09-07 - Add the memory Aha-moment tip
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -11,7 +11,7 @@ import type {
 } from "./extensions/index.ts";
 import { type ExtensionRunner, emitSessionShutdownEvent } from "./extensions/runner.ts";
 import type { CreateAgentSessionResult } from "./sdk.ts";
-import { assertSessionCwdExists } from "./session-cwd.ts";
+import { assertSessionCwdExists, MissingSessionCwdError } from "./session-cwd.ts";
 import { SessionManager } from "./session-manager.ts";
 
 /**
@@ -40,14 +40,21 @@ export interface AgentSessionLaunchProfile {
  * services for the effective cwd, resolves session options against those
  * services, and finally creates the AgentSession.
  */
-export type CreateAgentSessionRuntimeFactory = (options: {
+export interface AgentSessionRuntimeTarget {
 	cwd: string;
 	agentDir: string;
 	sessionManager: SessionManager;
 	sessionStartEvent?: SessionStartEvent;
 	projectTrustContext?: ProjectTrustContext;
 	launchProfile?: Readonly<AgentSessionLaunchProfile>;
-}) => Promise<CreateAgentSessionRuntimeResult>;
+}
+
+export type CreateAgentSessionRuntimeFactory = ((
+	options: AgentSessionRuntimeTarget,
+) => Promise<CreateAgentSessionRuntimeResult>) & {
+	/** Read-only admission: must not load extensions, construct sessions, or mutate the current runtime. */
+	prepareResume?: (options: AgentSessionRuntimeTarget) => Promise<void>;
+};
 
 /**
  * Thrown when /import references a JSONL file path that does not exist.
@@ -59,6 +66,14 @@ export class SessionImportFileNotFoundError extends Error {
 		super(`File not found: ${filePath}`);
 		this.name = "SessionImportFileNotFoundError";
 		this.filePath = filePath;
+	}
+}
+
+/** A resume target failed to prepare; the current session has not been torn down. */
+export class SessionResumePreparationError extends Error {
+	constructor(cause: unknown) {
+		super(cause instanceof Error ? cause.message : String(cause), { cause });
+		this.name = "SessionResumePreparationError";
 	}
 }
 
@@ -76,9 +91,9 @@ function extractUserMessageText(content: string | Array<{ type: string; text?: s
 /**
  * Owns the current AgentSession plus its cwd-bound services.
  *
- * Session replacement methods tear down the current runtime first, then create
- * and apply the next runtime. If creation fails, the error is propagated to the
- * caller. The caller is responsible for user-facing error handling.
+ * Resume can run a read-only admission preflight before teardown. Full runtime
+ * creation still runs after teardown because extension registration may mutate
+ * process-global services. The caller owns user-facing error handling.
  */
 export class AgentSessionRuntime {
 	private rebindSession?: (session: AgentSession) => Promise<void>;
@@ -251,19 +266,26 @@ export class AgentSessionRuntime {
 		}
 
 		const previousSessionFile = this.session.sessionFile;
-		const sessionManager = SessionManager.open(sessionPath, undefined, options?.cwdOverride);
-		assertSessionCwdExists(sessionManager, this.cwd);
-		await this.teardownCurrent("resume", sessionManager.getSessionFile());
-		await this.apply(
-			await this.createRuntime({
+		let target: AgentSessionRuntimeTarget;
+		try {
+			const sessionManager = SessionManager.open(sessionPath, undefined, options?.cwdOverride);
+			assertSessionCwdExists(sessionManager, this.cwd);
+			target = {
 				cwd: sessionManager.getCwd(),
 				agentDir: this.services.agentDir,
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile },
 				projectTrustContext: options?.projectTrustContextFactory?.(sessionManager.getCwd()),
 				launchProfile: this._launchProfile,
-			}),
-		);
+			};
+			await this.createRuntime.prepareResume?.(target);
+		} catch (error) {
+			if (error instanceof MissingSessionCwdError) throw error;
+			throw new SessionResumePreparationError(error);
+		}
+
+		await this.teardownCurrent("resume", target.sessionManager.getSessionFile());
+		await this.apply(await this.createRuntime(target));
 		await this.finishSessionReplacement(options?.withSession);
 		return { cancelled: false };
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2911,7 +2911,7 @@ export class AgentSession {
 	 * Remove all listeners and disconnect from agent.
 	 * Call this when completely done with the session.
 	 */
-	dispose(): void {
+	dispose(options: { skipProviderResourceCleanup?: boolean } = {}): void {
 		try {
 			this._probeBackScheduler.cancel("dispose");
 			this.abortRetry();
@@ -2933,7 +2933,9 @@ export class AgentSession {
 		this._unsubscribeWakeSources?.();
 		this._unsubscribeWakeSources = undefined;
 		this._eventListeners = [];
-		cleanupSessionResources(this.sessionId);
+		// Unadmitted SDK candidates have never made a provider request. A live
+		// runtime may still own transport/cache resources under the same saved id.
+		if (!options.skipProviderResourceCleanup) cleanupSessionResources(this.sessionId);
 	}
 
 	/** Live in-session activity signals; see `session-activity.ts` for the contract. */

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,23 @@
+## 2026-09-08 - Reject configured resume budgets before tearing down the current session
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session-runtime.ts`: `switchSession` runs an optional read-only factory `prepareResume` hook before abort/shutdown/invalidation, wrapping only preflight errors in `SessionResumePreparationError`. Full factory creation remains after teardown because extension registration can mutate shared services. Success ordering and new/fork/import flows are unchanged.
+- `packages/coding-agent/src/core/sdk.ts`: share initial model selection with a configured-catalog resume preflight. The preflight projects transcript tokens with zero prompt/tool overhead and no speculation lead, rejecting only this lower bound; unresolved extension-dependent model selection is deferred to the unchanged full admission guard. A rejected constructed SDK session is disposed before the error propagates.
+- `packages/coding-agent/src/core/agent-session.ts`: allow disposal of unadmitted SDK candidates without cleaning provider resources keyed by the saved session id, which may still belong to another live runtime.
+
+### Why
+
+- A saved conversation can exceed its model's current catalog window. Previously selecting it disposed the current runtime before discovering that mismatch and exited the TUI. Preparing a complete candidate first was not safe either: registration rebound the tool-search singleton and installed MCP listeners before admission. The preflight does not load extensions or construct a candidate, preserving the live runtime and its provider resources.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/agent-session-runtime.ts` owns the preflight/teardown boundary, `packages/coding-agent/src/core/sdk.ts` owns initial selection and admission, and `packages/coding-agent/src/core/agent-session.ts` owns resource disposal. These run below extension lifecycle interception.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/agent-session-runtime.ts` factory type and `switchSession`; `packages/coding-agent/src/core/agent-session.ts` `dispose`; MEDIUM: extracted initial-selection block and post-construction admission in `packages/coding-agent/src/core/sdk.ts`.
+
 ## Goal backstop default is 270s (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -10,6 +10,10 @@ import { AuthStorage } from "./auth-storage.ts";
 import { estimateTokens } from "./compaction/compaction.ts";
 import { createSessionCursorExecBridge } from "./cursor-exec-bridge-session.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
+import {
+	ModelUsabilityBudgetError,
+	projectModelUsabilityBudget,
+} from "./extensions/builtin/compaction/model-usability-budget.ts";
 import { type ServiceTier, supportsServiceTier } from "./extensions/builtin/service-tier.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlmForTransport, TRANSPORT_IMAGE_BUDGET_BYTES } from "./messages.ts";
@@ -185,6 +189,139 @@ export function clampThinkingLevelToModel(
 	return available[0] ?? "off";
 }
 
+/** Resolve startup/resume model selection without loading resources or constructing a session. */
+export async function resolveInitialSessionModel(
+	options: Pick<CreateAgentSessionOptions, "model" | "initialModelProvenance" | "thinkingSelection">,
+	existingSession: ReturnType<SessionManager["buildSessionContext"]>,
+	modelRuntime: ModelRuntime,
+	settingsManager: SettingsManager,
+	scopedModels: NonNullable<CreateAgentSessionOptions["scopedModels"]>,
+) {
+	const hasExistingSession = existingSession.messages.length > 0;
+	let model = options.model;
+	let initialModelProvenance = options.initialModelProvenance;
+	let initialResolvedThinkingLevel: ThinkingLevel | undefined;
+	let initialThinkingSelection = options.thinkingSelection;
+	let modelFallbackMessage: string | undefined;
+
+	if (model) {
+		const resolved = resolveStoredModelReference(model.provider, model.id, modelRuntime);
+		if (resolved?.thinkingSelection) {
+			model = resolved.model;
+			initialResolvedThinkingLevel = resolved.thinkingLevel;
+			initialThinkingSelection ??= resolved.thinkingSelection;
+		}
+	}
+
+	// If session has data, try to restore model from it
+	if (!model && hasExistingSession && existingSession.model) {
+		const restored = resolveStoredModelReference(
+			existingSession.model.provider,
+			existingSession.model.modelId,
+			modelRuntime,
+		);
+		if (restored && modelRuntime.hasConfiguredAuth(restored.model.provider)) {
+			model = restored.model;
+			initialResolvedThinkingLevel = restored.thinkingLevel;
+			initialThinkingSelection = restored.thinkingSelection;
+		}
+		if (!model) {
+			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+		}
+	}
+
+	// If still no model, use findInitialModel (checks settings default, then provider defaults)
+	if (!model) {
+		const result = await findInitialModel({
+			scopedModels,
+			isContinuing: hasExistingSession,
+			defaultProvider: settingsManager.getDefaultProvider(),
+			defaultModelId: settingsManager.getDefaultModel(),
+			defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),
+			modelThinkingLevels: settingsManager.getAllModelThinkingLevels(),
+			modelRuntime,
+		});
+		model = result.model;
+		initialModelProvenance = result.provenance;
+		const selectedModel = model;
+		const scopedSelection = selectedModel
+			? scopedModels.find(
+					(entry) => entry.model.provider === selectedModel.provider && entry.model.id === selectedModel.id,
+				)
+			: undefined;
+		initialResolvedThinkingLevel = scopedSelection?.thinkingLevel ?? result.thinkingLevel;
+		initialThinkingSelection = scopedSelection?.thinkingSelection ?? result.thinkingSelection;
+		if (!model) {
+			modelFallbackMessage = formatNoModelsAvailableMessage();
+		} else if (modelFallbackMessage) {
+			modelFallbackMessage += `. Using ${model.provider}/${model.id}`;
+		}
+	}
+
+	return {
+		model,
+		initialModelProvenance,
+		initialResolvedThinkingLevel,
+		initialThinkingSelection,
+		modelFallbackMessage,
+	};
+}
+
+/**
+ * Reject only a configured resume model whose minimum budget already cannot fit.
+ * Unknown/extension-only models are left to final admission after resource loading.
+ * Empty prompt/tools intentionally underestimate the final requirement; this is
+ * not a replacement for the SDK's fully assembled admission guard.
+ */
+export async function assertConfiguredSessionResumeUsable(
+	options: Pick<CreateAgentSessionOptions, "model" | "initialModelProvenance" | "thinkingSelection">,
+	sessionManager: SessionManager,
+	modelRuntime: ModelRuntime,
+	settingsManager: SettingsManager,
+	scopedModels: NonNullable<CreateAgentSessionOptions["scopedModels"]>,
+	isModelReliable: (model: NonNullable<CreateAgentSessionOptions["model"]>) => boolean = () => true,
+): Promise<void> {
+	const existingSession = sessionManager.buildSessionContext();
+	if (existingSession.messages.length === 0) return;
+	if (!options.model && existingSession.model) {
+		const restored = resolveStoredModelReference(
+			existingSession.model.provider,
+			existingSession.model.modelId,
+			modelRuntime,
+		);
+		// An extension may supply a missing model or its auth; do not reject a
+		// speculative fallback that full resource loading could replace.
+		if (!restored || !modelRuntime.hasConfiguredAuth(restored.model.provider)) return;
+	}
+	const { model, initialModelProvenance } = await resolveInitialSessionModel(
+		options,
+		existingSession,
+		modelRuntime,
+		settingsManager,
+		scopedModels,
+	);
+	// Extensions can supply an unresolved default. A speculative provider/first
+	// fallback is not yet evidence of which model full startup will select.
+	if (!options.model && !existingSession.model && initialModelProvenance !== "settings") return;
+	if (
+		!model ||
+		model.contextWindow <= 0 ||
+		!modelRuntime.getModel(model.provider, model.id) ||
+		!isModelReliable(model)
+	)
+		return;
+	const projection = projectModelUsabilityBudget({
+		model,
+		systemPrompt: "",
+		tools: [],
+		liveContextTokens: existingSession.messages.reduce((total, message) => total + estimateTokens(message), 0),
+		compaction: settingsManager.getCompactionSettings(),
+		includeSpeculationLead: false,
+		admission: "resume",
+	});
+	if (!projection.usable) throw new ModelUsabilityBudgetError(projection);
+}
+
 // Helper Functions
 
 function getDefaultAgentDir(): string {
@@ -262,66 +399,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const hasExistingSession = existingSession.messages.length > 0;
 	const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
 
-	let model = options.model;
-	let initialModelProvenance = options.initialModelProvenance;
-	let initialResolvedThinkingLevel: ThinkingLevel | undefined;
-	let initialThinkingSelection = options.thinkingSelection;
-	let modelFallbackMessage: string | undefined;
-
-	if (model) {
-		const resolved = resolveStoredModelReference(model.provider, model.id, modelRuntime);
-		if (resolved?.thinkingSelection) {
-			model = resolved.model;
-			initialResolvedThinkingLevel = resolved.thinkingLevel;
-			initialThinkingSelection ??= resolved.thinkingSelection;
-		}
-	}
-
-	// If session has data, try to restore model from it
-	if (!model && hasExistingSession && existingSession.model) {
-		const restored = resolveStoredModelReference(
-			existingSession.model.provider,
-			existingSession.model.modelId,
-			modelRuntime,
-		);
-		if (restored && modelRuntime.hasConfiguredAuth(restored.model.provider)) {
-			model = restored.model;
-			initialResolvedThinkingLevel = restored.thinkingLevel;
-			initialThinkingSelection = restored.thinkingSelection;
-		}
-		if (!model) {
-			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
-		}
-	}
-
-	// If still no model, use findInitialModel (checks settings default, then provider defaults)
-	if (!model) {
-		const result = await findInitialModel({
-			scopedModels,
-			isContinuing: hasExistingSession,
-			defaultProvider: settingsManager.getDefaultProvider(),
-			defaultModelId: settingsManager.getDefaultModel(),
-			defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),
-			modelThinkingLevels: settingsManager.getAllModelThinkingLevels(),
-			modelRuntime,
-		});
-		model = result.model;
-		initialModelProvenance = result.provenance;
-		const selectedModel = model;
-		const scopedSelection = selectedModel
-			? scopedModels.find(
-					(entry) => entry.model.provider === selectedModel.provider && entry.model.id === selectedModel.id,
-				)
-			: undefined;
-		initialResolvedThinkingLevel = scopedSelection?.thinkingLevel ?? result.thinkingLevel;
-		initialThinkingSelection = scopedSelection?.thinkingSelection ?? result.thinkingSelection;
-		if (!model) {
-			modelFallbackMessage = formatNoModelsAvailableMessage();
-		} else if (modelFallbackMessage) {
-			modelFallbackMessage += `. Using ${model.provider}/${model.id}`;
-		}
-	}
-
+	const {
+		model,
+		initialModelProvenance,
+		initialResolvedThinkingLevel,
+		initialThinkingSelection,
+		modelFallbackMessage,
+	} = await resolveInitialSessionModel(options, existingSession, modelRuntime, settingsManager, scopedModels);
 	let thinkingLevel = options.thinkingLevel ?? initialResolvedThinkingLevel;
 	let thinkingSelection =
 		options.thinkingSelection ??
@@ -541,11 +625,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const liveContextTokens = hasExistingSession
 		? existingSession.messages.reduce((total, message) => total + estimateTokens(message), 0)
 		: 0;
-	session.assertModelUsable(
-		undefined,
-		liveContextTokens,
-		hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
-	);
+	try {
+		session.assertModelUsable(
+			undefined,
+			liveContextTokens,
+			hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
+		);
+	} catch (error) {
+		// Construction has already subscribed to agent/settings events and built
+		// an extension runner, but this rejected session will never be returned.
+		session.dispose({ skipProviderResourceCleanup: true });
+		throw error;
+	}
 	sessionRef.current = session;
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -6,7 +6,7 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { type ImageContent, modelsAreEqual } from "@earendil-works/pi-ai";
 import { setCapabilityOverrides } from "@earendil-works/pi-tui";
@@ -43,7 +43,11 @@ import {
 } from "./cli/startup-loading-indicator.ts";
 import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
 import { APP_NAME, DISPLAY_VERSION, ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir } from "./config.ts";
-import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
+import {
+	type AgentSessionRuntimeTarget,
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionRuntime,
+} from "./core/agent-session-runtime.ts";
 import {
 	type AgentSessionRuntimeDiagnostic,
 	createAgentSessionFromServices,
@@ -63,9 +67,10 @@ import {
 	type ScopedModel,
 } from "./core/model-resolver.ts";
 import { ModelRuntime } from "./core/model-runtime.ts";
+import { InMemoryCodingAgentModelsStore } from "./core/models-store.ts";
 import { restoreStdout, takeOverStdout } from "./core/output-guard.ts";
 import { type AppMode, resolveProjectTrusted } from "./core/project-trust.ts";
-import type { CreateAgentSessionOptions } from "./core/sdk.ts";
+import { assertConfiguredSessionResumeUsable, type CreateAgentSessionOptions } from "./core/sdk.ts";
 import {
 	formatMissingSessionCwdPrompt,
 	getMissingSessionCwdIssue,
@@ -657,6 +662,54 @@ function buildSessionOptions(
 	return { options, cliThinkingFromModel, diagnostics };
 }
 
+/** Read-only configured-catalog lower bound; never loads extension factories. */
+export async function prepareConfiguredSessionResume(
+	parsed: Args,
+	target: AgentSessionRuntimeTarget,
+	projectTrusted: boolean,
+	activeModelRuntime?: ModelRuntime,
+): Promise<void> {
+	const settingsManager = SettingsManager.create(target.cwd, target.agentDir, { projectTrusted });
+	const modelRuntime = await ModelRuntime.create({
+		credentials: new ReadOnlyAuthStorage(join(target.agentDir, "auth.json")),
+		modelsPath: join(target.agentDir, "models.json"),
+		modelsStore: new InMemoryCodingAgentModelsStore(),
+		allowModelNetwork: false,
+		signal: AbortSignal.timeout(15_000),
+	});
+	const patterns = getModelNarrowingPatterns({
+		cliPatterns: parsed.models,
+		legacyEnabledPatterns: settingsManager.getEnabledModels(),
+	});
+	const scopedModels = patterns?.length
+		? await resolveModelScope(patterns, modelRuntime, { signal: AbortSignal.timeout(15_000) })
+		: [];
+	const { options, diagnostics } = buildSessionOptions(
+		parsed,
+		scopedModels,
+		target.sessionManager.hasContextMessages(),
+		modelRuntime,
+		settingsManager,
+	);
+	// Extensions may supply a CLI selector missing from the configured catalog.
+	if (diagnostics.some((diagnostic) => diagnostic.type === "error")) return;
+	if (parsed.apiKey && options.model) await modelRuntime.setRuntimeApiKey(options.model.provider, parsed.apiKey);
+	await assertConfiguredSessionResumeUsable(
+		options,
+		target.sessionManager,
+		modelRuntime,
+		settingsManager,
+		scopedModels,
+		(model) => {
+			if (!activeModelRuntime) return true;
+			// Cached catalog data or an extension can override any configured id.
+			// Only corroborated budget geometry is safe to project without reloading it.
+			const effective = activeModelRuntime.getModel(model.provider, model.id);
+			return effective?.contextWindow === model.contextWindow && effective.maxTokens === model.maxTokens;
+		},
+	);
+}
+
 function resolveCliPaths(cwd: string, paths: string[] | undefined): string[] | undefined {
 	return paths?.map((value) => (isLocalPath(value) ? resolvePath(value, cwd) : value));
 }
@@ -936,6 +989,21 @@ export async function main(args: string[], options?: MainOptions) {
 		startupLoadingIndicator.setPhase("extensions & models");
 	}
 
+	const getRuntimeArgs = (launchProfile: AgentSessionRuntimeTarget["launchProfile"]): Args =>
+		launchProfile === undefined
+			? parsed
+			: {
+					...parsed,
+					...(launchProfile.creationModel === undefined
+						? {}
+						: {
+								provider: launchProfile.creationModel.provider,
+								model: launchProfile.creationModel.modelId,
+							}),
+					...(launchProfile.initialThinkingLevel === undefined
+						? {}
+						: { thinking: launchProfile.initialThinkingLevel as Args["thinking"] }),
+				};
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 		cwd,
 		agentDir,
@@ -1023,21 +1091,7 @@ export async function main(args: string[], options?: MainOptions) {
 		// Multi-session opens carry their per-session startup choices here rather
 		// than through process argv. This deliberately feeds the same resolver as
 		// --provider/--model/--thinking, preserving classic flag semantics.
-		const runtimeParsed: Args =
-			launchProfile === undefined
-				? parsed
-				: {
-						...parsed,
-						...(launchProfile.creationModel === undefined
-							? {}
-							: {
-									provider: launchProfile.creationModel.provider,
-									model: launchProfile.creationModel.modelId,
-								}),
-						...(launchProfile.initialThinkingLevel === undefined
-							? {}
-							: { thinking: launchProfile.initialThinkingLevel as Args["thinking"] }),
-					};
+		const runtimeParsed = getRuntimeArgs(launchProfile);
 		const {
 			options: sessionOptions,
 			cliThinkingFromModel,
@@ -1122,6 +1176,23 @@ export async function main(args: string[], options?: MainOptions) {
 		startupLoadingIndicator.stop();
 	});
 	time("createAgentSessionRuntime");
+	createRuntime.prepareResume = async (target) => {
+		// Different cwd can discover different extension model overrides.
+		if (target.cwd !== runtime.cwd) return;
+		const cachedTrust = projectTrustByCwd.get(target.cwd);
+		const hasProjectResources = hasTrustRequiringProjectResources(target.cwd);
+		// A trust prompt can change project settings. Leave that uncertain target
+		// to the existing full creation path rather than project the wrong config.
+		if (parsed.projectTrustOverride === undefined && cachedTrust === undefined && hasProjectResources) return;
+		const trusted =
+			cachedTrust ?? parsed.projectTrustOverride ?? (!hasProjectResources || trustStore.get(target.cwd) === true);
+		await prepareConfiguredSessionResume(
+			getRuntimeArgs(target.launchProfile),
+			target,
+			trusted,
+			runtime.services.modelRuntime,
+		);
+	};
 	let selectedRuntime = runtime;
 	if (isTruthyEnvFlag(envValue("DISABLE_SHARED_HOST"))) {
 		console.error(

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-08 - Render resume preparation failures without exiting the TUI
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: render read-only preflight `SessionResumePreparationError` as a nonfatal error and leave the current session active. Budget rejection includes the original projection and guidance to open the saved session separately with a larger-context model and compact it. The missing-cwd retry goes through the same error handling, while failures after preparation still use the fatal path.
+
+### Why
+
+- Selecting an oversized saved session previously called `process.exit(1)` before the error could render, even though rejecting the target should not terminate the user's current session.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` owns the resume selector callback and fatal-error dispatch; extensions cannot replace that host control flow.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/interactive/interactive-mode.ts` imports and `handleResumeSession`.
+
 
 ## 2026-09-08 - Shortcut context exposes the effective service tier
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -64,7 +64,11 @@ import {
 	VERSION,
 } from "../../config.ts";
 import { type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
-import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
+import {
+	type AgentSessionRuntime,
+	SessionImportFileNotFoundError,
+	SessionResumePreparationError,
+} from "../../core/agent-session-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import { envValue } from "../../core/brand.ts";
 import {
@@ -74,6 +78,7 @@ import {
 	computeCacheWaste,
 	detectCacheMiss,
 } from "../../core/cache-stats.ts";
+import { ModelUsabilityBudgetError } from "../../core/extensions/builtin/compaction/model-usability-budget.ts";
 import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
@@ -7550,32 +7555,40 @@ export class InteractiveMode {
 	): Promise<{ cancelled: boolean }> {
 		this.clearStatusIndicator();
 		try {
-			const result = await this.runtimeHost.switchSession(sessionPath, {
-				withSession: options?.withSession,
-				projectTrustContextFactory: (cwd) => this.createProjectTrustContext(cwd),
-			});
-			if (result.cancelled) {
-				return result;
-			}
-			this.showStatus("Resumed session");
-			return result;
-		} catch (error: unknown) {
-			if (error instanceof MissingSessionCwdError) {
-				const selectedCwd = await this.promptForMissingSessionCwd(error);
+			let result: { cancelled: boolean };
+			let selectedCwd: string | undefined;
+			try {
+				result = await this.runtimeHost.switchSession(sessionPath, {
+					withSession: options?.withSession,
+					projectTrustContextFactory: (cwd) => this.createProjectTrustContext(cwd),
+				});
+			} catch (error) {
+				if (!(error instanceof MissingSessionCwdError)) throw error;
+				selectedCwd = await this.promptForMissingSessionCwd(error);
 				if (!selectedCwd) {
 					this.showStatus("Resume cancelled");
 					return { cancelled: true };
 				}
-				const result = await this.runtimeHost.switchSession(sessionPath, {
+				result = await this.runtimeHost.switchSession(sessionPath, {
 					cwdOverride: selectedCwd,
 					withSession: options?.withSession,
 					projectTrustContextFactory: (cwd) => this.createProjectTrustContext(cwd),
 				});
-				if (result.cancelled) {
-					return result;
-				}
-				this.showStatus("Resumed session in current cwd");
-				return result;
+			}
+			if (!result.cancelled) {
+				this.showStatus(selectedCwd ? "Resumed session in current cwd" : "Resumed session");
+			}
+			return result;
+		} catch (error: unknown) {
+			if (error instanceof SessionResumePreparationError) {
+				const recovery =
+					error.cause instanceof ModelUsabilityBudgetError
+						? " Open the saved session separately with --session <path> --model <larger-context-model>, then compact it before retrying here."
+						: " Fix the target session's setup and retry, or select another session.";
+				this.showError(
+					`Failed to resume session: ${error.message} Your current session is still active.${recovery}`,
+				);
+				return { cancelled: true };
 			}
 			return this.handleFatalRuntimeError("Failed to resume session", error);
 		}

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -1,16 +1,23 @@
-import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, parse } from "node:path";
+import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../../src/core/agent-session.ts";
 import {
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionFromServices,
 	createAgentSessionRuntime,
 	createAgentSessionServices,
+	SessionResumePreparationError,
 } from "../../src/core/agent-session-runtime.ts";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { ModelUsabilityBudgetError } from "../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import { getMcpService } from "../../src/core/extensions/builtin/mcp/service.ts";
+import { getToolSearchService } from "../../src/core/extensions/builtin/tool-search/service.ts";
+import { assertConfiguredSessionResumeUsable } from "../../src/core/sdk.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import type {
 	AgentToolResult,
@@ -32,6 +39,7 @@ describe("AgentSessionRuntime characterization", () => {
 	const cleanups: Array<() => Promise<void> | void> = [];
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		while (cleanups.length > 0) {
 			await cleanups.pop()?.();
 		}
@@ -39,7 +47,12 @@ describe("AgentSessionRuntime characterization", () => {
 
 	async function createRuntimeForTest(
 		extensionFactory: ExtensionFactory,
-		options?: { cwd?: string; bootstrapModel?: boolean; bootstrapThinkingLevel?: boolean },
+		options?: {
+			cwd?: string;
+			bootstrapModel?: boolean;
+			bootstrapThinkingLevel?: boolean;
+			beforePrepare?: () => Promise<void>;
+		},
 	) {
 		const tempDir =
 			options?.cwd ?? join(tmpdir(), `pi-runtime-suite-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -109,6 +122,16 @@ describe("AgentSessionRuntime characterization", () => {
 			agentDir: tempDir,
 			sessionManager: SessionManager.create(tempDir),
 		});
+		createRuntime.prepareResume = async ({ sessionManager }) => {
+			await options?.beforePrepare?.();
+			await assertConfiguredSessionResumeUsable(
+				{ model: runtimeOptions.model },
+				sessionManager,
+				runtime.services.modelRuntime,
+				runtime.services.settingsManager,
+				[],
+			);
+		};
 		await runtime.session.bindExtensions({});
 
 		cleanups.push(async () => {
@@ -121,6 +144,216 @@ describe("AgentSessionRuntime characterization", () => {
 
 		return { runtime, faux, tempDir };
 	}
+
+	it("keeps the real builtin runtime usable when read-only resume admission rejects before candidate construction", async () => {
+		const events: RecordedSessionEvent[] = [];
+		const { runtime, faux, tempDir } = await createRuntimeForTest((pi) => {
+			pi.on("session_before_switch", (event) => {
+				events.push(event);
+			});
+			pi.on("session_shutdown", (event) => {
+				events.push(event);
+			});
+			pi.on("session_start", (event) => {
+				events.push(event);
+			});
+		});
+		await runtime.session.prompt("current session");
+		const oldSession = runtime.session;
+		const oldServices = runtime.services;
+		const oldContext = oldSession.extensionRunner.createContext();
+		// The real DefaultResourceLoader includes these builtins; a plain prompt
+		// can otherwise succeed while extension errors are swallowed by the runner.
+		expect(oldSession.extensionRunner.getExtensionIdentities().map((extension) => extension.path)).toEqual(
+			expect.arrayContaining(["<builtin:tool-search>", "<builtin:mcp>"]),
+		);
+		const extensionErrors = vi.fn();
+		oldSession.extensionRunner.onError(extensionErrors);
+		const oldToolSearch = getToolSearchService();
+		const mcpSubscribe = vi.spyOn(getMcpService(), "onWireStatusChanged");
+		const oldMessages = [...oldSession.messages];
+		const oldFile = readFileSync(oldSession.sessionFile!, "utf8");
+		const target = SessionManager.create(tempDir, join(tempDir, "sessions"));
+		target.appendModelChange(faux.getModel().provider, faux.getModel().id);
+		target.appendThinkingLevelChange("off");
+		target.appendMessage({
+			role: "user",
+			content: "x".repeat(faux.getModel().contextWindow * 4),
+			timestamp: Date.now(),
+		});
+		target.appendMessage(fauxAssistantMessage("saved response"));
+		const targetFile = target.getSessionFile()!;
+		const targetContents = readFileSync(targetFile, "utf8");
+		const dispose = vi.spyOn(AgentSession.prototype, "dispose");
+		const abort = vi.spyOn(oldSession, "abort");
+		const invalidate = vi.spyOn(oldSession.extensionRunner, "invalidate");
+		const beforeInvalidate = vi.fn();
+		const rebind = vi.fn(async () => {});
+		runtime.setBeforeSessionInvalidate(beforeInvalidate);
+		runtime.setRebindSession(rebind);
+		events.length = 0;
+
+		const error = await runtime.switchSession(targetFile).catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(SessionResumePreparationError);
+		if (!(error instanceof SessionResumePreparationError)) throw new Error("expected preparation failure");
+		expect(error.cause).toBeInstanceOf(ModelUsabilityBudgetError);
+		expect(error.cause).toMatchObject({
+			projection: { admission: "resume", usable: false, speculationLeadTokens: 0 },
+		});
+		expect(events).toEqual([{ type: "session_before_switch", reason: "resume", targetSessionFile: targetFile }]);
+		expect(abort).not.toHaveBeenCalled();
+		expect(invalidate).not.toHaveBeenCalled();
+		expect(beforeInvalidate).not.toHaveBeenCalled();
+		expect(rebind).not.toHaveBeenCalled();
+		expect(dispose).not.toHaveBeenCalled();
+		expect(runtime.session).toBe(oldSession);
+		expect(runtime.services).toBe(oldServices);
+		expect(oldContext.cwd).toBe(oldServices.cwd);
+		expect(oldSession.messages).toEqual(oldMessages);
+		expect(readFileSync(oldSession.sessionFile!, "utf8")).toBe(oldFile);
+		expect(readFileSync(targetFile, "utf8")).toBe(targetContents);
+		expect(getToolSearchService()).toBe(oldToolSearch);
+		expect(() => oldToolSearch.getCatalog()).not.toThrow();
+		expect(mcpSubscribe).not.toHaveBeenCalled();
+
+		const observed: string[] = [];
+		oldSession.subscribe((event) => {
+			observed.push(event.type);
+		});
+		await oldSession.prompt("still usable");
+		expect(observed).toContain("message_end");
+		expect(extensionErrors).not.toHaveBeenCalled();
+		expect(oldSession.messages.at(-1)).toMatchObject({ role: "assistant", content: [{ type: "text", text: "two" }] });
+		expect(SessionManager.open(oldSession.sessionFile!).buildSessionContext().messages).toEqual(oldSession.messages);
+	});
+
+	it("does not clean up provider resources owned by the same saved session when an unbound candidate is rejected", async () => {
+		const { runtime, faux } = await createRuntimeForTest(() => {});
+		await runtime.session.prompt("saved current session");
+		const oldSession = runtime.session;
+		// Simulate disk history exceeding current admission without changing the
+		// live runtime's already-loaded branch or invoking a real provider.
+		const diskSession = SessionManager.open(oldSession.sessionFile!);
+		diskSession.appendMessage({
+			role: "user",
+			content: "x".repeat(faux.getModel().contextWindow * 4),
+			timestamp: Date.now(),
+		});
+		const cleanupResources = vi.fn();
+		const unregister = registerSessionResourceCleanup(cleanupResources);
+		try {
+			await expect(runtime.switchSession(oldSession.sessionFile!)).rejects.toBeInstanceOf(
+				SessionResumePreparationError,
+			);
+			expect(cleanupResources).not.toHaveBeenCalled();
+			expect(runtime.session).toBe(oldSession);
+			await oldSession.prompt("still active");
+			expect(cleanupResources).not.toHaveBeenCalled();
+		} finally {
+			unregister();
+		}
+	});
+
+	it("keeps the current session alive while asynchronous target preparation fails", async () => {
+		const preparing = Promise.withResolvers<void>();
+		const preparation = Promise.withResolvers<void>();
+		let rejectPreparation = false;
+		const shutdown = vi.fn();
+		const { runtime } = await createRuntimeForTest(
+			(pi) => {
+				pi.on("session_shutdown", shutdown);
+			},
+			{
+				beforePrepare: async () => {
+					if (!rejectPreparation) return;
+					preparing.resolve();
+					await preparation.promise;
+				},
+			},
+		);
+		await runtime.session.prompt("target");
+		const target = runtime.session.sessionFile!;
+		await runtime.newSession();
+		await runtime.session.bindExtensions({});
+		const oldSession = runtime.session;
+		const abort = vi.spyOn(oldSession, "abort");
+		const invalidate = vi.fn();
+		runtime.setBeforeSessionInvalidate(invalidate);
+		shutdown.mockClear();
+		rejectPreparation = true;
+		const error = new Error("target services unavailable");
+		const switchPromise = runtime.switchSession(target);
+		const rejected = expect(switchPromise).rejects.toMatchObject({
+			name: "SessionResumePreparationError",
+			cause: error,
+		});
+		await preparing.promise;
+		expect(runtime.session).toBe(oldSession);
+		expect(oldSession.extensionRunner.isActive).toBe(true);
+		await oldSession.prompt("works during preparation");
+		preparation.reject(error);
+		await rejected;
+		expect(runtime.session).toBe(oldSession);
+		expect(abort).not.toHaveBeenCalled();
+		expect(shutdown).not.toHaveBeenCalled();
+		expect(invalidate).not.toHaveBeenCalled();
+	});
+
+	it("does not construct a candidate if outgoing teardown fails after read-only admission", async () => {
+		const { runtime } = await createRuntimeForTest(() => {});
+		await runtime.session.prompt("target");
+		const target = runtime.session.sessionFile!;
+		await runtime.newSession();
+		const oldSession = runtime.session;
+		const error = new Error("outgoing abort failed");
+		vi.spyOn(oldSession, "abort").mockRejectedValueOnce(error);
+		const dispose = vi.spyOn(AgentSession.prototype, "dispose");
+
+		await expect(runtime.switchSession(target)).rejects.toBe(error);
+
+		expect(dispose).not.toHaveBeenCalled();
+		expect(runtime.session).toBe(oldSession);
+	});
+
+	it("preserves shutdown, invalidation, rebind/start, and withSession ordering on successful resume", async () => {
+		const phases: string[] = [];
+		const { runtime } = await createRuntimeForTest((pi) => {
+			pi.on("session_before_switch", () => {
+				phases.push("before");
+			});
+			pi.on("session_shutdown", () => {
+				phases.push("shutdown");
+			});
+			pi.on("session_start", () => {
+				phases.push("start");
+			});
+		});
+		await runtime.session.prompt("target");
+		const target = runtime.session.sessionFile!;
+		await runtime.newSession();
+		await runtime.session.bindExtensions({});
+		const oldSession = runtime.session;
+		runtime.setBeforeSessionInvalidate(() => {
+			phases.push("invalidate");
+			expect(oldSession.extensionRunner.isActive).toBe(true);
+		});
+		runtime.setRebindSession(async (session) => {
+			phases.push("rebind");
+			expect(oldSession.extensionRunner.isActive).toBe(false);
+			await session.bindExtensions({});
+		});
+		phases.length = 0;
+
+		await runtime.switchSession(target, {
+			withSession: async () => {
+				phases.push("withSession");
+			},
+		});
+
+		expect(phases).toEqual(["before", "shutdown", "invalidate", "rebind", "start", "withSession"]);
+		runtime.setBeforeSessionInvalidate(undefined);
+	});
 
 	it("persists message_end assistant replacements to the session manager", async () => {
 		const { runtime } = await createRuntimeForTest((pi: ExtensionAPI) => {

--- a/packages/coding-agent/test/suite/configured-resume-preflight.test.ts
+++ b/packages/coding-agent/test/suite/configured-resume-preflight.test.ts
@@ -1,0 +1,241 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseArgs } from "../../src/cli/args.ts";
+import { AgentSession } from "../../src/core/agent-session.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { InMemoryCodingAgentModelsStore } from "../../src/core/models-store.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { assertConfiguredSessionResumeUsable, createAgentSession } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { prepareConfiguredSessionResume } from "../../src/main.ts";
+
+const dirs: string[] = [];
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function fixture(storedModel: string | undefined = "small", defaultModel = "large") {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-resume-preflight-"));
+	dirs.push(dir);
+	const models = [
+		{ id: "small", name: "Small", contextWindow: 600_000, maxTokens: 4_000 },
+		{ id: "large", name: "Large", contextWindow: 1_050_000, maxTokens: 4_000 },
+	].map((model) => ({
+		...model,
+		reasoning: false,
+		input: ["text" as const],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	}));
+	writeFileSync(
+		join(dir, "models.json"),
+		JSON.stringify({
+			providers: {
+				fixture: {
+					api: "openai-completions",
+					baseUrl: "https://invalid.invalid",
+					apiKey: "fixture-not-real",
+					models,
+				},
+			},
+		}),
+	);
+	writeFileSync(join(dir, "settings.json"), JSON.stringify({ defaultProvider: "fixture", defaultModel }));
+	const sessionManager = SessionManager.inMemory(dir);
+	if (storedModel) sessionManager.appendModelChange("fixture", storedModel);
+	sessionManager.appendMessage({ role: "user", content: "x".repeat(600_585), timestamp: 1 });
+	return { dir, target: { cwd: dir, agentDir: dir, sessionManager }, models };
+}
+
+describe("configured resume read-only admission", () => {
+	it("installs classic preflight only after the initial runtime exists and multi-session dispatch has returned", () => {
+		const source = readFileSync(new URL("../../src/main.ts", import.meta.url), "utf8");
+		const dispatch = source.indexOf("await runMultiSessionHost({");
+		const creation = source.indexOf("const runtime = await createAgentSessionRuntime(createRuntime,");
+		const install = source.indexOf("createRuntime.prepareResume =");
+		expect(dispatch).toBeGreaterThan(0);
+		expect(creation).toBeGreaterThan(dispatch);
+		expect(install).toBeGreaterThan(creation);
+		expect(source.match(/createRuntime\.prepareResume =/g)).toHaveLength(1);
+	});
+
+	it("disposes an SDK admission rejection without cleaning provider resources or masking its budget error", async () => {
+		const { dir, target } = fixture();
+		const modelRuntime = await ModelRuntime.create({
+			modelsPath: join(dir, "models.json"),
+			modelsStore: new InMemoryCodingAgentModelsStore(),
+		});
+		const dispose = vi.spyOn(AgentSession.prototype, "dispose");
+		const cleanup = vi.fn(() => {
+			throw new Error("provider resources still owned by another runtime");
+		});
+		const unregister = registerSessionResourceCleanup(cleanup);
+		try {
+			await expect(
+				createAgentSession({ cwd: dir, agentDir: dir, modelRuntime, sessionManager: target.sessionManager }),
+			).rejects.toMatchObject({
+				name: "ModelUsabilityBudgetError",
+				projection: { admission: "resume", usable: false },
+			});
+			expect(dispose).toHaveBeenCalledExactlyOnceWith({ skipProviderResourceCleanup: true });
+			expect(cleanup).not.toHaveBeenCalled();
+			const rejected = dispose.mock.contexts[0];
+			if (!(rejected instanceof AgentSession)) throw new Error("missing rejected candidate");
+			expect(rejected.extensionRunner.isActive).toBe(false);
+		} finally {
+			unregister();
+		}
+	});
+
+	it("rejects the stored model before resource loading without changing files or session entries", async () => {
+		const { dir, target } = fixture();
+		const beforeFiles = new Map(readdirSync(dir).map((file) => [file, readFileSync(join(dir, file), "utf8")]));
+		const beforeEntries = [...target.sessionManager.getEntries()];
+		const reload = vi.spyOn(DefaultResourceLoader.prototype, "reload");
+		const dispose = vi.spyOn(AgentSession.prototype, "dispose");
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true)).rejects.toMatchObject({
+			name: "ModelUsabilityBudgetError",
+			projection: {
+				model: "fixture/small",
+				contextWindow: 600_000,
+				liveContextTokens: 600_585,
+				admission: "resume",
+				systemPromptTokens: 0,
+				activeToolSchemaTokens: 0,
+				speculationLeadTokens: 0,
+			},
+		});
+		expect(reload).not.toHaveBeenCalled();
+		expect(dispose).not.toHaveBeenCalled();
+		expect(target.sessionManager.getEntries()).toEqual(beforeEntries);
+		expect(new Map(readdirSync(dir).map((file) => [file, readFileSync(join(dir, file), "utf8")]))).toEqual(
+			beforeFiles,
+		);
+	});
+
+	it.each([
+		["--model", "fixture/large"],
+		["--provider", "fixture", "--model", "large"],
+	])("honors an explicit larger-context model override: %j", async (...args) => {
+		const { target } = fixture();
+		await expect(prepareConfiguredSessionResume(parseArgs(args), target, true)).resolves.toBeUndefined();
+	});
+
+	it("uses the configured default only when the saved session has no model", async () => {
+		const { target } = fixture("", "small");
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true)).rejects.toMatchObject({
+			projection: { model: "fixture/small" },
+		});
+	});
+
+	it("does not substitute a scoped model for the restored model during resume", async () => {
+		const { target } = fixture();
+		await expect(
+			prepareConfiguredSessionResume(parseArgs(["--models", "fixture/large"]), target, true),
+		).rejects.toMatchObject({
+			projection: { model: "fixture/small" },
+		});
+	});
+
+	it("defers unresolved stored models instead of rejecting their speculative fallback", async () => {
+		const { target } = fixture("extension-only", "small");
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true)).resolves.toBeUndefined();
+	});
+
+	it("defers synthetic CLI models whose configured budget is unknown", async () => {
+		const { target } = fixture();
+		await expect(
+			prepareConfiguredSessionResume(
+				parseArgs(["--provider", "fixture", "--model", "extension-only"]),
+				target,
+				true,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("defers same-id cached geometry mismatches even without extension registrations", async () => {
+		const { dir, target } = fixture();
+		const active = await ModelRuntime.create({
+			modelsPath: join(dir, "models.json"),
+			modelsStore: new InMemoryCodingAgentModelsStore(),
+		});
+		expect(active.getRegisteredProviderIds()).toEqual([]);
+		const original = active.getModel.bind(active);
+		vi.spyOn(active, "getModel").mockImplementation((provider, id) => {
+			const model = original(provider, id);
+			return model ? { ...model, contextWindow: 1_050_000 } : undefined;
+		});
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true, active)).resolves.toBeUndefined();
+	});
+
+	it.each([0, -1])(
+		"defers unknown/nonpositive context limits like final SDK admission (%s)",
+		async (contextWindow) => {
+			const { dir, target } = fixture();
+			const runtime = await ModelRuntime.create({
+				modelsPath: join(dir, "models.json"),
+				modelsStore: new InMemoryCodingAgentModelsStore(),
+			});
+			const configured = runtime.getModel("fixture", "small");
+			if (!configured) throw new Error("missing configured model");
+			await expect(
+				assertConfiguredSessionResumeUsable(
+					{ model: { ...configured, contextWindow } },
+					target.sessionManager,
+					runtime,
+					SettingsManager.create(dir, dir),
+					[],
+				),
+			).resolves.toBeUndefined();
+		},
+	);
+
+	it("defers speculative fallback when the saved session has no model and an extension may supply the default", async () => {
+		const { target } = fixture("", "extension-only");
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true)).resolves.toBeUndefined();
+	});
+
+	it("does not reject a configured id whose active extension overrides its budget", async () => {
+		const { dir, target, models } = fixture();
+		const active = await ModelRuntime.create({
+			modelsPath: join(dir, "models.json"),
+			modelsStore: new InMemoryCodingAgentModelsStore(),
+		});
+		active.registerProvider(
+			"fixture",
+			{
+				api: "openai-completions",
+				baseUrl: "https://invalid.invalid",
+				apiKey: "fixture-not-real",
+				models: models.map((model) => ({ ...model, contextWindow: 1_050_000 })),
+			},
+			{ refresh: false },
+		);
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true, active)).resolves.toBeUndefined();
+	});
+
+	it("rejects when the active extension corroborates the configured budget", async () => {
+		const { dir, target, models } = fixture();
+		const active = await ModelRuntime.create({
+			modelsPath: join(dir, "models.json"),
+			modelsStore: new InMemoryCodingAgentModelsStore(),
+		});
+		active.registerProvider(
+			"fixture",
+			{
+				api: "openai-completions",
+				baseUrl: "https://invalid.invalid",
+				apiKey: "fixture-not-real",
+				models,
+			},
+			{ refresh: false },
+		);
+		await expect(prepareConfiguredSessionResume(parseArgs([]), target, true, active)).rejects.toMatchObject({
+			projection: { model: "fixture/small", contextWindow: 600_000 },
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/interactive-resume-session.test.ts
+++ b/packages/coding-agent/test/suite/interactive-resume-session.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { type AgentSessionRuntime, SessionResumePreparationError } from "../../src/core/agent-session-runtime.ts";
+import { ModelUsabilityBudgetError } from "../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import type { ExtensionCommandContext, ProjectTrustContext } from "../../src/core/extensions/index.ts";
+import { MissingSessionCwdError } from "../../src/core/session-cwd.ts";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
+
+type ResumeContext = {
+	clearStatusIndicator: () => void;
+	runtimeHost: Pick<AgentSessionRuntime, "switchSession">;
+	createProjectTrustContext: (cwd: string) => ProjectTrustContext;
+	promptForMissingSessionCwd: (error: MissingSessionCwdError) => Promise<string | undefined>;
+	showError: (message: string) => void;
+	showStatus: (message: string) => void;
+	handleFatalRuntimeError: (prefix: string, error: unknown) => Promise<never>;
+};
+
+const handleResumeSession = Object.getOwnPropertyDescriptor(InteractiveMode.prototype, "handleResumeSession")!
+	.value as (
+	this: ResumeContext,
+	sessionPath: string,
+	options?: Parameters<ExtensionCommandContext["switchSession"]>[1],
+) => Promise<{ cancelled: boolean }>;
+
+function createContext() {
+	return {
+		clearStatusIndicator: vi.fn(),
+		runtimeHost: { switchSession: vi.fn<AgentSessionRuntime["switchSession"]>() },
+		createProjectTrustContext: vi.fn<ResumeContext["createProjectTrustContext"]>(),
+		promptForMissingSessionCwd: vi.fn<ResumeContext["promptForMissingSessionCwd"]>(),
+		showError: vi.fn(),
+		showStatus: vi.fn(),
+		handleFatalRuntimeError: vi.fn<ResumeContext["handleFatalRuntimeError"]>(async (_prefix, error) => {
+			throw error;
+		}),
+	};
+}
+
+function budgetError() {
+	return new ModelUsabilityBudgetError({
+		model: "test/model",
+		contextWindow: 600_000,
+		liveContextTokens: 600_585,
+		systemPromptTokens: 2_000,
+		activeToolSchemaTokens: 1_000,
+		outputReserveTokens: 16_000,
+		compactionReserveTokens: 0,
+		speculationLeadTokens: 0,
+		safetyMarginTokens: 8_192,
+		safetyMarginProfile: "default",
+		requiredTokens: 627_777,
+		shortfallTokens: 27_777,
+		usable: false,
+		admission: "resume",
+	});
+}
+
+const missingCwd = new MissingSessionCwdError({
+	sessionFile: "/saved.jsonl",
+	sessionCwd: "/missing",
+	fallbackCwd: "/current",
+});
+
+describe("interactive resume preparation failures", () => {
+	it.each([false, true])("shows a nonfatal, actionable budget error (cwd retry: %s)", async (retryCwd) => {
+		const context = createContext();
+		const error = new SessionResumePreparationError(budgetError());
+		if (retryCwd) {
+			context.runtimeHost.switchSession.mockRejectedValueOnce(missingCwd);
+			context.promptForMissingSessionCwd.mockResolvedValue("/current");
+		}
+		context.runtimeHost.switchSession.mockRejectedValueOnce(error);
+
+		await expect(handleResumeSession.call(context, "/saved.jsonl")).resolves.toEqual({ cancelled: true });
+
+		expect(context.showError).toHaveBeenCalledExactlyOnceWith(expect.stringContaining(error.message));
+		expect(context.showError).toHaveBeenCalledWith(expect.stringContaining("Your current session is still active"));
+		expect(context.showError).toHaveBeenCalledWith(
+			expect.stringContaining("--session <path> --model <larger-context-model>"),
+		);
+		expect(context.showStatus).not.toHaveBeenCalled();
+		expect(context.handleFatalRuntimeError).not.toHaveBeenCalled();
+		expect(context.runtimeHost.switchSession).toHaveBeenCalledTimes(retryCwd ? 2 : 1);
+	});
+
+	it("keeps generic target setup failures nonfatal", async () => {
+		const context = createContext();
+		context.runtimeHost.switchSession.mockRejectedValue(new SessionResumePreparationError(new Error("setup failed")));
+		await expect(handleResumeSession.call(context, "/saved.jsonl")).resolves.toEqual({ cancelled: true });
+		expect(context.showError).toHaveBeenCalledWith(
+			expect.stringContaining("Fix the target session's setup and retry"),
+		);
+		expect(context.handleFatalRuntimeError).not.toHaveBeenCalled();
+	});
+
+	it.each([false, true])(
+		"does not misclassify failures after preparation as safe (cwd retry: %s)",
+		async (retryCwd) => {
+			const context = createContext();
+			if (retryCwd) {
+				context.runtimeHost.switchSession.mockRejectedValueOnce(missingCwd);
+				context.promptForMissingSessionCwd.mockResolvedValue("/current");
+			}
+			const error = new Error("rebind failed");
+			context.runtimeHost.switchSession.mockRejectedValueOnce(error);
+			await expect(handleResumeSession.call(context, "/saved.jsonl")).rejects.toBe(error);
+			expect(context.handleFatalRuntimeError).toHaveBeenCalledExactlyOnceWith("Failed to resume session", error);
+			expect(context.showError).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([false, true])("preserves success feedback and withSession (cwd retry: %s)", async (retryCwd) => {
+		const context = createContext();
+		const withSession = vi.fn();
+		if (retryCwd) {
+			context.runtimeHost.switchSession.mockRejectedValueOnce(missingCwd);
+			context.promptForMissingSessionCwd.mockResolvedValue("/current");
+		}
+		context.runtimeHost.switchSession.mockResolvedValueOnce({ cancelled: false });
+		await expect(handleResumeSession.call(context, "/saved.jsonl", { withSession })).resolves.toEqual({
+			cancelled: false,
+		});
+		expect(context.runtimeHost.switchSession).toHaveBeenLastCalledWith(
+			"/saved.jsonl",
+			expect.objectContaining({ withSession }),
+		);
+		expect(context.showStatus).toHaveBeenCalledExactlyOnceWith(
+			retryCwd ? "Resumed session in current cwd" : "Resumed session",
+		);
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("preserves extension cancellation", async () => {
+		const context = createContext();
+		context.runtimeHost.switchSession.mockResolvedValue({ cancelled: true });
+		await expect(handleResumeSession.call(context, "/saved.jsonl")).resolves.toEqual({ cancelled: true });
+		expect(context.showStatus).not.toHaveBeenCalled();
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("cancels without a second switch if the cwd prompt is declined", async () => {
+		const context = createContext();
+		context.runtimeHost.switchSession.mockRejectedValueOnce(missingCwd);
+		context.promptForMissingSessionCwd.mockResolvedValue(undefined);
+		await expect(handleResumeSession.call(context, "/saved.jsonl")).resolves.toEqual({ cancelled: true });
+		expect(context.runtimeHost.switchSession).toHaveBeenCalledTimes(1);
+		expect(context.showStatus).toHaveBeenCalledExactlyOnceWith("Resume cancelled");
+		expect(context.handleFatalRuntimeError).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Add a narrow, read-only configured-model resume preflight for the classic TUI in the same working directory, before the current runtime is aborted, shut down, or invalidated.
- Reject only a corroborated configured model whose saved conversation already exceeds the lower-bound budget, using zero system-prompt/tool overhead and no speculation lead. A visible resume error leaves the old session available to answer.
- Preserve the final full SDK admission guard and dispose an unadmitted candidate without cleaning provider resources that may still belong to a live session.

## Scope

Uncertain model/auth/configuration selection, unresolved trust, cross-directory resumes, full-prompt-overhead-only failures, and extension-dependent cases defer to the existing full admission path. This is not blanket rollback for arbitrary session replacement failures and does not change the experimental shared-host recovery contract. No history is truncated or settings rewritten by the preflight.

## Validation

- Clean worktree with no local telemetry customizations: frozen Bun install with scripts ignored, workspace build, and root static check passed.
- Exact focused regression selection: **89 passed, 3 credential-gated skipped** across **12 passed files and 1 skipped file**.
- Existing SDK service-tier wire regressions: **5 passed**, confirming the upstream request-tier behavior survives the cherry-pick.
- Isolated mock-provider TUI QA on a copy of a saved conversation confirmed a visible resume failure, a successful response from the retained session, and no stale-context errors. A mock 1M-token budget opened the intact copy. No real provider calls were made, and the original history and user settings were left untouched. Private transcripts and QA artifacts are not included.

## Integration

Rebased the reviewed fix onto current upstream `main`, retaining its SDK `supportsServiceTier`/request-tier behavior and shared session reference. The tracker conflict keeps both the upstream entries and the new preflight entry. A narrow Unreleased changelog entry is being finalized before this draft is marked ready.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume of oversized saved sessions in the classic TUI so the current interactive session is not torn down and lost when the target's model budget doesn't fit. A read-only preflight now rejects a corroborated configured-model budget mismatch before any abort, shutdown, or invalidation, leaving the old session available to answer.

**Bug Fixes**

- Added a `prepareResume` hook on the runtime factory that runs after session file validation and before teardown, using the same CLI/launch-profile model selection as normal creation.
- Budgets project transcript tokens with zero prompt/tool overhead; only lower-bound mismatches corroborated by the active configured catalog reject. Different cwd, unresolved trust, and extension-dependent models still go through the existing full admission path.
- Rejected SDK candidates are disposed without cleaning provider resources that may belong to another live runtime.
- Resume preparation errors now render as nonfatal in interactive mode with recovery guidance; failures after preparation still use the fatal path.

<sup>Written for commit 23d7a83518bfe6a62f1dee022eca083c204bbcf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

