### PR TITLE
fix(coding-agent): warn for GPT-6 Astra high reasoning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- GPT-6 Astra variants now show the same high-reasoning warning as GPT-5.6 Sol at `xhigh` and `max` effort.
+
 - Sessions created without builtin extensions (SDK embedders, oh-my-openagent's in-process delegated children) now send the priority service tier of a `-fast` catalog model, a scoped `:priority` pin, or session fast mode on the wire; previously only the interactive service-tier extension's payload hook wrote `service_tier`, so a delegated task displayed a fast model but ran at the standard tier (code-yeongyu/oh-my-openagent#6795). Extensions can read the session's `effectiveServiceTier` from their context.
 
 - Foreground `bash` commands now run git with `GIT_EDITOR=true` and `GIT_TERMINAL_PROMPT=0`, so a `git commit` without `-m`, an interactive rebase, or a terminal credential prompt on the captured foreground PTY fails fast (`Aborting commit due to empty commit message` / `could not read Username`) instead of blocking the agent until the command timeout kills it. Background PTY sessions keep the user's real git settings.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,21 @@
+## GPT-6 Astra high-reasoning warning parity (2026-09-08)
+
+### What changed
+
+- `packages/coding-agent/src/core/high-reasoning-warning.ts`: include GPT-6 Astra variants in the existing Sol warning policy, retaining the xhigh/max threshold and shared warning content.
+
+### Why
+
+- Astra users need the same excessive-reasoning warning as Sol users at the same effort levels.
+
+### Why an extension could not handle it
+
+- The shared core predicate controls warning events for model and thinking-level changes across CLI surfaces.
+
+### Expected merge conflict zones
+
+- LOW: the model-id matcher in `packages/coding-agent/src/core/high-reasoning-warning.ts`.
+
 ## Goal backstop default is 270s (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -1,14 +1,12 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 
-// Matches only the gpt-5.x "sol" variants (gpt-5.6-sol, -sol-fast, -sol-pro and
-// provider-prefixed forms such as openai/ or openai.). The trailing negative
-// lookahead stops unrelated ids that merely continue with letters after "sol" —
-// notably upstage/solar-pro-3 — from matching.
-const SOL_MODEL_ID_PATTERN = /gpt-5(?:\.\d+)?-sol(?![a-z])/i;
+// Matches GPT-5.x Sol and GPT-6 Astra variants, including provider-prefixed
+// forms. The trailing lookahead excludes unrelated ids that continue with letters.
+const SENSITIVE_MODEL_ID_PATTERN = /(?:gpt-5(?:\.\d+)?-sol|gpt-6-astra)(?![a-z])/i;
 
 export function isSensitiveHighReasoningModel(model: Pick<Model<Api>, "id">): boolean {
-	return SOL_MODEL_ID_PATTERN.test(model.id);
+	return SENSITIVE_MODEL_ID_PATTERN.test(model.id);
 }
 
 export function shouldWarnHighReasoning(model: Pick<Model<Api>, "id">, thinkingLevel: ThinkingLevel): boolean {

--- a/packages/coding-agent/test/suite/astra-high-reasoning-warning.test.ts
+++ b/packages/coding-agent/test/suite/astra-high-reasoning-warning.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { shouldWarnHighReasoning } from "../../src/core/high-reasoning-warning.ts";
+
+const ASTRA_MODEL_IDS = [
+	"gpt-6-astra",
+	"gpt-6-astra-fast",
+	"gpt-6-astra-pro",
+	"openai/gpt-6-astra",
+	"openai.gpt-6-astra",
+	"openrouter/openai/gpt-6-astra-fast",
+	"GPT-6-ASTRA",
+] as const;
+
+const EFFORTS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+describe.each(ASTRA_MODEL_IDS)("Astra warning parity for %s", (id) => {
+	it.each(EFFORTS)("warns only above high when effort is %s", (effort) => {
+		// Given an Astra model variant and a selected effort.
+		const model = { id };
+		// When the existing warning policy is evaluated.
+		const warns = shouldWarnHighReasoning(model, effort);
+		// Then Astra uses the same effort threshold as Sol.
+		expect(warns).toBe(effort === "xhigh" || effort === "max");
+	});
+});
+
+describe("Astra warning negative controls", () => {
+	it.each(["gpt-6-astral", "gpt-6-astrafoo", "gpt-6", "gpt-6-luna", "gpt-5.6-astra", "upstage/solar-pro-3"])(
+		"does not warn for unrelated model %s",
+		(id) => {
+			// Given a model outside the existing Sol and requested Astra families.
+			const model = { id };
+			// When either warning-level effort is selected, then no warning is requested.
+			expect(shouldWarnHighReasoning(model, "xhigh")).toBe(false);
+			expect(shouldWarnHighReasoning(model, "max")).toBe(false);
+		},
+	);
+});


### PR DESCRIPTION
## Summary
- Extend the existing high-reasoning warning policy from Sol models to GPT-6 Astra.
- Preserve effort thresholds, suffix boundaries, warning content, event emission, and deduplication.
- Add deterministic Astra regression coverage plus the required fork tracker and changelog entries.

## Verification
- 121 targeted tests passed across five suites.
- Mutation run reproduced the expected 14 Astra xhigh/max failures with the Sol-only implementation.
- `npm run check` passed remotely, including typecheck and browser smoke.
- Real RPC CLI QA passed for Astra, Sol, and unrelated model controls.
- TUI warning capture remains pending and is explicitly not claimed as passing; see `local-ignore/qa-evidence/20260908-astra-warning/REPORT.md`.

## Scope
Exactly four files under `packages/coding-agent/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the high-reasoning warning to GPT-6 Astra models at `xhigh` and `max` effort, matching the existing Sol behavior.

- Updates the shared model matcher to include Astra variants while preserving the existing effort thresholds and warning content.
- Adds regression tests covering Astra model IDs and negative controls.

<sup>Written for commit 26aeab6cee01be058c1b179e77ee3a58a1855a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

