### PR TITLE
fix(agent,goal): recover empty tool_use turns instead of stalling the goal

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Recover a provider response that reports the `tool_use` stop reason while carrying no tool-call block. The turn is retried once on models that already use stream recovery, and the contradictory terminal state is demoted to a coherent stop for every model, so a lost tool call no longer ends the turn silently.
+
 ### Removed
 
 ## [2026.9.7-2] - 2026-09-07

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -16,6 +16,7 @@ import {
 } from "@earendil-works/pi-ai";
 import {
 	createTerminalFailureAssistantMessage,
+	demoteToolUseWithoutToolCalls,
 	isStreamIdleTimeoutError,
 	normalizeTerminalAssistantMessage,
 	promoteStopWithPendingToolCalls,
@@ -262,7 +263,7 @@ async function runLoop(
 				withEmptyAssistantRecovery(requestConfig.model, streamFunction),
 				isInitialProviderRequest ? config.timeoutMs : requestConfig.timeoutMs,
 			);
-			const message = promoteStopWithPendingToolCalls(streamed.message);
+			const message = demoteToolUseWithoutToolCalls(promoteStopWithPendingToolCalls(streamed.message));
 			const providerToolResults = streamed.providerToolResults;
 			newMessages.push(message);
 			const toolResults: ToolResultMessage[] = [];

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -29,6 +29,12 @@ export class ProviderRetryWatchdogAbortError extends Error {
 	}
 }
 
+export function demoteToolUseWithoutToolCalls(message: AssistantMessage): AssistantMessage {
+	// Count raw blocks: cursor-resolved calls are legitimate completed tool calls and must not be demoted.
+	if (message.stopReason !== "toolUse" || message.content.some((block) => block.type === "toolCall")) return message;
+	return { ...message, stopReason: "stop" };
+}
+
 export function promoteStopWithPendingToolCalls(message: AssistantMessage): AssistantMessage {
 	if (message.stopReason !== "stop") return message;
 	if (!message.content.some((block) => block.type === "toolCall")) return message;

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -29,10 +29,24 @@ export class ProviderRetryWatchdogAbortError extends Error {
 	}
 }
 
+/**
+ * Marks a terminal message whose `toolUse` stop reason was demoted because the provider sent no
+ * tool call. Demotion rewrites the stop reason, so this diagnostic is the only surviving evidence
+ * that the turn was malformed rather than a clean stop; downstream recovery keys on it.
+ */
+export const EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC = "empty_tool_use_terminal_state";
+
 export function demoteToolUseWithoutToolCalls(message: AssistantMessage): AssistantMessage {
 	// Count raw blocks: cursor-resolved calls are legitimate completed tool calls and must not be demoted.
 	if (message.stopReason !== "toolUse" || message.content.some((block) => block.type === "toolCall")) return message;
-	return { ...message, stopReason: "stop" };
+	return {
+		...message,
+		stopReason: "stop",
+		diagnostics: [
+			...(message.diagnostics ?? []),
+			{ type: EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC, timestamp: Date.now(), details: {} },
+		],
+	};
 }
 
 export function promoteStopWithPendingToolCalls(message: AssistantMessage): AssistantMessage {

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -45,6 +45,27 @@
 
 # Changes
 
+## 2026-09-08 - Recover empty native tool-use responses
+
+### What changed
+
+- `packages/agent/src/empty-assistant-recovery.ts`: retry terminal native `toolUse` responses with no tool-call blocks once, then surface an error and telemetry diagnostic; preserve existing empty-stop gating.
+- `packages/agent/src/assistant-terminal-state.ts`: demote contradictory tool-use terminal messages without tool calls.
+- `packages/agent/src/agent-loop.ts`: compose terminal normalization with pending-tool promotion.
+
+### Why
+
+- Providers can lose a streamed tool call while retaining the `toolUse` stop reason, which otherwise silently ends the user's session.
+
+### Why an extension could not handle it
+
+- Provider stream buffering and terminal-state normalization occur inside the core agent loop before extension callbacks observe the message.
+
+### Expected merge conflict zones
+
+- MEDIUM: `empty-assistant-recovery.ts` stream terminal handling and `agent-loop.ts` terminal message normalization.
+
+
 ## 2026-09-04 - Drop the byte count from write-tool results
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -50,8 +50,9 @@
 ### What changed
 
 - `packages/agent/src/empty-assistant-recovery.ts`: retry terminal native `toolUse` responses with no tool-call blocks once, then surface an error and telemetry diagnostic; preserve existing empty-stop gating.
-- `packages/agent/src/assistant-terminal-state.ts`: demote contradictory tool-use terminal messages without tool calls.
+- `packages/agent/src/assistant-terminal-state.ts`: demote contradictory tool-use terminal messages without tool calls, stamping an `empty_tool_use_terminal_state` diagnostic so the demotion stays identifiable after the stop reason is rewritten.
 - `packages/agent/src/agent-loop.ts`: compose terminal normalization with pending-tool promotion.
+- `packages/agent/src/index.ts`: export `EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC` so the goal builtin can recognize a demoted malformed turn.
 
 ### Why
 
@@ -64,6 +65,7 @@
 ### Expected merge conflict zones
 
 - MEDIUM: `empty-assistant-recovery.ts` stream terminal handling and `agent-loop.ts` terminal message normalization.
+- LOW: the `assistant-terminal-state.ts` re-export line in `index.ts`.
 
 
 ## 2026-09-04 - Drop the byte count from write-tool results

--- a/packages/agent/src/empty-assistant-recovery.ts
+++ b/packages/agent/src/empty-assistant-recovery.ts
@@ -15,35 +15,37 @@ import type { StreamFn } from "./types.ts";
 type StreamFactory = () => AssistantMessageEventStream | Promise<AssistantMessageEventStream>;
 
 const EMPTY_RESPONSE_ERROR = "Model returned an empty response twice";
+const EMPTY_TOOL_USE_ERROR = "Model returned tool_use without a tool call twice";
 
 function isEmptyStop(message: AssistantMessage): boolean {
 	return message.stopReason === "stop" && !hasVisibleAssistantContent(message);
+}
+
+function isEmptyToolUse(message: AssistantMessage): boolean {
+	return message.stopReason === "toolUse" && !message.content.some((block) => block.type === "toolCall");
 }
 
 function eventStartsVisibleContent(event: AssistantMessageEvent): boolean {
 	return event.type === "toolcall_start" || (event.type === "text_delta" && hasVisibleText(event.delta));
 }
 
-function appendRetryDiagnostic(message: AssistantMessage): AssistantMessage {
+function appendRetryDiagnostic(
+	message: AssistantMessage,
+	type = "empty_assistant_response_recovery",
+): AssistantMessage {
 	return {
 		...message,
-		diagnostics: [
-			...(message.diagnostics ?? []),
-			{
-				type: "empty_assistant_response_recovery",
-				timestamp: Date.now(),
-				details: { retries: 1 },
-			},
-		],
+		diagnostics: [...(message.diagnostics ?? []), { type, timestamp: Date.now(), details: { retries: 1 } }],
 	};
 }
 
-function createEmptyResponseFailure(message: AssistantMessage): AssistantMessage {
+function createEmptyResponseFailure(message: AssistantMessage, toolUse = false): AssistantMessage {
+	const errorMessage = toolUse ? EMPTY_TOOL_USE_ERROR : EMPTY_RESPONSE_ERROR;
 	return {
-		...appendRetryDiagnostic(message),
-		content: [{ type: "text", text: EMPTY_RESPONSE_ERROR }],
+		...appendRetryDiagnostic(message, toolUse ? "empty_tool_use_response_recovery" : undefined),
+		content: [{ type: "text", text: errorMessage }],
 		stopReason: "error",
-		errorMessage: EMPTY_RESPONSE_ERROR,
+		errorMessage,
 	};
 }
 
@@ -60,17 +62,26 @@ function createRetryingStream(firstStream: AssistantMessageEventStream, createSt
 				let retry = false;
 				for await (const event of stream) {
 					if (event.type === "done") {
-						if (isEmptyStop(event.message)) {
+						const emptyToolUse = isEmptyToolUse(event.message);
+						if (isEmptyStop(event.message) || emptyToolUse) {
 							if (!retrying) {
 								retry = true;
 								break;
 							}
-							const error = createEmptyResponseFailure(event.message);
+							const error = createEmptyResponseFailure(event.message, emptyToolUse);
 							outerStream.push({ type: "error", reason: "error", error });
 							outerStream.end();
 							return;
 						}
-						const terminal = retrying ? { ...event, message: appendRetryDiagnostic(event.message) } : event;
+						const terminal = retrying
+							? {
+									...event,
+									message: appendRetryDiagnostic(
+										event.message,
+										isEmptyToolUse(event.message) ? "empty_tool_use_response_recovery" : undefined,
+									),
+								}
+							: event;
 						if (!forwarding) {
 							for (const pending of buffered) outerStream.push(pending);
 						}
@@ -111,6 +122,10 @@ function createRetryingStream(firstStream: AssistantMessageEventStream, createSt
 	return outerStream;
 }
 
+// Wrapping replaces the provider stream with a buffering proxy, which does not carry the
+// underlying stream's liveness surface (trackLocalWork/hasPendingLocalWork) that the loop's
+// idle watchdog reads. Only wrap models that actually need stream-level recovery; the
+// empty-tool_use contradiction is normalized for every model by the agent loop instead.
 export function withEmptyAssistantRecovery<TApi extends Api>(model: Model<TApi>, streamFunction: StreamFn): StreamFn {
 	if (!shouldRecoverTextToolCalls(model) && getToolCallFormat(model) === undefined) return streamFunction;
 	return async (requestedModel, context, options) => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -43,7 +43,7 @@ export {
 export * from "./agent.ts";
 // Loop functions
 export * from "./agent-loop.ts";
-export { ProviderRetryWatchdogAbortError } from "./assistant-terminal-state.ts";
+export { EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC, ProviderRetryWatchdogAbortError } from "./assistant-terminal-state.ts";
 export * from "./harness/agent-harness.ts";
 export {
 	type BranchPreparation,

--- a/packages/agent/test/empty-tool-use-native-retry.test.ts
+++ b/packages/agent/test/empty-tool-use-native-retry.test.ts
@@ -1,0 +1,120 @@
+import {
+	type AssistantMessage,
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { withEmptyAssistantRecovery } from "../src/empty-assistant-recovery.ts";
+
+function nativeToolCallingModel(): Model<"anthropic-messages"> {
+	return {
+		id: "claude-fable-5-1",
+		name: "claude-fable-5-1",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	};
+}
+
+function assistantMessage(
+	stopReason: AssistantMessage["stopReason"],
+	content: AssistantMessage["content"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-fable-5-1",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 0,
+	};
+}
+
+function streamOf(message: AssistantMessage, reason: "stop" | "length" | "toolUse" = "toolUse") {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		stream.push({ type: "done", reason, message });
+		stream.end();
+	});
+	return stream;
+}
+
+const thinkingOnlyToolUse = (): AssistantMessage =>
+	assistantMessage("toolUse", [{ type: "thinking", thinking: "planning", thinkingSignature: "sig" }]);
+
+describe("empty tool_use recovery on native tool-calling providers", () => {
+	it("retries the same request when tool_use arrives with no tool call", async () => {
+		//#given - a native tool-calling model whose first response is toolUse with no tool call
+		const model = nativeToolCallingModel();
+		const seen: Array<{ model: Model<never> | undefined; context: Context | undefined }> = [];
+		let call = 0;
+		const streamFunction = (
+			requestedModel: Model<never>,
+			context: Context,
+			_options?: SimpleStreamOptions,
+		): ReturnType<typeof streamOf> => {
+			seen.push({ model: requestedModel, context });
+			call += 1;
+			return call === 1
+				? streamOf(thinkingOnlyToolUse())
+				: streamOf(assistantMessage("toolUse", [{ type: "toolCall", id: "call-1", name: "eval", arguments: {} }]));
+		};
+		const context: Context = { systemPrompt: "", messages: [], tools: [] };
+
+		//#when
+		const recovered = withEmptyAssistantRecovery(model, streamFunction as never);
+		const stream = await recovered(model as never, context, undefined);
+		const message = await stream.result();
+
+		//#then - the retry reissued the same request and the recovered tool call survived
+		expect(seen).toHaveLength(2);
+		expect(seen[1]?.model).toBe(model);
+		expect(seen[1]?.context).toBe(context);
+		expect(
+			message.content.filter((block: AssistantMessage["content"][number]) => block.type === "toolCall"),
+		).toHaveLength(1);
+		expect(message.stopReason).toBe("toolUse");
+	});
+
+	it("fails the turn as an error when the retry is malformed too", async () => {
+		//#given - a native model that returns the malformed shape twice
+		const model = nativeToolCallingModel();
+		let call = 0;
+		const streamFunction = (): ReturnType<typeof streamOf> => {
+			call += 1;
+			return streamOf(thinkingOnlyToolUse());
+		};
+		const context: Context = { systemPrompt: "", messages: [], tools: [] };
+
+		//#when
+		const recovered = withEmptyAssistantRecovery(model, streamFunction as never);
+		const stream = await recovered(model as never, context, undefined);
+		const message = await stream.result();
+
+		//#then - the second malformed response is terminal rather than a silent clean end
+		expect(call).toBe(2);
+		expect(message.stopReason).toBe("error");
+		expect(
+			message.diagnostics?.some(
+				(entry: NonNullable<AssistantMessage["diagnostics"]>[number]) =>
+					entry.type === "empty_tool_use_response_recovery",
+			),
+		).toBe(true);
+	});
+});

--- a/packages/agent/test/empty-tool-use-native-retry.test.ts
+++ b/packages/agent/test/empty-tool-use-native-retry.test.ts
@@ -6,6 +6,7 @@ import {
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
+import { demoteToolUseWithoutToolCalls, EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC } from "../src/assistant-terminal-state.ts";
 import { withEmptyAssistantRecovery } from "../src/empty-assistant-recovery.ts";
 
 function nativeToolCallingModel(): Model<"anthropic-messages"> {
@@ -90,6 +91,39 @@ describe("empty tool_use recovery on native tool-calling providers", () => {
 			message.content.filter((block: AssistantMessage["content"][number]) => block.type === "toolCall"),
 		).toHaveLength(1);
 		expect(message.stopReason).toBe("toolUse");
+	});
+
+	it("leaves an unwrapped native model to the loop's demotion instead of a stream retry", async () => {
+		//#given - a native tool-calling model that neither text-tool-call recovery nor a tool-call format covers
+		const model: Model<"anthropic-messages"> = {
+			...nativeToolCallingModel(),
+			id: "gemini-3-pro",
+			name: "gemini-3-pro",
+		};
+		let calls = 0;
+		const streamFunction = (): ReturnType<typeof streamOf> => {
+			calls += 1;
+			return streamOf(thinkingOnlyToolUse());
+		};
+		const context: Context = { systemPrompt: "", messages: [], tools: [] };
+
+		//#when
+		const recovered = withEmptyAssistantRecovery(model, streamFunction as never);
+		const message = await (await recovered(model as never, context, undefined)).result();
+
+		//#then - the stream is not rewrapped, so liveness is preserved and no retry fires
+		expect(calls).toBe(1);
+		expect(recovered).toBe(streamFunction);
+
+		//#then - the loop's demotion still removes the contradiction and records why
+		const demoted = demoteToolUseWithoutToolCalls(message);
+		expect(demoted.stopReason).toBe("stop");
+		expect(
+			demoted.diagnostics?.some(
+				(entry: NonNullable<AssistantMessage["diagnostics"]>[number]) =>
+					entry.type === EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC,
+			),
+		).toBe(true);
 	});
 
 	it("fails the turn as an error when the retry is malformed too", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- An active goal no longer stalls forever when a provider ends the turn with the `tool_use` stop reason but no tool-call block. Nothing executed on such a turn, so it is treated as provider breakage and resumed through the existing provider-recovery lane instead of being read as a deliberate tool-driven stop. A turn that a tool genuinely ended still waits for the user, and every existing admission guard (continuation cap, repetition, single-flight, unattended budget) still bounds the recovery.
+
 - A rejected Anthropic request now reports its HTTP status through the provider response hook: previously the Anthropic SDK's rejection path never reached `onResponse`/`after_provider_response`, so the native tool-search adapter's permanent 400 fallback was dead code on the live error path (senpi #1481). Errors without a numeric status (network failures, aborts) report nothing rather than a fabricated code.
 
 - A native tool-search 400 no longer demotes the session to a weaker model: the turn is retried once in place on the same model with native injection already disabled for the session, and only a second rejection consults the fallback chain (senpi #1482).

--- a/packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts
@@ -1,4 +1,5 @@
 import type { AgentEndEvent, ExtensionContext } from "../../types.ts";
+import { isMalformedToolUseTurn } from "./continuation.ts";
 import type { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
 import { didTerminalProviderErrorEndTurn } from "./terminal-provider-error.ts";
 import type { Goal } from "./types.ts";
@@ -15,6 +16,16 @@ export async function continueGoalAfterAgentEnd(
 ): Promise<Goal | null> {
 	if (options.event.aborted === true && options.event.abortSource === "system") {
 		return monitor.afterSystemAbort({
+			ctx: options.ctx,
+			event: options.event,
+			goal: options.goal,
+			messages: options.event.messages,
+			willRetry: options.event.willRetry === true,
+		});
+	}
+	const lastAssistant = [...options.event.messages].reverse().find((message) => message.role === "assistant");
+	if (lastAssistant?.role === "assistant" && isMalformedToolUseTurn(lastAssistant)) {
+		return monitor.afterProviderFailure({
 			ctx: options.ctx,
 			event: options.event,
 			goal: options.goal,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,26 @@
 # goal Extension Changes
 
+## 2026-09-08 - Recover malformed empty tool-use turns
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts`: distinguish `toolUse` assistant turns with no tool-call blocks from intentional tool termination and admit only the malformed case on immediate continuation.
+- `packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts`: route malformed empty tool-use turns through `providerRecovery`.
+- `packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts` and `packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts`: populate the malformed-turn fact in every verdict input.
+- `packages/coding-agent/test/suite/goal-continuation-verdict.test.ts`: cover malformed and intentional tool-use verdicts.
+
+### Why
+
+- A provider can emit `toolUse` without any tool-call block. Nothing executed, so treating it as a deliberate terminating tool leaves an active goal permanently stalled.
+
+### Why an extension could not handle this
+
+- The built-in goal extension owns agent-end admission and its recovery routing.
+
+### Expected merge conflict zones
+
+- LOW: continuation eligibility and agent-end verdict-input construction.
+
 ## 2026-09-08 - The monitor backstop is a periodic re-check again, default 270s
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { type AgentMessage, EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC } from "@earendil-works/pi-agent-core";
 import type { Goal } from "./types.ts";
 
 type AssistantAgentMessage = Extract<AgentMessage, { role: "assistant" }>;
@@ -103,8 +103,16 @@ function isContinuableStopReason(stopReason: AssistantAgentMessage["stopReason"]
 	return stopReason === "stop" || stopReason === "length";
 }
 
+// The agent loop demotes a tool-call-less `toolUse` stop to `stop` before `agent_end`, so the
+// original stop reason is gone by the time a goal sees the turn. Accept either shape: the raw
+// message (extensions observing it pre-demotion) or the demotion diagnostic the loop leaves behind.
 export function isMalformedToolUseTurn(message: AssistantAgentMessage): boolean {
-	return message.stopReason === "toolUse" && !message.content.some((content) => content.type === "toolCall");
+	if (message.content.some((content) => content.type === "toolCall")) return false;
+	if (message.stopReason === "toolUse") return true;
+	return (
+		message.stopReason === "stop" &&
+		(message.diagnostics ?? []).some((diagnostic) => diagnostic.type === EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC)
+	);
 }
 
 function isAbortedToolResult(message: ToolResultAgentMessage): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -31,6 +31,7 @@ export type GoalContinuationInput = {
 	readonly hasPendingMessages: boolean;
 	readonly path: GoalContinuationPath;
 	readonly lastStopReason: AssistantAgentMessage["stopReason"] | undefined;
+	readonly lastTurnWasMalformedToolUse: boolean;
 	readonly consecutiveContinuations: number;
 	readonly lastContinuationSignature: string | undefined;
 	readonly currentSignature: string | undefined;
@@ -78,7 +79,8 @@ function didAgentEndCleanly(messages: readonly AgentMessage[]): boolean {
 	if (lastAssistantIndex === undefined) return false;
 
 	const lastAssistant = messages[lastAssistantIndex];
-	if (lastAssistant?.role !== "assistant" || !isContinuableStopReason(lastAssistant.stopReason)) return false;
+	if (lastAssistant?.role !== "assistant") return false;
+	if (!isContinuableStopReason(lastAssistant.stopReason) && !isMalformedToolUseTurn(lastAssistant)) return false;
 
 	for (let index = lastAssistantIndex + 1; index < messages.length; index++) {
 		const message = messages[index];
@@ -99,6 +101,10 @@ function findLastAssistantMessageIndex(messages: readonly AgentMessage[]): numbe
 
 function isContinuableStopReason(stopReason: AssistantAgentMessage["stopReason"]): boolean {
 	return stopReason === "stop" || stopReason === "length";
+}
+
+export function isMalformedToolUseTurn(message: AssistantAgentMessage): boolean {
+	return message.stopReason === "toolUse" && !message.content.some((content) => content.type === "toolCall");
 }
 
 function isAbortedToolResult(message: ToolResultAgentMessage): boolean {
@@ -185,7 +191,10 @@ function isEligibleForGoalContinuation(input: GoalContinuationInput): boolean {
 	if (input.goal?.status !== "active" || input.hasPendingMessages) return false;
 	if (input.path === "systemRecovery" || input.path === "providerRecovery") return true;
 	if (input.path === "immediate") {
-		return input.lastStopReason !== undefined && isContinuableStopReason(input.lastStopReason);
+		return (
+			input.lastTurnWasMalformedToolUse ||
+			(input.lastStopReason !== undefined && isContinuableStopReason(input.lastStopReason))
+		);
 	}
 	return input.isIdle;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -108,6 +108,7 @@ export async function queueGoalContinuation(
 			hasPendingMessages: ctx.hasPendingMessages(),
 			path: "sessionStart",
 			lastStopReason: undefined,
+			lastTurnWasMalformedToolUse: false,
 			consecutiveContinuations: goal.consecutiveContinuations ?? 0,
 			lastContinuationSignature: goal.lastContinuationSignature,
 			currentSignature: signature,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -25,6 +25,7 @@ import {
 	type GoalContinuationPath,
 	hasGoalContinuationProgress,
 	hashAssistantText,
+	isMalformedToolUseTurn,
 	normalizeAssistantText,
 } from "./continuation.ts";
 import { lastAssistantMessage } from "./last-assistant-message.ts";
@@ -508,6 +509,7 @@ export class MonitorAwareGoalContinuation {
 			hasPendingMessages: ctx.hasPendingMessages(),
 			path,
 			lastStopReason: lastAssistant?.stopReason,
+			lastTurnWasMalformedToolUse: lastAssistant?.role === "assistant" && isMalformedToolUseTurn(lastAssistant),
 			consecutiveContinuations: goal.consecutiveContinuations ?? 0,
 			lastContinuationSignature: goal.lastContinuationSignature,
 			currentSignature: buildCurrentGoalContinuationSignature(ctx, goal, lastAssistantText(messages)),

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -36,6 +36,7 @@ function makeInput(overrides: Partial<VerdictInput> = {}): VerdictInput {
 		hasPendingMessages: false,
 		path: "immediate",
 		lastStopReason: "stop",
+		lastTurnWasMalformedToolUse: false,
 		consecutiveContinuations: 0,
 		lastContinuationSignature: undefined,
 		currentSignature: "goal-1:1/2:abc123",
@@ -216,6 +217,15 @@ describe("goal continuation verdict", () => {
 				),
 			).toEqual({ kind: "deny", reason: "context-overflow" });
 		}
+	});
+
+	it("admits malformed toolUse only when no tool call was produced", () => {
+		expect(
+			evaluateGoalContinuation(makeInput({ lastStopReason: "toolUse", lastTurnWasMalformedToolUse: true })),
+		).toMatchObject({ kind: "continue" });
+		expect(
+			evaluateGoalContinuation(makeInput({ lastStopReason: "toolUse", lastTurnWasMalformedToolUse: false })),
+		).toEqual({ kind: "deny", reason: "not-eligible" });
 	});
 
 	it("keeps provider recovery eligible while the session is settling", () => {

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -188,6 +188,7 @@ describe("goal continuation gating", () => {
 			isIdle: true,
 			hasPendingMessages: false,
 			lastStopReason: "stop",
+			lastTurnWasMalformedToolUse: false,
 			consecutiveContinuations: 8,
 			lastContinuationSignature: undefined,
 			currentSignature: undefined,

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1026,6 +1026,7 @@ describe("goal continuation while a monitor is active", () => {
 						hasPendingMessages: false,
 						path: "immediate",
 						lastStopReason: "stop",
+						lastTurnWasMalformedToolUse: false,
 						consecutiveContinuations: goal.consecutiveContinuations ?? 0,
 						lastContinuationSignature: goal.lastContinuationSignature,
 						currentSignature: undefined,

--- a/packages/coding-agent/test/suite/regressions/empty-tool-use-goal-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/empty-tool-use-goal-stall.test.ts
@@ -1,0 +1,80 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { readGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
+import { goalStoreRef } from "../../../src/core/extensions/builtin/goal/store-ref.ts";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import {
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+} from "../goal-monitor-test-harness.ts";
+
+// A provider under upstream overload returned a streamed assistant message whose
+// message_delta carried stop_reason "tool_use" while the tool_use content block was
+// lost in transit, producing `{ stopReason: "toolUse", content: [thinking] }` with zero
+// toolCall blocks. The agent loop saw no tool calls and ended the turn as if it were
+// finished, while goal continuation refused to resume anything that ended in "toolUse".
+// The two layers disagreed on what a coherent terminal state is, so an active goal froze
+// with nothing pending and nothing running until the user noticed and re-prompted.
+//
+// A malformed terminal message is infrastructure breakage, not a decision by the model or
+// the user, so the goal must resume. A turn a tool deliberately ended must still not.
+
+async function createActiveGoal(ctx: ExtensionContext, harness: ReturnType<typeof createGoalHarness>): Promise<void> {
+	await harness.tools
+		.get("create_goal")
+		?.execute("c1", { objective: "Fix the placeholder typo and land the change" }, undefined, undefined, ctx);
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+}
+
+describe("empty tool_use terminal message does not stall an active goal", () => {
+	afterEach(async () => {
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("queues a continuation when the provider ends the turn as toolUse with no tool call", async () => {
+		//#given - an active goal whose turn ended on a toolUse message that carries no tool call
+		const harness = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-empty-tool-use");
+		await createActiveGoal(ctx, harness);
+		const malformed = fauxAssistantMessage("", { stopReason: "toolUse" });
+
+		//#when
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [malformed], willRetry: false },
+			ctx,
+		);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		//#then - the goal resumes instead of freezing while still marked active
+		expect(harness.sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({ status: "active" });
+	});
+
+	it("does not queue a continuation when an executed tool deliberately ended the turn", async () => {
+		//#given - an active goal whose turn ended on a toolUse message whose tool call did run
+		const harness = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-terminating-tool-use");
+		await createActiveGoal(ctx, harness);
+		const terminated = fauxAssistantMessage([fauxToolCall("ask_user", { question: "which branch?" })], {
+			stopReason: "toolUse",
+		});
+
+		//#when
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [terminated], willRetry: false },
+			ctx,
+		);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		//#then - a deliberate stop keeps its existing behavior and waits for the user
+		expect(harness.sent).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/empty-tool-use-goal-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/empty-tool-use-goal-stall.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { readGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
@@ -53,6 +54,54 @@ describe("empty tool_use terminal message does not stall an active goal", () => 
 		//#then - the goal resumes instead of freezing while still marked active
 		expect(harness.sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({ status: "active" });
+	});
+
+	it("queues a continuation after the agent loop demoted the malformed turn to a clean stop", async () => {
+		//#given - the loop rewrites the stop reason to "stop" and leaves only the demotion diagnostic
+		const harness = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-demoted-tool-use");
+		await createActiveGoal(ctx, harness);
+		const demoted = {
+			...fauxAssistantMessage("", { stopReason: "toolUse" }),
+			stopReason: "stop" as const,
+			diagnostics: [{ type: EMPTY_TOOL_USE_DEMOTION_DIAGNOSTIC, timestamp: 0, details: {} }],
+		};
+
+		//#when
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [demoted], willRetry: false },
+			ctx,
+		);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		//#then - the demotion diagnostic still identifies the turn as provider breakage
+		expect(harness.sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({ status: "active" });
+	});
+
+	it("does not queue a continuation for an ordinary clean stop", async () => {
+		//#given - an active goal whose turn ended as a plain stop with no demotion diagnostic
+		const harness = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-plain-stop");
+		await createActiveGoal(ctx, harness);
+		const plain = fauxAssistantMessage("all done", { stopReason: "stop" });
+
+		//#when
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [plain], willRetry: false },
+			ctx,
+		);
+
+		//#then - a clean stop must not be mistaken for provider breakage
+		expect(
+			harness.sent.filter((entry) => entry.message.customType === "goal-continuation").length,
+		).toBeLessThanOrEqual(1);
 	});
 
 	it("does not queue a continuation when an executed tool deliberately ended the turn", async () => {

--- a/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
@@ -123,6 +123,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 						hasPendingMessages: false,
 						path: "monitorDelayed",
 						lastStopReason: "stop",
+						lastTurnWasMalformedToolUse: false,
 						consecutiveContinuations: 7,
 						lastContinuationSignature: undefined,
 						currentSignature: `${goal.id}:0/0:deadbeef`,


### PR DESCRIPTION
## Problem

A provider can end a turn reporting the `tool_use` stop reason while the `tool_use` content block never arrives, producing an assistant message with **zero** `toolCall` blocks.

This was observed in production on 2026-09-08 (`claude-fable-5-1` through a proxy, during upstream overload). Token accounting on the incident message shows 1035 output tokens against only 299 reasoning tokens, so a substantial tool call was generated and lost in transit. The session had an active goal and silently froze mid-task.

Two layers then disagreed about what that message meant:

| Layer | Reading | Result |
|---|---|---|
| `packages/agent/src/agent-loop.ts` | zero tool calls → nothing to execute | emits `turn_end` + `agent_end`, turn "finished" |
| `goal/continuation.ts` `isContinuableStopReason` | stop reason is `toolUse`, not `stop`/`length` | refuses to queue a continuation |

The loop said the turn was over; the goal layer said it had not ended cleanly. Nothing was pending, nothing was running, and the goal stayed `active` forever. The user only noticed because the session went quiet.

## Fix

Three layers, each with a distinct responsibility, all agreeing on one definition of a coherent terminal state.

**1. Recover the lost tool call (`packages/agent/src/empty-assistant-recovery.ts`)**

A terminal message claiming `toolUse` with no tool call is structurally impossible, so it is treated like the empty-`stop` defect the file already handles: retry the request once, reusing the same closure so the retry reissues the identical model/context/options. If the retry is malformed too, the turn finalizes as `stopReason: "error"` with an `empty_tool_use_response_recovery` diagnostic rather than a silent clean end.

The wrapper deliberately stays scoped to models that already need stream recovery. Wrapping replaces the provider stream with a buffering proxy that does not carry the underlying stream's liveness surface (`trackLocalWork` / `hasPendingLocalWork`), which the loop's idle watchdog reads — wrapping unconditionally broke 7 timeout/abort tests. Universal coverage is provided by layer 2 instead.

**2. Normalize the contradiction (`packages/agent/src/assistant-terminal-state.ts`)**

`demoteToolUseWithoutToolCalls` is the exact inverse of the existing `promoteStopWithPendingToolCalls`, composed with it in the loop. It counts raw `toolCall` blocks so a cursor-exec-resolved call — a legitimately completed tool call — is never demoted. This applies to every model and needs no stream rewrapping.

**3. Resolve the deadlock (`goal/`)**

`isMalformedToolUseTurn` distinguishes the anomaly from a deliberate terminating-tool stop. At `agent_end` the anomaly routes through the existing `afterProviderFailure` / `providerRecovery` lane — infrastructure breakage, same class as a terminal provider error — and `lastTurnWasMalformedToolUse` is threaded into the verdict input so the immediate path admits only this case.

`isContinuableStopReason` is deliberately **not** widened to accept `toolUse`; that would wrongly admit deliberate terminating-tool stops. A turn a tool genuinely ended still waits for the user.

Every existing admission guard still bounds the recovery: single-flight latch, `GOAL_CONTINUATION_CAP` (8), `GOAL_REPETITION_HASH_STREAK` (3), and `GOAL_UNATTENDED_CONTINUATION_LIMIT` (150), which is the concrete bound if a provider returns the malformed shape persistently.

## Verification

Both new tests fail on `main` and pass here.

`packages/coding-agent/test/suite/regressions/empty-tool-use-goal-stall.test.ts` reproduces the incident end to end. Before the goal fix:

```
AssertionError: expected [] to have a length of 1 but got +0
 Tests  1 failed | 1 passed (2)
```

After:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`packages/agent/test/empty-tool-use-native-retry.test.ts` asserts the retry reissues with the **same model and context** (a call-count-only assertion would have passed an earlier broken revision where the retry factory was invoked with no arguments) and that a twice-malformed response terminates as `error` with the right diagnostic.

Full suites:

```
packages/agent          Test Files  43 passed (43)   Tests  555 passed | 1 skipped (556)
goal suites (11 files)  Test Files  11 passed (11)   Tests  199 passed (199)
```

Changelog gate:

```
changelog-gate: PASS - changes.md coverage complete (1 production path(s) covered);
changelog entry updated (packages/agent/CHANGELOG.md, packages/coding-agent/CHANGELOG.md)
```

Three pre-existing test files (`goal-modules`, `goal-monitor-continuation`, `issue-506-monitor-delayed-cap`) construct `GoalContinuationInput` directly and were updated for the new required field.

## Notes

- Both `changes.md` trackers are updated (`packages/agent/src/changes.md`, `goal/changes.md`).
- The upstream cause is a provider/proxy transport defect. This PR makes the client survive it rather than claiming to fix the provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stall where an active goal froze when a provider ended a turn reporting `tool_use` but lost the tool call block in transit. The agent now recovers that contradictory response, and the goal layer resumes through the existing provider-recovery path instead of reading it as a deliberate stop.

**Bug Fixes**
- Retries the request once with the same model and context when a terminal `toolUse` message has no tool call; a second malformed response ends the turn as `error` with an `empty_tool_use_response_recovery` diagnostic.
- Demotes the contradictory `toolUse` stop reason to `stop` for every model when no raw tool call block is present, stamping an `empty_tool_use_terminal_state` diagnostic so the demotion stays identifiable downstream; cursor-resolved calls (which are complete) are never demoted.
- `isMalformedToolUseTurn` accepts either the raw `toolUse` shape or the demoted `stop` carrying that diagnostic, so a plain clean stop is unaffected.
- Only wraps models that already use stream recovery, so the idle watchdog's liveness surface is preserved; a new test pins that unwrapped native models still get the demotion.
- Routes malformed tool-use turns through the provider-recovery lane for active goals; a turn a tool legitimately ended still waits for the user.
- All existing continuation bounds (single-flight, cap 8, repetition streak 3, unattended limit 150) still apply.

<sup>Written for commit bf17b5eb9ae009bdeb21dc3bf0a501be8dff2206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

