### PR TITLE
fix(ai): handle Anthropic mid-output fallback safely.

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/anthropic-mid-output-fallback-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/anthropic-mid-output-fallback-qa.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import {
+	evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox, runCli,
+} from "../lib/common.mjs";
+import { hermeticEnv, writeMockModelsJson } from "../lib/mock-loop-support.mjs";
+
+const primary = "mock-claude";
+const fallback = "mock-claude-fallback";
+const final = "MID_OUTPUT_RECOVERED";
+installCleanupHooks();
+const guard = guardRealAuth();
+const evidence = evidenceDir("anthropic-mid-output-wire");
+
+function block(index, content) {
+	return [
+		{ type: "content_block_start", index, content_block: content.type === "text" ? { ...content, text: "" } : content },
+		...(content.type === "text"
+			? [{ type: "content_block_delta", index, delta: { type: "text_delta", text: content.text } }]
+			: []),
+		{ type: "content_block_stop", index },
+	];
+}
+
+function responseEvents(model, first, sentinel) {
+	const events = [{
+		type: "message_start",
+		message: {
+			id: "msg_wire", type: "message", role: "assistant", model, content: [],
+			stop_reason: null, stop_sequence: null,
+			usage: { input_tokens: 1, output_tokens: 0 },
+		},
+	}];
+	if (first) {
+		events.push(...block(0, { type: "text", text: "Discarded attempt. " }));
+		events.push(
+			{ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "abandoned", name: "bash", input: {} } },
+			{ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: JSON.stringify({ command: `touch '${sentinel}'` }) } },
+			{ type: "content_block_stop", index: 1 },
+			...block(2, { type: "fallback", from: { model: primary }, to: { model: "mock-server-substitute" } }),
+		);
+	}
+	events.push(
+		...block(first ? 3 : 0, { type: "text", text: final }),
+		{ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } },
+		{ type: "message_stop" },
+	);
+	return events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+function hasFallback(value) {
+	if (!value || typeof value !== "object") return false;
+	return value.type === "fallback" || Object.values(value).some(hasFallback);
+}
+
+for (const abort of [true, false]) {
+	const box = makeSandbox("senpi-mid-output-wire");
+	const sentinel = join(box.cwd, "abandoned-tool-ran");
+	const requests = [];
+	const server = createServer(async (request, response) => {
+		try {
+			let body = "";
+			for await (const chunk of request) body += chunk;
+			const payload = JSON.parse(body);
+			requests.push({ model: payload.model, fallbackInInput: hasFallback(payload.messages) });
+			response.writeHead(200, { "content-type": "text/event-stream" });
+			response.end(responseEvents(payload.model, requests.length === 1, sentinel));
+		} catch {
+			response.writeHead(500);
+			response.end();
+		}
+	});
+	await new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	assert(address && typeof address !== "string");
+	const origin = `http://127.0.0.1:${address.port}`;
+	const label = abort ? "abort" : "continue";
+	try {
+		writeMockModelsJson(box.agentDir, { origin }, "anthropic-messages", {}, {
+			models: [{ id: fallback }],
+			retry: {
+				enabled: true, maxRetries: 2, baseDelayMs: 0, abortServerSideFallback: abort,
+				provider: { maxRetries: 0 },
+				fallbackChains: { [`anthropic/${primary}`]: [`anthropic/${fallback}`] },
+			},
+		});
+		const args = ["--provider", "anthropic", "--model", primary, "--print", "--no-extensions"];
+		const env = hermeticEnv(box.env);
+		for (const key of Object.keys(env)) {
+			if (key.endsWith("_PACKAGE_DIR")) delete env[key];
+		}
+		const result = await runCli([...args, "Return the scripted final marker."], {
+			env, cwd: box.cwd, timeoutMs: 60000,
+		});
+		writeFileSync(join(evidence, `${label}-stdout.txt`), result.stdout);
+		writeFileSync(join(evidence, `${label}-stderr.txt`), result.stderr);
+		assert.equal(result.code, 0, result.stderr);
+		assert.equal(result.timedOut, false);
+		assert(result.stdout.includes(final));
+		assert(!`${result.stdout}${result.stderr}`.includes("unsupported mid-output"));
+		assert.deepEqual(requests.map((item) => item.model), abort ? [primary, fallback] : [primary]);
+		assert.equal(existsSync(sentinel), false, "abandoned tool must not run");
+		const logPath = join(box.agentDir, "logs", "fallback.log");
+		const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+		const rows = log.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+		assert.equal(rows.some((row) => row.event === "cooldown_noted"), false);
+		if (abort) assert(rows.some((row) => row.event === "fallback_applied" && row.reason === "refusal"));
+		writeFileSync(join(evidence, `${label}-fallback.log`), log);
+		const next = await runCli([...args, "--continue", "Return the next scripted marker."], {
+			env, cwd: box.cwd, timeoutMs: 60000,
+		});
+		assert.equal(next.code, 0, next.stderr);
+		assert(next.stdout.includes(final));
+		assert(requests.length > (abort ? 2 : 1));
+		assert.equal(requests.some((item) => item.fallbackInInput), false);
+		writeFileSync(join(evidence, `${label}-requests.json`), JSON.stringify(requests, null, 2));
+		guard.assertUnchanged();
+		console.log(`PASS ${label}: marker returned, abandoned tools=0, cooldown=0, replay markers=0`);
+	} finally {
+		server.closeAllConnections();
+		await new Promise((resolve) => server.close(resolve));
+		box.cleanup();
+		assert.equal(server.listening, false);
+		assert.equal(existsSync(box.dir), false);
+		writeFileSync(join(evidence, `${label}-cleanup.json`), JSON.stringify({
+			serverListening: server.listening, sandboxExists: existsSync(box.dir), authUnchanged: guard.assertUnchanged(),
+		}));
+	}
+}
+console.log(`PASS evidence=${evidence}`);

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Anthropic mid-output server fallback now follows the configured abort/continue policy instead of raising an unsupported-fallback error. Continuing responses retain their serving-model identity and do not execute abandoned pre-fallback tools, including through text-tool recovery middleware.
+
 - `streamSimple` on the OpenAI Responses and Codex Responses adapters forwards the new `SimpleStreamOptions.serviceTier` into the request (`service_tier`) and tier-aware usage pricing; the simple path previously dropped it (code-yeongyu/oh-my-openagent#6795).
 
 ### Removed

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -52,6 +52,7 @@ import { normalizeAnthropicRetryFailure } from "../utils/retry-profile/failure.t
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import {
 	applyServerFallbackAbort,
+	applyServerFallbackContinuation,
 	parseServerFallbackReceipt,
 	parseStickyFallbackReceipt,
 	type ServerFallbackReceipt,
@@ -1342,17 +1343,14 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 						break;
 					}
 				} else if (event.type === "content_block_start") {
-					if (event.content_block.type === "fallback" && output.content.length > 0) {
-						throw new Error("Anthropic performed an unsupported mid-output model fallback");
-					}
-					const receipt =
-						options?.abortServerSideFallback === true
-							? parseServerFallbackReceipt(event.content_block)
-							: undefined;
+					const receipt = parseServerFallbackReceipt(event.content_block);
 					if (receipt !== undefined) {
-						serverFallbackReceipt = receipt;
-						serverFallbackAbort.abort();
-						break;
+						if (options?.abortServerSideFallback === true) {
+							serverFallbackReceipt = receipt;
+							serverFallbackAbort.abort();
+							break;
+						}
+						usageModel = applyServerFallbackContinuation(output, model, receipt);
 					}
 					if (event.content_block.type === "text") {
 						const block: Block = {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -3721,3 +3721,22 @@ Detection has to happen inside the Anthropic SSE loop while the stream is still 
 
 ### Expected merge conflict zones
 - MEDIUM: `api/anthropic-messages.ts` cache-control placement in `buildParams()` and the final checkpoint pass in `convertMessages()`.
+
+## 2026-09-08 - Handle Anthropic mid-output server fallback
+
+### What changed
+
+- `packages/ai/src/api/anthropic-messages.ts` handles Anthropic `fallback` content blocks through the existing receipt path regardless of whether they arrive before or after output starts.
+- When client-side abort is disabled, `packages/ai/src/api/anthropic-messages.ts` preserves the fallback boundary, records the serving model, and continues accumulating its output.
+
+### Why
+
+- Anthropic documents mid-output fallback blocks as a supported streaming response. The early error in `packages/ai/src/api/anthropic-messages.ts` prevented configured refusal fallback routing.
+
+### Why an extension could not handle it
+
+- `packages/ai/src/api/anthropic-messages.ts` owns the SSE boundary, stream cancellation, and serving-model attribution before extension hooks receive the completed message.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/api/anthropic-messages.ts`: the `content_block_start` fallback receipt branch.

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -1,5 +1,23 @@
 # Tool Call Middleware Changes
 
+## 2026-09-08 - Preserve server fallback boundaries during recovery
+
+### What changed
+
+- `packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts` removes executable tools before a valid fallback boundary and derives the terminal reason from surviving tools. Server-fallback abort diagnostics remain errors rather than being promoted into tool execution.
+
+### Why
+
+- `packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts` previously retained tools projected before the provider discarded them, reviving abandoned calls in the current turn even though later replay was sanitized.
+
+### Why an extension could not handle it
+
+- `packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts` finalizes provider recovery before session/tool execution or extension hooks.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts`: terminal reason calculation and source-error handling.
+
 ## 2026-08-23 - Kimi XTML sep-less channel marker leak
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-stream-terminal.ts
@@ -1,8 +1,18 @@
 import type { AssistantMessage, AssistantMessageEventStream, StopReason } from "../types.ts";
+import { parseServerFallbackReceipt, SERVER_FALLBACK_ABORTED_DIAGNOSTIC } from "../utils/server-fallback-receipt.ts";
 import type { StreamMessageProjection } from "./stream-wrapper-shared.ts";
 
 function errorText(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function discardSupersededTools(message: AssistantMessage): boolean {
+	const boundary = message.content.findLastIndex(
+		(block) => block.type === "providerNative" && parseServerFallbackReceipt(block.raw) !== undefined,
+	);
+	if (boundary < 0) return false;
+	message.content = message.content.filter((block, index) => index > boundary || block.type !== "toolCall");
+	return true;
 }
 
 /** Emits one terminal event after recovery projection state has been flushed. */
@@ -23,8 +33,10 @@ export class RecoveryStreamTerminal {
 		if (this.emitted) return;
 		projection.finalizeDanglingToolCalls();
 		const message = projection.finalize(source, sawToolCall);
-		const recovered = sawToolCall || message.content.some((block) => block.type === "toolCall");
+		const superseded = discardSupersededTools(message);
+		const recovered = (!superseded && sawToolCall) || message.content.some((block) => block.type === "toolCall");
 		const finalReason = recovered && (reason === "stop" || reason === "length") ? "toolUse" : reason;
+		message.stopReason = finalReason;
 		this.emit({ type: "done", reason: finalReason, message });
 	}
 
@@ -35,6 +47,11 @@ export class RecoveryStreamTerminal {
 		reason: Extract<StopReason, "aborted" | "error">,
 	): void {
 		if (this.emitted) return;
+		if (source.diagnostics?.some((entry) => entry.type === SERVER_FALLBACK_ABORTED_DIAGNOSTIC)) {
+			this.emit({ type: "error", reason, error: source });
+			return;
+		}
+		discardSupersededTools(projection.message);
 		projection.finalizeDanglingToolCalls();
 		const message = projection.finalize(source, sawToolCall);
 		if (reason === "aborted") {

--- a/packages/ai/src/utils/server-fallback-receipt.ts
+++ b/packages/ai/src/utils/server-fallback-receipt.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage } from "../types.ts";
+import type { AssistantMessage, Model } from "../types.ts";
 import { appendAssistantMessageDiagnostic } from "./diagnostics.ts";
 
 export const SERVER_FALLBACK_ABORTED_DIAGNOSTIC = "server_fallback_aborted";
@@ -55,6 +55,30 @@ export function parseStickyFallbackReceipt(
 
 export function serverFallbackRefusalExplanation(receipt: ServerFallbackReceipt): string {
 	return `Server-side fallback (${receipt.from} -> ${receipt.to}) aborted by client policy`;
+}
+
+export function applyServerFallbackContinuation(
+	message: AssistantMessage,
+	model: Model<"anthropic-messages">,
+	receipt: ServerFallbackReceipt,
+): Model<"anthropic-messages"> {
+	// Keep source indices stable for stream projections while making abandoned
+	// client calls audit-only before the agent can execute the completed message.
+	for (const [index, block] of message.content.entries()) {
+		if (block.type === "toolCall") {
+			message.content[index] = { type: "providerNative", subtype: "discarded_tool_call", raw: block };
+		}
+	}
+	message.model = receipt.to;
+	const fallback = model.compat?.allowedFallbackModels?.find(
+		(candidate) =>
+			typeof candidate !== "string" && candidate.provider === model.provider && candidate.model === receipt.to,
+	);
+	return {
+		...model,
+		id: receipt.to,
+		cost: fallback && typeof fallback !== "string" ? fallback.cost : model.cost,
+	};
 }
 
 /**

--- a/packages/ai/test/anthropic-mid-output-fallback-ideal.test.ts
+++ b/packages/ai/test/anthropic-mid-output-fallback-ideal.test.ts
@@ -1,0 +1,220 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { getModel } from "../src/compat.ts";
+import { wrapStreamWithModelRecovery } from "../src/tool-call-middleware/index.ts";
+
+function responseFor(events: Array<{ event: string; data: unknown }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n`).join("\n");
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function clientFor(response: Response): Anthropic {
+	return {
+		beta: { messages: { create: () => ({ asResponse: async () => response }) } },
+	} as unknown as Anthropic;
+}
+
+describe("Anthropic mid-output fallback", () => {
+	it.each([
+		[false, false, false],
+		[true, false, false],
+		[true, true, false],
+		[true, false, true],
+		[true, true, true],
+	])("honors boundary with recovery=%s, truncated=%s, survivor=%s", async (recovery, truncated, survivor) => {
+		const events = [
+			{ type: "message_start", message: { id: "msg-tools", model: "claude-opus-5", usage: {} } },
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: "abandoned", name: "must_not_run", input: {} },
+			},
+			{ type: "content_block_stop", index: 0 },
+			{
+				type: "content_block_start",
+				index: 1,
+				content_block: {
+					type: "fallback",
+					from: { model: "claude-opus-5" },
+					to: { model: "claude-opus-4-8" },
+				},
+			},
+			{ type: "content_block_stop", index: 1 },
+			{ type: "content_block_start", index: 2, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 2, delta: { type: "text_delta", text: "safe answer" } },
+			{ type: "content_block_stop", index: 2 },
+			{ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: {} },
+			{ type: "message_stop" },
+		];
+		if (survivor) {
+			events.splice(
+				events.length - 2,
+				0,
+				{
+					type: "content_block_start",
+					index: 3,
+					content_block: { type: "tool_use", id: "survivor", name: "must_not_run", input: {} },
+				},
+				{ type: "content_block_stop", index: 3 },
+			);
+		}
+		const model = getModel("anthropic", "claude-opus-5");
+		const raw = streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Hello", timestamp: 1 }] },
+			{
+				client: clientFor(
+					responseFor((truncated ? events.slice(0, -2) : events).map((data) => ({ event: data.type, data }))),
+				),
+				abortServerSideFallback: false,
+			},
+		);
+		const result = await (recovery
+			? wrapStreamWithModelRecovery(raw, model, [
+					{
+						name: "must_not_run",
+						description: "Abandoned tool",
+						parameters: Type.Object({}),
+					},
+				])
+			: raw
+		).result();
+
+		expect(result.stopReason).toBe(survivor ? "toolUse" : truncated ? "error" : "stop");
+		expect(result.content.filter((block) => block.type === "toolCall").map((block) => block.id)).toEqual(
+			survivor ? ["survivor"] : [],
+		);
+		expect(result.content.filter((block) => block.type === "text").map((block) => block.text)).toEqual([
+			"safe answer",
+		]);
+	});
+
+	it("routes a fallback marker after partial output through server fallback handling", async () => {
+		const result = await streamAnthropic(
+			getModel("anthropic", "claude-opus-5"),
+			{ messages: [{ role: "user", content: "Hello", timestamp: 1 }] },
+			{
+				client: clientFor(
+					responseFor([
+						{
+							event: "message_start",
+							data: { type: "message_start", message: { id: "msg", model: "claude-opus-5", usage: {} } },
+						},
+						{
+							event: "content_block_start",
+							data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "partial" } },
+						},
+						{ event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+						{
+							event: "content_block_start",
+							data: {
+								type: "content_block_start",
+								index: 1,
+								content_block: {
+									type: "fallback",
+									from: { model: "claude-opus-5" },
+									to: { model: "claude-opus-4-8" },
+								},
+							},
+						},
+					]),
+				),
+				abortServerSideFallback: true,
+			},
+		).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.stopDetails?.type).toBe("refusal");
+		expect(result.content).toEqual([]);
+		expect(result.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "server_fallback_aborted",
+					details: { from: "claude-opus-5", to: "claude-opus-4-8" },
+				}),
+			]),
+		);
+		expect(result.errorMessage).toContain("Server-side fallback");
+		expect(result.errorMessage).not.toContain("unsupported mid-output");
+	});
+
+	it("continues a mid-output fallback stream when client abort is disabled", async () => {
+		const result = await streamAnthropic(
+			{
+				...getModel("anthropic", "claude-opus-5"),
+				cost: { input: 11, output: 13, cacheRead: 0, cacheWrite: 0 },
+				compat: {
+					allowedFallbackModels: [
+						{
+							provider: "anthropic",
+							model: "claude-opus-4-8",
+							cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+						},
+					],
+				},
+			},
+			{ messages: [{ role: "user", content: "Hello", timestamp: 1 }] },
+			{
+				client: clientFor(
+					responseFor([
+						{
+							event: "message_start",
+							data: {
+								type: "message_start",
+								message: { id: "msg-continue", model: "claude-opus-5", usage: {} },
+							},
+						},
+						{
+							event: "content_block_start",
+							data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "before " } },
+						},
+						{ event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+						{
+							event: "content_block_start",
+							data: {
+								type: "content_block_start",
+								index: 1,
+								content_block: {
+									type: "fallback",
+									from: { model: "claude-opus-5" },
+									to: { model: "claude-opus-4-8" },
+								},
+							},
+						},
+						{
+							event: "content_block_start",
+							data: { type: "content_block_start", index: 2, content_block: { type: "text", text: "after" } },
+						},
+						{ event: "content_block_stop", data: { type: "content_block_stop", index: 2 } },
+						{
+							event: "message_delta",
+							data: {
+								type: "message_delta",
+								delta: { stop_reason: "end_turn" },
+								usage: { input_tokens: 1_000_000, output_tokens: 2_000_000 },
+							},
+						},
+						{ event: "message_stop", data: { type: "message_stop" } },
+					]),
+				),
+				abortServerSideFallback: false,
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.model).toBe("claude-opus-4-8");
+		expect(result.usage.cost).toMatchObject({ input: 2, output: 6, total: 8 });
+		expect(result.content).toEqual([
+			{ type: "text", text: "before " },
+			{
+				type: "providerNative",
+				subtype: "fallback",
+				raw: { type: "fallback", from: { model: "claude-opus-5" }, to: { model: "claude-opus-4-8" } },
+				index: 1,
+			},
+			{ type: "text", text: "after" },
+		]);
+	});
+});

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -121,11 +121,11 @@ describe("Anthropic raw SSE parsing", () => {
 		const result = await streamAnthropic(
 			model,
 			{ messages: [{ role: "user", content: "Hello", timestamp: 1 }] },
-			{ client: createFakeAnthropicClient(response) },
+			{ client: createFakeAnthropicClient(response), abortServerSideFallback: true },
 		).result();
 
 		expect(result.stopReason).toBe("error");
-		expect(result.errorMessage).toContain("unsupported mid-output model fallback");
+		expect(result.errorMessage).toContain("Server-side fallback");
 	});
 
 	it("forces streaming after an onPayload replacement", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Anthropic mid-output server fallback now recovers through the configured refusal chain without cooling down the original model. When server fallback is allowed, abandoned tool calls are not executed and fallback markers stay out of subsequent requests.
+
 - A rejected Anthropic request now reports its HTTP status through the provider response hook: previously the Anthropic SDK's rejection path never reached `onResponse`/`after_provider_response`, so the native tool-search adapter's permanent 400 fallback was dead code on the live error path (senpi #1481). Errors without a numeric status (network failures, aborts) report nothing rather than a fabricated code.
 
 - A native tool-search 400 no longer demotes the session to a weaker model: the turn is retried once in place on the same model with native injection already disabled for the session, and only a second rejection consults the fallback chain (senpi #1482).


### PR DESCRIPTION
## Summary

Handle Anthropic server-side fallback blocks after output has started instead of throwing an unsupported-fallback error. The abort policy now reaches the existing refusal chain; the continuation policy preserves the serving model, configured pricing, and an audit-only fallback boundary.

Abandoned client tools are demoted before the agent can execute them. Recovery middleware also removes tools projected before the final fallback boundary on both successful and failed streams, while retaining valid post-boundary tools.

## Verification

- Captured failing-first regressions for the original unsupported error, abandoned tool execution, recovery middleware resurrection, and premature-EOF recovery.
- Ran the focused Anthropic and recovery middleware suites on a separate macOS host: 46 files / 576 tests passed. Session refusal/fallback coverage added 2 files / 9 passing tests.
- Ran root `bun run check` locally and the full root `bun run build` on the remote host, both successfully.
- Drove the real CLI against a local Anthropic SSE server:
  `node .agents/skills/senpi-qa/scripts/scenarios/anthropic-mid-output-fallback-qa.mjs --self-test`
  Both abort and continue modes returned the final marker; abandoned tool execution and cooldown entries were absent. A second CLI turn contained no fallback input marker. Both sandbox and server teardown were verified, and real credentials were unchanged.
- Read-only review approved the final EOF/pruning correction after identifying the error-terminal gap.

Local, sanitized evidence is retained under `local-ignore/qa-evidence/20260908-anthropic-fallback/` and `local-ignore/qa-evidence/20260908-anthropic-mid-output-wire/`. The reproducible real-CLI scenario is included in this PR.

## Scope and limitations

No release or installed runtime update is included. Costs use configured fallback pricing when available, retaining the adapter's existing estimate policy otherwise.

The generic mock-loop self-test also reported unrelated text-tool leak scenarios failing (13/22); its general result is not claimed as green. The exact fallback wire scenario above is a separate passing check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles Anthropic server-side fallback blocks that arrive after output has started, so the stream no longer errors with an unsupported-fallback message. Abort policy now routes through the existing refusal chain; continuation preserves the serving model and configured pricing, and abandoned pre-fallback tools are never executed.

**Behavior**
- With `abortServerSideFallback` enabled, a mid-output fallback aborts the stream and produces a refusal diagnostic, matching pre-output fallback handling.
- With abort disabled, the stream continues, records the fallback boundary, and updates the serving model and cost to the fallback model when configured.
- Recovery middleware now discards tool calls that appear before a fallback boundary, on both successful and failed streams, so they cannot run.
- Fallback markers are kept out of subsequent request payloads during `--continue`.

<sup>Written for commit 7e288d824031e5dcc90497945d4109a528258abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

