### PR TITLE
fix(ci): pin Bun toolchain to 1.4.2

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -19,7 +19,7 @@ upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
 
 | Task | Path |
 |---|---|
-| CI parity for local checks | `workflows/ci.yml` (Node 24, `npm ci --ignore-scripts`, bun 1.4.0 pinned through `oven-sh/setup-bun` in the jobs that run bun, fan-in job named exactly `Check and test`) |
+| CI parity for local checks | `workflows/ci.yml` (Node 24, `npm ci --ignore-scripts`, bun 1.4.2 pinned through `oven-sh/setup-bun` in the jobs that run bun, fan-in job named exactly `Check and test`) |
 | npm publish path | `workflows/publish-npm.yml` (the ONLY publisher; triggered after release tag) |
 | Binary/native builds | `workflows/build-binaries.yml`, `workflows/native-prebuilds.yml` |
 | PR changelog gate | `workflows/changelog-gate.yml` (drives `scripts/check-pr-changelog.mjs`) |
@@ -30,7 +30,7 @@ upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
 ## CONVENTIONS
 
 - GitHub Actions are pinned by full commit SHA (e.g. `actions/checkout@df4cb1c0...`); never reference floating tags.
-- Workflows install with `npm ci --ignore-scripts` and run the root scripts through npm (`npm run check`, `npm run build`, `npm run test:scripts`); `test-workspaces` also runs `bun run test:scripts` under pinned bun 1.4.0 to prove the bun path of the root scripts and runs the workspace suites through `scripts/run-workspaces.mjs`; `rpc-windows` runs its suites through `bunx vitest`.
+- Workflows install with `npm ci --ignore-scripts` and run the root scripts through npm (`npm run check`, `npm run build`, `npm run test:scripts`); `test-workspaces` also runs `bun run test:scripts` under pinned bun 1.4.2 to prove the bun path of the root scripts and runs the workspace suites through `scripts/run-workspaces.mjs`; `rpc-windows` runs its suites through `bunx vitest`.
 - The release driver emits a final stdout status line: `RELEASE_DECISION: RELEASE | SKIP | FAILED`.
   The merge agent emits `MERGE_RESULT: CLEAN_PR_READY | NO_RELEASE_NEEDED | CONFLICTS | QA_FAILED | AGENT_FAILED`.
 - Release runs only after the upstream PR is merge-committed into `main`, a fresh `/cl`

--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Pin Bun CI and release builds to 1.4.2 (2026-09-08)
+
+### What changed
+
+- Updated the Bun pins in CI, binary builds, and npm publishing to stable 1.4.2, together with the workflow assertion and current CI guidance.
+
+### Why
+
+- Keep the build and test toolchain on the current stable release with published cross-compilation assets.
+
+### Why an extension could not handle it
+
+- GitHub Actions selects the toolchain before runtime extensions load.
+
+### Expected merge conflict zones
+
+- LOW: Bun setup steps in the three workflows and their version assertion.
+
 ## test-workspaces proves the bun path of the root scripts (2026-09-07)
 
 ### What changed

--- a/.github/changes.md
+++ b/.github/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- Updated the Bun pins in CI, binary builds, and npm publishing to stable 1.4.2, together with the workflow assertion and current CI guidance.
+- Updated `.github/workflows/ci.yml`, `.github/workflows/build-binaries.yml`, and `.github/workflows/publish-npm.yml` to pin stable Bun 1.4.2, together with the workflow assertion and current CI guidance.
 
 ### Why
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           # Cross-compilation downloads target executables matching the running Bun
           # release. Canary can advance before those target artifacts are published.
-          bun-version: '1.4.0'
+          bun-version: '1.4.2'
 
       - name: Report Bun compiler version
         run: bun --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -180,7 +180,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: '1.4.0'
+          bun-version: '1.4.2'
 
       - name: Assert bun 1.4 toolchain
         run: bash scripts/assert-bun-toolchain.sh

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -17,7 +17,7 @@ const codingAgentPackage = JSON.parse(
 
 describe("binary release workflow", () => {
 	it("pins a stable Bun release with downloadable cross-compile executables", () => {
-		assert.match(workflow, /bun-version:\s*['"]1\.4\.0['"]/);
+		assert.match(workflow, /bun-version:\s*['"]1\.4\.2['"]/);
 		assert.doesNotMatch(workflow, /bun-version:\s*canary/);
 		assert.doesNotMatch(workflow, /assert-bun-canary\.sh/);
 	});


### PR DESCRIPTION
## Summary
- Pin CI, binary builds, and npm publishing to Bun 1.4.2
- Update workflow assertion and CI guidance

## Verification
- Independent QA: `/tmp/bun142-qa-01a0806b-senpi-qa.md`
- Focused workflow tests: 5 passed, 0 failed
- Frozen install/build: exit 0
- Built senpi CLI `--version`: exit 0

No product release or unrelated source changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Bun toolchain to 1.4.2 across CI, binary builds, and npm publishing, replacing the previous 1.4.0 pin. Updates the workflow assertion and CI guidance to match, keeping builds on a stable release with published cross-compilation assets.

<sup>Written for commit c382bd99e6316f246ba6fac62a672bc054097912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

