### PR TITLE
fix(compaction): recover fitting suffixes after summarizer failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Required compaction no longer charges serialized prose bytes as tokens, which could reject a fitting retained turn after summarization failed. Automatic blocking compaction and failed warm summaries now share manual compaction's deterministic recovery. Recovery preserves complete tool pairs across steering messages and ignores duplicate IDs in discarded history; genuinely rejected suffixes now report their boundary, token budget, and unsafe message location with recovery guidance ([oh-my-openagent#7952](https://github.com/code-yeongyu/oh-my-openagent/issues/7952)).
+
 - Anthropic mid-output server fallback now recovers through the configured refusal chain without cooling down the original model. When server fallback is allowed, abandoned tool calls are not executed and fallback markers stay out of subsequent requests.
 
 - An active goal no longer stalls forever when a provider ends the turn with the `tool_use` stop reason but no tool-call block. Nothing executed on such a turn, so it is treated as provider breakage and resumed through the existing provider-recovery lane instead of being read as a deliberate tool-driven stop. A turn that a tool genuinely ended still waits for the user, and every existing admission guard (continuation cap, repetition, single-flight, unattended budget) still bounds the recovery.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,29 @@
 # changes.md — builtin compaction policy
 
+## Recover fitting retained suffixes with consistent token accounting (2026-09-08)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts` estimates serialized envelopes and checkpoint text through the shared weighted token estimator instead of treating UTF-8 bytes as tokens. Only actual image payloads are omitted from envelope estimation; image costs remain additive and opaque metadata remains charged.
+- Candidate chain validation is suffix-local: discarded historical duplicate IDs cannot invalidate a retained unique pair. Recovery also backtracks from the latest user request to its complete tool-chain boundary.
+- `packages/coding-agent/src/core/extensions/builtin/compaction/index.ts` now passes fallback diagnostics into a bounded rejection message containing the effective window, reserve, budget, candidate, and unsafe message location, with recovery guidance.
+- Fresh blocking compaction and unchanged failed warm snapshots now use the same required fallback as manual/core compaction. Stale warm failures are regenerated against a fresh snapshot; abort, generation, revision, lane, and core apply checks remain in place.
+
+### Why
+
+- code-yeongyu/oh-my-openagent#7952 reported a chain-valid latest turn of roughly 136k tokens that could not recover. The serialized-byte floor could charge that prose as over 540k tokens, while the production caller discarded the diagnostic that distinguished budget rejection from malformed content.
+- Real CLI validation found that the separate automatic blocking route never reached deterministic recovery after a classified summary failure, so correcting only the core/manual hook left that route unprotected.
+
+### Why an extension could not handle it
+
+- The builtin owns candidate acceptance and cancels required compaction before another extension can correct its estimate or select a valid boundary. The repair stays inside that builtin rather than modifying session-core admission.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts`: suffix scan, chain-valid ranges, candidate diagnostics.
+- `packages/coding-agent/src/core/extensions/builtin/compaction/index.ts`: classified summarization failure handler.
+- Tests: `test/suite/regressions/issue-7952-compaction-recovery.test.ts` and the existing deterministic-fallback budget/unsafe-message fixtures.
+
 ## Normalize failed and aborted assistant fragments in the fallback projection (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
@@ -46,9 +46,54 @@ export interface DeterministicFallbackDiagnostic {
 	candidateRejections?: Array<{
 		firstKeptEntryId: string;
 		rejectionReason: DeterministicFallbackRejectionReason;
+		estimatedTokens?: number;
+		unsafeMessageIndex?: number;
+		unsafeEntryId?: string;
+		unsafeMessageRole?: string;
 	}>;
 	candidatesChecked?: number;
 	budgetExceeded?: boolean;
+	contextWindow?: number;
+	reserveTokens?: number;
+	budgetTokens?: number;
+}
+
+export function formatRequiredCompactionFallbackRejection(diagnostics: DeterministicFallbackDiagnostic): string {
+	const candidate = diagnostics.candidateRejections?.at(-1);
+	const reason = diagnostics.rejectionReason ?? "context-reconstruction-failed";
+	const recovery: Record<DeterministicFallbackRejectionReason, string> = {
+		"retained-token-budget-exceeded":
+			"The retained turn exceeds the usable context. Select a model with a larger context and run /compact, or start a new session with an explicit checkpoint.",
+		"atomic-tool-chain-cut":
+			"The retained tool calls and results do not form complete pairs. Finish the pending tool operation before /compact; if the transcript is damaged, start a new session with an explicit checkpoint.",
+		"unsafe-retained-content":
+			"The retained message cannot be replayed safely. Inspect the identified entry; start a new session with an explicit checkpoint if it cannot be repaired.",
+		"missing-preparation-boundary":
+			"The prepared boundary is absent from the branch. Reload the session and run /compact.",
+		"context-reconstruction-failed":
+			"The retained context could not be reconstructed. Reload the session and run /compact.",
+	};
+	const diagnostic = {
+		rejectionReason: reason,
+		contextWindow: diagnostics.contextWindow,
+		reserveTokens: diagnostics.reserveTokens,
+		budgetTokens: diagnostics.budgetTokens,
+		budgetExceeded: diagnostics.budgetExceeded ?? false,
+		candidatesChecked: diagnostics.candidatesChecked ?? 0,
+		...(candidate
+			? {
+					candidate: {
+						...candidate,
+						firstKeptEntryId: capUtf8Bytes(candidate.firstKeptEntryId, 128),
+						...(candidate.unsafeEntryId ? { unsafeEntryId: capUtf8Bytes(candidate.unsafeEntryId, 128) } : {}),
+						...(candidate.unsafeMessageRole
+							? { unsafeMessageRole: capUtf8Bytes(candidate.unsafeMessageRole, 32) }
+							: {}),
+					},
+				}
+			: {}),
+	};
+	return `deterministic compaction fallback could not retain a safe suffix\n${JSON.stringify(diagnostic)}\n${recovery[reason]} The original transcript has not been changed.`;
 }
 
 const NON_VISIBLE_USER_TEXT = /[\p{White_Space}\p{Default_Ignorable_Code_Point}]/gu;
@@ -121,9 +166,18 @@ export function createRequiredCompactionFallback(
 	branchEntries: SessionEntry[] = [],
 	diagnostics?: DeterministicFallbackDiagnostic,
 ): CompactionResult<DeterministicFallbackDetails> | undefined {
+	const reserveTokens = resolveEffectiveReserveTokens(contextWindow, preparation.settings);
+	const budget = contextWindow - reserveTokens;
 	const preparedBoundaryIndex = branchEntries.findIndex((entry) => entry.id === preparation.firstKeptEntryId);
 	if (!preparation.firstKeptEntryId || preparedBoundaryIndex === -1) {
-		if (diagnostics) diagnostics.rejectionReason = "missing-preparation-boundary";
+		if (diagnostics) {
+			Object.assign(diagnostics, {
+				rejectionReason: "missing-preparation-boundary",
+				contextWindow,
+				reserveTokens,
+				budgetTokens: budget,
+			});
+		}
 		return undefined;
 	}
 
@@ -173,7 +227,14 @@ export function createRequiredCompactionFallback(
 			buildSessionContext([...branchEntries, syntheticCompaction]).messages,
 		);
 	} catch {
-		if (diagnostics) diagnostics.rejectionReason = "context-reconstruction-failed";
+		if (diagnostics) {
+			Object.assign(diagnostics, {
+				rejectionReason: "context-reconstruction-failed",
+				contextWindow,
+				reserveTokens,
+				budgetTokens: budget,
+			});
+		}
 		return undefined;
 	}
 
@@ -191,12 +252,14 @@ export function createRequiredCompactionFallback(
 	}
 	const summaryIndex = messageIndexesByEntryId.get(syntheticCompaction.id);
 	const unsafeSuffix = new Array(projectedMessages.length + 1).fill(false);
+	const unsafeIndexSuffix = new Int32Array(projectedMessages.length + 1).fill(-1);
 	const tokenSuffix = new Array(projectedMessages.length + 1).fill(0);
-	const toolCalls = new Map<string, { indexes: number[]; incomplete: boolean }>();
+	const toolCalls = new Map<string, { indexes: number[]; newestIncomplete: boolean }>();
 	const toolResults = new Map<string, number[]>();
 	for (let index = projectedMessages.length - 1; index >= 0; index--) {
 		const message = projectedMessages[index];
 		tokenSuffix[index] = tokenSuffix[index + 1];
+		unsafeIndexSuffix[index] = unsafeIndexSuffix[index + 1];
 		if (droppedByFailedTurnNormalization[index]) {
 			unsafeSuffix[index] = unsafeSuffix[index + 1];
 			continue;
@@ -205,27 +268,34 @@ export function createRequiredCompactionFallback(
 		let serialized: string | undefined;
 		try {
 			messageUnsafe = hasUnsafeRetainedContent([message]);
-			serialized = isSafeBoundedValue(message) ? JSON.stringify(message) : undefined;
-			let imagePayloadBytes = 0;
+			const bounded = isSafeBoundedValue(message);
+			messageUnsafe ||= !bounded;
 			let imageTokens = 0;
-			if (!messageUnsafe && serialized !== undefined && message.role === "toolResult") {
-				for (const block of message.content) {
-					if (block.type !== "image") continue;
-					// Keep the JSON delimiters and metadata charged, but replace only
-					// this validated image's escaped payload bytes with its token cost.
-					imagePayloadBytes += Buffer.byteLength(JSON.stringify(block.data)) - 2;
+			if (!messageUnsafe && message.role === "toolResult") {
+				const content = message.content.map((block) => {
+					if (block.type !== "image") return block;
 					imageTokens += estimateTokens({ ...message, content: [block] });
-				}
+					return { ...block, data: "" };
+				});
+				serialized = JSON.stringify({ ...message, content });
+			} else {
+				serialized = bounded ? JSON.stringify(message) : undefined;
 			}
+			// Apply the shared weighted chars/4 estimator to the envelope too.
+			// Storage bytes are not tokens; opaque text and image costs still count.
 			tokenSuffix[index] +=
 				serialized === undefined
 					? Number.POSITIVE_INFINITY
-					: Math.max(estimateTokens(message), Buffer.byteLength(serialized) - imagePayloadBytes + imageTokens);
+					: Math.max(
+							estimateTokens(message),
+							estimateTokens({ role: "user", content: serialized, timestamp: 0 }) + imageTokens,
+						);
 		} catch {
 			messageUnsafe = true;
 			tokenSuffix[index] = Number.POSITIVE_INFINITY;
 		}
 		unsafeSuffix[index] = unsafeSuffix[index + 1] || messageUnsafe;
+		if (messageUnsafe) unsafeIndexSuffix[index] = index;
 		if (!isRecord(message)) continue;
 		if (message.role === "toolResult" && typeof message.toolCallId === "string") {
 			const indexes = toolResults.get(message.toolCallId) ?? [];
@@ -234,9 +304,8 @@ export function createRequiredCompactionFallback(
 		} else if (message.role === "assistant" && Array.isArray(message.content)) {
 			for (const block of message.content) {
 				if (!isRecord(block) || block.type !== "toolCall" || typeof block.id !== "string") continue;
-				const call = toolCalls.get(block.id) ?? { indexes: [], incomplete: false };
+				const call = toolCalls.get(block.id) ?? { indexes: [], newestIncomplete: block.incomplete === true };
 				call.indexes.push(index);
-				call.incomplete ||= block.incomplete === true;
 				toolCalls.set(block.id, call);
 			}
 		}
@@ -251,15 +320,20 @@ export function createRequiredCompactionFallback(
 	};
 	for (const [id, call] of toolCalls) {
 		const results = toolResults.get(id) ?? [];
-		if (call.indexes.length !== 1 || results.length !== 1) {
+		if (results.length === 0) {
 			markInvalidRange(0, Math.max(call.indexes[0] ?? -1, results[0] ?? -1) + 1);
 			continue;
 		}
 		const callIndex = call.indexes[0];
 		const resultIndex = results[0];
-		if (call.incomplete) markInvalidRange(0, Math.max(callIndex, resultIndex) + 1);
-		else if (callIndex < resultIndex) markInvalidRange(callIndex + 1, resultIndex + 1);
-		else markInvalidRange(0, Math.max(callIndex, resultIndex) + 1);
+		// Indexes are newest-first. Older duplicate IDs matter only while retained;
+		// dropping an entire historical pair leaves the newest pair valid.
+		markInvalidRange(0, Math.max(call.indexes[1] ?? -1, results[1] ?? -1) + 1);
+		if (call.newestIncomplete || callIndex >= resultIndex) {
+			markInvalidRange(0, Math.max(callIndex, resultIndex) + 1);
+		} else {
+			markInvalidRange(callIndex + 1, resultIndex + 1);
+		}
 	}
 	for (const [id, results] of toolResults) {
 		if (toolCalls.has(id)) continue;
@@ -278,11 +352,20 @@ export function createRequiredCompactionFallback(
 	): CompactionResult<DeterministicFallbackDetails> | undefined => {
 		candidateCount++;
 		const details = { ...baseDetails, retainedSuffix };
-		const reject = (rejectionReason: DeterministicFallbackRejectionReason): undefined => {
+		const reject = (
+			rejectionReason: DeterministicFallbackRejectionReason,
+			detail: Omit<
+				NonNullable<DeterministicFallbackDiagnostic["candidateRejections"]>[number],
+				"firstKeptEntryId" | "rejectionReason"
+			> = {},
+		): undefined => {
 			if (diagnostics) {
 				diagnostics.rejectionReason = rejectionReason;
+				diagnostics.contextWindow = contextWindow;
+				diagnostics.reserveTokens = reserveTokens;
+				diagnostics.budgetTokens = budget;
 				diagnostics.candidateRejections ??= [];
-				diagnostics.candidateRejections.push({ firstKeptEntryId, rejectionReason });
+				diagnostics.candidateRejections.push({ firstKeptEntryId, rejectionReason, ...detail });
 			}
 			return undefined;
 		};
@@ -295,22 +378,33 @@ export function createRequiredCompactionFallback(
 		const startIndex = messageIndexesByEntryId.get(firstKeptEntryId);
 		if (startIndex === undefined) return reject("context-reconstruction-failed");
 		const retainedStart = Math.min(startIndex, projectedMessages.length);
-		if (unsafeSuffix[retainedStart]) return reject("unsafe-retained-content");
+		if (unsafeSuffix[retainedStart]) {
+			const unsafeMessageIndex = unsafeIndexSuffix[retainedStart];
+			const unsafeMessage = projectedMessages[unsafeMessageIndex];
+			return reject("unsafe-retained-content", {
+				unsafeMessageIndex,
+				unsafeEntryId: getSessionContextEntryId(unsafeMessage),
+				unsafeMessageRole: unsafeMessage.role,
+			});
+		}
 		if (!toolChainValidAt[retainedStart]) return reject("atomic-tool-chain-cut");
 		// The hard-limit valve reserves the scaled budget, so accepting against the raw
 		// configured reserve would admit a context that valve immediately compacts again.
-		const budget = contextWindow - resolveEffectiveReserveTokens(contextWindow, preparation.settings);
 		const summaryTokens =
 			summaryIndex === undefined
 				? Number.POSITIVE_INFINITY
 				: Math.max(
 						estimateTokens(projectedMessages[summaryIndex]),
-						Buffer.byteLength(JSON.stringify(projectedMessages[summaryIndex])),
+						estimateTokens({
+							role: "user",
+							content: JSON.stringify(projectedMessages[summaryIndex]),
+							timestamp: 0,
+						}),
 					);
 		const retainedTokens = (tokenSuffix[retainedStart] ?? Number.POSITIVE_INFINITY) + summaryTokens;
 		if (retainedTokens > budget) {
 			if (diagnostics) diagnostics.budgetExceeded = true;
-			return reject("retained-token-budget-exceeded");
+			return reject("retained-token-budget-exceeded", { estimatedTokens: retainedTokens });
 		}
 		return { ...result, estimatedTokensAfter: retainedTokens };
 	};
@@ -343,6 +437,17 @@ export function createRequiredCompactionFallback(
 		if (latestUser) {
 			if (diagnostics) diagnostics.candidatesChecked = candidateCount;
 			return latestUser;
+		}
+		// A steering user message can occur inside a tool chain. Keep that request
+		// and walk back to its declaring assistant instead of orphaning the result.
+		for (let earlierIndex = index - 1; earlierIndex > preparedBoundaryIndex; earlierIndex--) {
+			const earlierEntry = branchEntries[earlierIndex];
+			if (earlierEntry.type === "compaction") break;
+			const earlier = projectCandidate(earlierEntry.id, "earlier-safe-boundary");
+			if (earlier) {
+				if (diagnostics) diagnostics.candidatesChecked = candidateCount;
+				return earlier;
+			}
 		}
 		break;
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -15,6 +15,9 @@ import {
 import {
 	classifyRequiredCompactionFallbackFailure,
 	createRequiredCompactionFallback,
+	type DeterministicFallbackDiagnostic,
+	formatRequiredCompactionFallbackRejection,
+	type RequiredCompactionFallbackFailure,
 } from "./deterministic-fallback.ts";
 import * as idle from "./idle.ts";
 import * as idleRetry from "./idle-retry.ts";
@@ -368,6 +371,22 @@ export default function compactionExtension(
 		todoBridge.persistTodoSnapshot(pi, metadata.todoSnapshot);
 	}
 
+	function recoverRequiredCompaction(
+		snapshot: SpeculativeCompactionSnapshot,
+		failureKind: RequiredCompactionFallbackFailure,
+	): { compaction?: CompactionResult; rejectionReason?: string } {
+		const diagnostics: DeterministicFallbackDiagnostic = {};
+		const compaction = createRequiredCompactionFallback(
+			snapshot.preparation,
+			snapshot.contextWindow,
+			failureKind,
+			{ taskIntent: resolveInheritedTaskIntent(snapshot.branchEntries ?? []) },
+			snapshot.branchEntries,
+			diagnostics,
+		);
+		return compaction ? { compaction } : { rejectionReason: formatRequiredCompactionFallbackRejection(diagnostics) };
+	}
+
 	async function applyBlockingCompaction(
 		ctx: ExtensionContext,
 		customInstructions: string,
@@ -448,7 +467,24 @@ export default function compactionExtension(
 				}
 				if (inheritedFailure !== undefined) {
 					speculativeJob = undefined;
-					if (isTransientSummarizationFailure(inheritedFailure, inheritedFailure.message)) {
+					const failureKind = classifyRequiredCompactionFallbackFailure(inheritedFailure);
+					if (
+						failureKind !== undefined &&
+						!feedbackSignal?.aborted &&
+						pendingJob.snapshot.generation === speculativeGeneration &&
+						pendingJob.snapshot.expectedRevision === ctx.getMessageRevision()
+					) {
+						const recovery = recoverRequiredCompaction(pendingJob.snapshot, failureKind);
+						compaction = recovery.compaction;
+						if (!compaction) {
+							const result = { applied: false, reason: "failed" } as const;
+							endCompactionFeedback(ctx, feedbackSignal, result, recovery.rejectionReason);
+							return result;
+						}
+					} else if (
+						failureKind === undefined &&
+						isTransientSummarizationFailure(inheritedFailure, inheritedFailure.message)
+					) {
 						ctx.endCompaction?.({
 							reason: "extension",
 							signal: feedbackSignal,
@@ -506,8 +542,19 @@ export default function compactionExtension(
 					}),
 				);
 			} catch (error) {
-				if (!(error instanceof SummaryGenerationError)) throw error;
-				getLogger(ctx).debug("summary_failed", { reason: error.kind });
+				const failureKind = classifyRequiredCompactionFallbackFailure(error);
+				if (failureKind !== undefined && !feedbackSignal?.aborted) {
+					const recovery = recoverRequiredCompaction(snapshot, failureKind);
+					compaction = recovery.compaction;
+					if (!compaction) {
+						const result = { applied: false, reason: "failed" } as const;
+						endCompactionFeedback(ctx, feedbackSignal, result, recovery.rejectionReason);
+						return result;
+					}
+				} else {
+					if (!(error instanceof SummaryGenerationError)) throw error;
+					getLogger(ctx).debug("summary_failed", { reason: error.kind });
+				}
 			}
 			const result = await applyGeneratedCompaction(
 				ctx,
@@ -555,6 +602,7 @@ export default function compactionExtension(
 		// keeps streaming for a result nobody will read.
 		let warmJobConsumed = false;
 		invalidateSpeculativeCompaction(ctx);
+		const claimedGeneration = speculativeGeneration;
 		try {
 			if (!lanePolicy.ownsCompaction(ctx, event.reason)) {
 				return {
@@ -609,6 +657,7 @@ export default function compactionExtension(
 				return { compaction: remoteCompaction };
 			}
 
+			let inheritedWarmFailure: Error | undefined;
 			if (claimedWarmJob) {
 				const unlinkAbort = linkAbortSignal(event.signal, claimedWarmJob.controller);
 				let warmCompaction: CompactionResult | undefined;
@@ -623,6 +672,16 @@ export default function compactionExtension(
 					getLogger(ctx).debug("warm_consumed", { generation: claimedWarmJob.generation, route: "core-route" });
 					warmJobConsumed = true;
 					return { compaction: warmCompaction };
+				}
+				if (
+					warmFailure !== undefined &&
+					isRequiredCompactionFallbackReason(event.reason) &&
+					classifyRequiredCompactionFallbackFailure(warmFailure) !== undefined &&
+					!event.signal.aborted &&
+					speculativeGeneration === claimedGeneration &&
+					claimedWarmJob.snapshot.expectedRevision === ctx.getMessageRevision()
+				) {
+					inheritedWarmFailure = warmFailure;
 				}
 			}
 
@@ -641,6 +700,7 @@ export default function compactionExtension(
 			};
 			let compaction: CompactionResult | undefined;
 			try {
+				if (inheritedWarmFailure) throw inheritedWarmFailure;
 				compaction = await runExtensionCompaction(ctx, snapshot, event.signal, (delta) =>
 					ctx.updateCompaction?.({ reason: event.reason, signal: event.signal, delta }),
 				);
@@ -652,18 +712,12 @@ export default function compactionExtension(
 					failureKind !== undefined &&
 					!event.signal.aborted
 				) {
-					const fallback = createRequiredCompactionFallback(
-						snapshot.preparation,
-						snapshot.contextWindow,
-						failureKind,
-						{ taskIntent: resolveInheritedTaskIntent(event.branchEntries) },
-						event.branchEntries,
-					);
-					if (fallback) return { compaction: fallback };
+					const recovery = recoverRequiredCompaction(snapshot, failureKind);
+					if (recovery.compaction) return { compaction: recovery.compaction };
 					pendingMetadata.delete(event.requestId);
 					return {
 						cancel: true,
-						reason: "deterministic compaction fallback cannot retain the prepared suffix",
+						reason: recovery.rejectionReason,
 					};
 				}
 				pendingMetadata.delete(event.requestId);

--- a/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
@@ -178,7 +178,7 @@ describe("session_before_compact error surfacing", () => {
 		expect(call?.context.systemPrompt).toBe("TEST AGENT SYSTEM PROMPT");
 	});
 
-	it("cancels with a stop-reason diagnosis when the summarization response has no text", async () => {
+	it("cancels with a boundary diagnosis when empty-summary recovery has no retained branch", async () => {
 		// Given: the model spends the whole output budget on thinking (adaptive
 		// reasoning models do this without being asked) and the stream ends at
 		// the token cap with zero text content.
@@ -193,7 +193,14 @@ describe("session_before_compact error surfacing", () => {
 		// Then: this classified failure enters deterministic recovery, but the
 		// deliberately boundary-less fixture cannot retain a safe suffix.
 		expect(result?.cancel).toBe(true);
-		expect(result?.reason).toBe("deterministic compaction fallback cannot retain the prepared suffix");
+		expect(JSON.parse(result?.reason?.split("\n")[1] ?? "{}")).toEqual({
+			rejectionReason: "missing-preparation-boundary",
+			contextWindow: 128_000,
+			reserveTokens: 16_384,
+			budgetTokens: 111_616,
+			budgetExceeded: false,
+			candidatesChecked: 0,
+		});
 	});
 
 	it("cancels with the credential error when summarization auth is unavailable", async () => {

--- a/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
@@ -126,19 +126,27 @@ describe("blocking compaction review hardening", () => {
 	});
 
 	describe("Given the summarization response has no text", () => {
-		it("Then blocking compaction surfaces the unavailable reason", async () => {
+		it("Then blocking compaction applies deterministic recovery", async () => {
 			// Given
 			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_950 });
 			registrations.push(harness.registration);
 			harness.registration.setResponses([fauxAssistantMessage("", { stopReason: "stop" })]);
 
-			// When / Then: the concrete reason is surfaced instead of the bare generic
-			// message (issue #765), so the failure is diagnosable after the fact.
+			// When: required blocking compaction receives an empty generated summary.
 			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
-			expect(
-				errorMessages(harness.endCompaction).map((call) => (call as [{ errorMessage: string }])[0].errorMessage),
-			).toEqual(["Compaction did not apply: unavailable"]);
+
+			// Then: the safe suffix is applied and the failure provenance is retained.
+			expect(harness.ctx.applyCompaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					details: expect.objectContaining({
+						origin: "required-compaction-recovery",
+						failureKind: "summarization-empty-summary",
+					}),
+				}),
+				expect.objectContaining({ reason: "extension" }),
+			);
+			expect(errorMessages(harness.endCompaction)).toHaveLength(0);
 		});
 	});
 

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -400,6 +400,9 @@ describe("required compaction deterministic fallback", () => {
 			expect(diagnostics.candidateRejections).toContainEqual({
 				firstKeptEntryId: preparedBoundaryId,
 				rejectionReason: "unsafe-retained-content",
+				unsafeEntryId: branchEntries.at(-1)?.id,
+				unsafeMessageIndex: 6,
+				unsafeMessageRole: "toolResult",
 			});
 		}
 	});
@@ -522,7 +525,7 @@ describe("required compaction deterministic fallback", () => {
 		const harness = createBlockingContext({ usageTokens: 9_900 });
 		harness.sessionManager.appendMessage({
 			role: "user",
-			content: `bulk retained context ${"filler ".repeat(139_000)}`,
+			content: `bulk retained context ${"filler ".repeat(556_000)}`,
 			timestamp: 4,
 		});
 		const branchEntries = harness.sessionManager.getBranch();
@@ -1407,6 +1410,9 @@ describe("deterministic fallback failed-turn normalization", () => {
 		expect(diagnostics.candidateRejections).toContainEqual({
 			firstKeptEntryId: imageBoundaryId,
 			rejectionReason: "unsafe-retained-content",
+			unsafeEntryId: branchEntries.at(-1)?.id,
+			unsafeMessageIndex: 8,
+			unsafeMessageRole: "toolResult",
 		});
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-7952-compaction-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-7952-compaction-recovery.test.ts
@@ -1,0 +1,292 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_COMPACTION_SETTINGS, estimateTokens, prepareCompaction } from "../../../src/core/compaction/index.ts";
+import {
+	createRequiredCompactionFallback,
+	type DeterministicFallbackDiagnostic,
+} from "../../../src/core/extensions/builtin/compaction/deterministic-fallback.ts";
+import { createSpeculativeCompactionSnapshot } from "../../../src/core/extensions/builtin/compaction/speculative.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import {
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../../helpers/blocking-compaction-harness.ts";
+
+const settings = {
+	...DEFAULT_COMPACTION_SETTINGS,
+	reserveTokens: 100,
+	reserveScalingEnabled: false,
+	keepRecentTokens: 1000,
+};
+
+function appendCall(manager: SessionManager, id: string) {
+	return manager.appendMessage({
+		...fauxAssistantMessage("", { timestamp: 2, stopReason: "toolUse" }),
+		content: [{ type: "toolCall", id, name: "read", arguments: { path: "fixture.txt" } }],
+	});
+}
+
+function appendResult(manager: SessionManager, id: string, text: string) {
+	return manager.appendMessage({
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 3,
+	});
+}
+
+function recover(manager: SessionManager, boundary: string, window: number, previousSummary?: string) {
+	const branch = manager.getBranch();
+	const preparation = prepareCompaction(branch, settings, true);
+	if (!preparation) throw new Error("Fixture needs a compaction preparation");
+	const diagnostics: DeterministicFallbackDiagnostic = {};
+	const result = createRequiredCompactionFallback(
+		{ ...preparation, firstKeptEntryId: boundary, previousSummary },
+		window,
+		"summarization-timeout",
+		{},
+		branch,
+		diagnostics,
+	);
+	return { result, diagnostics };
+}
+
+describe("issue #7952: fitting suffix recovery", () => {
+	it.each([
+		{ reason: "manual" as const, overBudget: false },
+		{ reason: "threshold" as const, overBudget: false },
+		{ reason: "manual" as const, overBudget: true },
+		{ reason: "threshold" as const, overBudget: true },
+	])("consumes a failed core-route warm job ($reason, overBudget=$overBudget)", async ({ reason, overBudget }) => {
+		// Given: a matching warm summary already failed on this unchanged branch.
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		if (overBudget) {
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: "oversized input ".repeat(4_000),
+				timestamp: 4,
+			});
+		}
+		const snapshot = createSpeculativeCompactionSnapshot(harness.ctx, { generation: 1, origin: "speculative" });
+		if (!snapshot) throw new Error("Fixture needs a speculative snapshot");
+		harness.registration.setResponses([fauxAssistantMessage("")]);
+		try {
+			await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+			await handlers.waitForSpeculativeJob();
+
+			// When: the core/manual hook claims the failed warm job.
+			const result = await handlers.sessionBeforeCompact(
+				{
+					type: "session_before_compact",
+					reason,
+					willRetry: false,
+					requestId: "7952-core-warm",
+					preparation: snapshot.preparation,
+					branchEntries: harness.sessionManager.getBranch(),
+					signal: new AbortController().signal,
+				},
+				harness.ctx,
+			);
+
+			// Then: it recovers or diagnoses without another provider request.
+			expect(harness.registration.getCallLog()).toHaveLength(1);
+			if (overBudget) {
+				expect(result?.cancel).toBe(true);
+				expect(JSON.parse(result?.reason?.split("\n")[1] ?? "{}")).toMatchObject({
+					rejectionReason: "retained-token-budget-exceeded",
+				});
+			} else {
+				expect(result?.compaction?.details).toMatchObject({
+					origin: "required-compaction-recovery",
+					failureKind: "summarization-empty-summary",
+				});
+			}
+		} finally {
+			harness.registration.unregister();
+		}
+	});
+
+	it("reports an impossible blocking recovery without applying a checkpoint", async () => {
+		// Given: the latest user turn alone exceeds the effective context budget.
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 9_950 });
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: "oversized input ".repeat(4_000),
+			timestamp: 4,
+		});
+		harness.registration.setResponses([fauxAssistantMessage("")]);
+		try {
+			// When: automatic blocking compaction cannot retain any safe fitting suffix.
+			await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+
+			// Then: it ends visibly with the same structured budget diagnosis.
+			expect(harness.ctx.applyCompaction).not.toHaveBeenCalled();
+			const errorMessage = harness.endCompaction.mock.calls.at(-1)?.[0]?.errorMessage;
+			expect(errorMessage).toBeDefined();
+			expect(JSON.parse(errorMessage?.split("\n")[1] ?? "{}")).toMatchObject({
+				rejectionReason: "retained-token-budget-exceeded",
+				budgetTokens: 9_600,
+			});
+		} finally {
+			harness.registration.unregister();
+		}
+	});
+
+	it.each([false, true])("recovers blocking compaction after a classified failure (warm=%s)", async (warm) => {
+		// Given: either a fresh summarization or an already-failed speculative job.
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: warm ? 4_000 : 9_950, graceBandEnabled: false });
+		harness.registration.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "upstream_stream_truncated: Responses stream ended before a terminal event",
+			}),
+		]);
+		try {
+			if (warm) {
+				await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+				await handlers.waitForSpeculativeJob();
+				harness.setUsageTokens(9_950);
+			}
+
+			// When: a blocking compaction is required by the next prompt.
+			await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+
+			// Then: deterministic recovery uses the failed attempt, not another billed request.
+			expect(harness.registration.getCallLog()).toHaveLength(1);
+			expect(harness.ctx.applyCompaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					details: expect.objectContaining({
+						origin: "required-compaction-recovery",
+						failureKind: "upstream-stream-truncated",
+					}),
+				}),
+				expect.objectContaining({ reason: "extension" }),
+			);
+		} finally {
+			harness.registration.unregister();
+		}
+	});
+
+	it("retains a 136k-token tool result even when its storage exceeds the window", () => {
+		// Given: the report's latest-turn geometry, with a complete tool pair.
+		const manager = SessionManager.inMemory();
+		const boundary = manager.appendMessage({ role: "user", content: "Keep this request", timestamp: 1 });
+		appendCall(manager, "read-1");
+		appendResult(manager, "read-1", "ordinary prose ".repeat(36_200));
+		const original = JSON.stringify(manager.getBranch());
+		const tokens = manager.buildSessionContext().messages.reduce((sum, message) => sum + estimateTokens(message), 0);
+		expect(tokens).toBeGreaterThan(135_000);
+		expect(tokens).toBeLessThan(137_000);
+		expect(original.length).toBeGreaterThan(400_000);
+
+		// When: the provider summarizer failed but this suffix fits its token window.
+		const { result } = recover(manager, boundary, 400_000);
+
+		// Then: no retained message is sacrificed to a storage-byte accounting error.
+		expect(result).toMatchObject({ firstKeptEntryId: boundary, details: { retainedSuffix: "prepared" } });
+		expect(result?.estimatedTokensAfter).toBeLessThan(140_000);
+		expect(JSON.stringify(manager.getBranch())).toBe(original);
+	});
+
+	it("counts the checkpoint in token units as well as the retained suffix", () => {
+		// Given: prose and an older checkpoint together fit a 10k-token window.
+		const manager = SessionManager.inMemory();
+		manager.appendMessage({ role: "user", content: "Previous request", timestamp: 0 });
+		manager.appendMessage(fauxAssistantMessage("Previous response", { timestamp: 0 }));
+		const boundary = manager.appendMessage({ role: "user", content: "word ".repeat(6_400), timestamp: 1 });
+
+		// When: recovery carries a bounded prior checkpoint.
+		const { result } = recover(manager, boundary, 10_000, "checkpoint ".repeat(300));
+
+		// Then: both estimates use tokens, not serialized bytes.
+		expect(result?.firstKeptEntryId).toBe(boundary);
+		expect(result?.estimatedTokensAfter).toBeLessThan(9_500);
+	});
+
+	it("backtracks from the latest user to a fitting declaring assistant", () => {
+		// Given: prepared history is too large; the latest user interrupts a tool pair.
+		const manager = SessionManager.inMemory();
+		const prepared = manager.appendMessage({ role: "user", content: "old ".repeat(20_000), timestamp: 1 });
+		const safeBoundary = appendCall(manager, "read-1");
+		manager.appendMessage({ role: "user", content: "Keep this steering request", timestamp: 2 });
+		appendResult(manager, "read-1", "result");
+
+		// When: the latest-user boundary alone would orphan that result.
+		const { result } = recover(manager, prepared, 10_000);
+
+		// Then: its complete pair is retained without losing the latest request.
+		expect(result?.firstKeptEntryId).toBe(safeBoundary);
+	});
+
+	it("ignores repeated tool IDs entirely outside the retained suffix", () => {
+		// Given: separate historical turns reused an ID; only the newest pair is kept.
+		const manager = SessionManager.inMemory();
+		manager.appendMessage({ role: "user", content: "Old request", timestamp: 1 });
+		appendCall(manager, "reused");
+		appendResult(manager, "reused", "old result");
+		const boundary = manager.appendMessage({ role: "user", content: "New request", timestamp: 4 });
+		appendCall(manager, "reused");
+		appendResult(manager, "reused", "new result");
+
+		// When: recovery projects the newest turn.
+		const { result } = recover(manager, boundary, 10_000);
+
+		// Then: discarded history cannot invalidate an internally unique pair.
+		expect(result?.firstKeptEntryId).toBe(boundary);
+	});
+
+	it.each(["threshold", "manual"] as const)("reports %s budget rejection", async (reason) => {
+		// Given: even the latest user turn genuinely exceeds the effective budget.
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 40_000 });
+		const boundary = harness.sessionManager.appendMessage({
+			role: "user",
+			content: "large retained input ".repeat(4_000),
+			timestamp: 4,
+		});
+		harness.registration.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "upstream_stream_truncated: Responses stream ended before a terminal event",
+			}),
+		]);
+		const branchEntries = harness.sessionManager.getBranch();
+		const preparation = prepareCompaction(branchEntries, harness.ctx.getCompactionSettings(), true);
+		if (!preparation) throw new Error("Fixture needs preparation");
+
+		// When: required fallback rejects every candidate.
+		const result = await handlers.sessionBeforeCompact(
+			{
+				type: "session_before_compact",
+				reason,
+				willRetry: false,
+				requestId: `7952-${reason}`,
+				preparation: { ...preparation, firstKeptEntryId: boundary },
+				branchEntries,
+				signal: new AbortController().signal,
+			},
+			harness.ctx,
+		);
+
+		// Then: the rejection contains a machine-readable, payload-free budget diagnostic.
+		expect(result?.cancel).toBe(true);
+		const diagnosticLine = result?.reason?.split("\n")[1];
+		expect(diagnosticLine).toBeDefined();
+		const diagnostic = JSON.parse(diagnosticLine ?? "{}");
+		expect(diagnostic).toMatchObject({
+			rejectionReason: "retained-token-budget-exceeded",
+			contextWindow: 10_000,
+			reserveTokens: 400,
+			budgetTokens: 9_600,
+			budgetExceeded: true,
+		});
+		expect(diagnostic.candidate.estimatedTokens).toBeGreaterThan(diagnostic.budgetTokens);
+		expect(result?.reason).not.toContain("large retained input");
+	});
+});


### PR DESCRIPTION
## Summary

Fix deterministic compaction recovery rejecting a valid retained suffix because
serialized bytes were compared directly with a token budget. A roughly 136k-token
tool-result suffix reproduced the rejection in a 400k-token window.

Real CLI verification also found that automatic blocking compaction did not use
the recovery available to manual compaction. Both fresh blocking failures and
unchanged failed warm summaries now use the same classified fallback.

## Changes

- Estimate retained JSON envelopes and checkpoint text with the shared weighted
  token estimator. Preserve additive image costs and opaque metadata accounting.
- Select complete tool-chain boundaries around steering messages and evaluate
  duplicate IDs only within the retained suffix.
- Report bounded, payload-free rejection diagnostics: window, reserve, budget,
  candidate boundary, estimated tokens, or the unsafe message entry/index/role.
- Keep abort, generation, revision, provider-lane, malformed-content, signature,
  and core compaction admission checks.

## QA and evidence

- Failing-first coverage: thirteen new regressions. The initial six covered text,
  checkpoint, two boundary cases, and manual/threshold diagnostics. Real CLI
  failure then led to two fresh/warm blocking regressions and one missing-error
  regression. Final review added four core/manual warm-handoff cases proving
  that unchanged failures must recover or reject without another provider call.
  Each defect was observed before its production fix.
- Remote package-runner tests: **10 files, 76 tests passed**, exit 0, on
  mengmotaMac with Bun 1.4.2. Covers image budgeting/persistence, signed state,
  invalid chains, reserve boundaries, aborts, lane guards, and bounded retries.
- Real CLI/RPC: manual and automatic threshold scenarios each start at
  **305,775 tokens**, persist exactly one deterministic checkpoint, preserve
  the original JSONL prefix and retained tool result, and finish the next turn.
  Each uses two requests to a local fake HTTP provider; no real provider calls.
  Session-file identity, real-auth integrity, and process/port/sandbox teardown
  are asserted.
- Full `bun run check` and `bun scripts/build-all.mjs --pm bun`: exit 0.
  Focused diagnostics and `git diff --check` are clean; intermittent LSP refresh
  timeouts were checked against the successful full TypeScript gate.
- Local receipts:
  `local-ignore/qa-evidence/20260908-7952-compaction/VERIFICATION.md`,
  `rpc-qa.mjs`, and `rpc-qa.json` (intentionally not shipped).

## Limits

The original private transcript and effective window were not available. This
reproduces the code defect and validates the repaired paths; it does not claim to
replay the reporter's exact historical request. A forced destructive cut and
unbounded retry are not introduced. Shipping this merge in an OmO release is
separate from merging the engine fix.

Overriding the package runner to run Vitest itself under Bun (`--bun`) failed in
Zod module initialization before an adjacent integration test ran. The final
declared package runner passes all 76 tests. No test was skipped or error
suppressed in the final run.

Closes code-yeongyu/oh-my-openagent#7952

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction recovery rejecting valid retained suffixes because serialized bytes were counted as tokens; a roughly 136k-token tool-result suffix was rejected in a 400k-token window. Automatic blocking compaction now uses the same deterministic recovery as manual compaction, and unchanged failed warm summaries recover without another provider call.

- Estimates serialized JSON envelopes and checkpoint text with the shared weighted token estimator; image costs stay additive and opaque metadata remains charged.
- Keeps complete tool-chain pairs across steering messages and checks duplicate IDs only within the retained suffix.
- Reports bounded, payload-free rejection diagnostics with window, reserve, budget, candidate boundary, estimated tokens, and unsafe message entry/index/role; tests assert these as exact machine-readable fields.
- Adds thirteen regression tests, including the 136k-token reproduction and fresh/warm blocking failure paths.

Closes code-yeongyu/oh-my-openagent#7952.

<sup>Written for commit 9c82c9b3a20d585e2ad5ca497cf3705993b9f733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

