### PR TITLE
fix(compaction): scale summarization duration budget with input size (#1068)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### Added
 
+- `compaction.summarizationMaxDurationMs` (settings) replaces the size-adaptive summarization wall-clock budget with a fixed one when set; positive finite values only, clamped to the 30-minute ceiling ([#1501](https://github.com/code-yeongyu/senpi/pull/1501)).
+
 ### Changed
 
 ### Fixed
+
+- Large sessions can compact again: the summarization wall-clock budget scales with the estimated input (`max(120s, 2ms per token)`, capped at 30 minutes) instead of a fixed 120 seconds, so a 200k+ token summary on a slower provider is no longer rejected while still streaming and the session no longer stays wedged above its compaction threshold. Small inputs keep the exact 120-second contract, the idle watchdog is unchanged, and the retry allowance stays at half of one attempt ([#1068](https://github.com/code-yeongyu/senpi/issues/1068), [#1501](https://github.com/code-yeongyu/senpi/pull/1501)).
 
 ### Removed
 
@@ -520,7 +524,6 @@
 ### Fixed
 
 - Hooks trust-state reads keep complete snapshots on a lock-free fast path while malformed or empty reads acquire the bounded writer lock and revalidate under writer exclusion. This prevents mixed-version legacy writers from hiding an absent-active-absent lock cycle around truncate-and-rewrite; a still-malformed exclusive reread or exhausted active lease fails closed without surfacing `ELOCKED`. Lock release failures no longer mask reader or writer failures, and multiple failures retain causal order. The files are internal same-account application state: new POSIX files use `0600`, existing POSIX numeric modes are retained, and custom ownership, ACL, or DACL preservation is not supported.
-
 
 - Compaction no longer wedges when the summarizer model hijacks the forwarded agent tools and answers with a bare tool call (observed on openai-codex gpt-5.6-sol at high reasoning as `Compaction rejected: summarization response contained no text (stopReason: toolUse)` followed by `Context remains above the compaction threshold because compaction did not complete`). The summarization request is retried once with tool calling forbidden (`toolChoice: "none"`, tools kept in the request for Anthropic compatibility), and a persistent empty-summary failure now degrades into the deterministic no-LLM fallback on required-compaction routes instead of leaving the session stuck above the threshold.
 - Windows session resume no longer aborts the process when `fs.watch()` receives an event for a watch path containing a non-canonical component; existing paths are canonicalized before watching ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)).
@@ -1456,7 +1459,6 @@
   tree, and degrades to killing the direct child only when no launcher starts at all
   ([#807](https://github.com/code-yeongyu/senpi/pull/807) by [@yeongjunyoo](https://github.com/yeongjunyoo)).
 
-
 - MCP shutdown no longer risks terminating unrelated processes on macOS when Homebrew `proctools` provides `pgrep`: process-tree collection now passes an explicit match-all pattern, and the kill path skips PID 1 and non-positive PIDs as defense in depth ([#824](https://github.com/code-yeongyu/senpi/pull/824) by [@bagelcode-jhkim](https://github.com/bagelcode-jhkim)).
 - `claude-sdk-oauth` sessions no longer re-send the full conversation after a transient content-less user message disappears. Such messages are now excluded from the sent-stream continuity hash, so an unchanged conversation stays a `delta` instead of forking with `sent_stream_diverged` ([#791](https://github.com/code-yeongyu/senpi/pull/791) by [@1vivy](https://github.com/1vivy)).
 - `config-reload` now accepts an extension watch rooted at the agent directory when every `filterGlob` is root-anchored and non-protected, so extensions can live-watch safe root config files such as `omo.jsonc`. Unfiltered targets, unanchored filters, and protected paths (`auth.json`, `sessions/`, `logs/`) remain rejected ([#819](https://github.com/code-yeongyu/senpi/issues/819)).
@@ -1468,7 +1470,6 @@
 - Expanding several tool results at once (Ctrl+O) no longer renders mismatched or truncated content when a frame grows above the viewport. The viewport-remap path now replays rows above the visible window so cached component layout and terminal output stay aligned ([#701](https://github.com/code-yeongyu/senpi/issues/701), [#879](https://github.com/code-yeongyu/senpi/pull/879)).
 
 - Fallback retries no longer escalate reasoning. A requested level the fallback model does not support previously resolved to that model's highest supported level, which pushed 191 of 197 always-on models to maximum reasoning on unattended retries; it now clamps to the nearest supported level. A session interrupted inside a fallback window also no longer resumes with the primary model carrying the fallback model's reasoning level, and favorite model patterns keep their `:level` / `:priority` decorators instead of being flattened to bare ids ([#894](https://github.com/code-yeongyu/senpi/pull/894)).
-
 
 ### New Features
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -191,6 +191,7 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the senpi version update check. Use `--
 | `compaction.enabled` | boolean | `true` | Enable auto-compaction |
 | `compaction.reserveTokens` | number | `16384` | Tokens reserved for LLM response |
 | `compaction.keepRecentTokens` | number | `20000` | Recent tokens to keep (not summarized) |
+| `compaction.summarizationMaxDurationMs` | number | adaptive | Wall-clock budget for one summarization attempt: larger of 120s and 2ms per estimated input token, capped at 30min. Set a positive value to override |
 
 ```json
 {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,21 @@
+## Size-adaptive summarization duration budget setting (2026-09-08)
+
+### What changed
+
+- `packages/coding-agent/src/core/compaction/compaction-settings.ts`, `compaction-settings-access.ts`, and `compaction-settings-resolver.ts`: new optional `compaction.summarizationMaxDurationMs` setting resolving to a positive finite number or `undefined` (adaptive default).
+
+### Why
+
+- Large sessions deadlock on compaction when the fixed 120s summarization watchdog outlives slow providers (#1068); the setting is the user-facing escape hatch over the size-adaptive default.
+
+### Why an extension could not handle it
+
+- The settings contract is consumed by core compaction execution before extension hooks run.
+
+### Expected merge conflict zones
+
+- LOW: the three settings files' `CompactionSettings` / `ResolvedCompactionSettings` shapes.
+
 ## Same-model recovery for a native tool-search 400 (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction-settings-access.ts
+++ b/packages/coding-agent/src/core/compaction-settings-access.ts
@@ -13,6 +13,12 @@ export interface CompactionSettings extends IdealCompactionSettings {
 	restorationMaxTotalTokens?: number; // default: 50000
 	restorationContextRatio?: number; // default: 0.15
 	idleCompactionEnabled?: boolean; // default: true
+	/**
+	 * Optional override for one summarization attempt's wall-clock budget.
+	 * Default: size-adaptive (120s floor, 2ms per estimated input token, 30min
+	 * cap); see `core/compaction/stream-watchdog.ts`.
+	 */
+	summarizationMaxDurationMs?: number;
 }
 
 export function compactionEnabled(settings?: CompactionSettings): boolean {

--- a/packages/coding-agent/src/core/compaction-settings-resolver.ts
+++ b/packages/coding-agent/src/core/compaction-settings-resolver.ts
@@ -18,6 +18,8 @@ export interface ResolvedCompactionSettings {
 	reminderEnabled: boolean;
 	reserveScalingEnabled: boolean;
 	speculativeLeadTokens?: number;
+	/** Positive finite number, or undefined for the size-adaptive default. */
+	summarizationMaxDurationMs?: number;
 }
 
 const DEFAULTS = {
@@ -70,6 +72,12 @@ export function resolveCompactionSettings(settings?: CompactionSettings): Resolv
 		speculativeLeadTokens:
 			typeof raw?.speculativeLeadTokens === "number" && Number.isFinite(raw.speculativeLeadTokens)
 				? Math.max(0, raw.speculativeLeadTokens)
+				: undefined,
+		summarizationMaxDurationMs:
+			typeof raw?.summarizationMaxDurationMs === "number" &&
+			Number.isFinite(raw.summarizationMaxDurationMs) &&
+			raw.summarizationMaxDurationMs > 0
+				? raw.summarizationMaxDurationMs
 				: undefined,
 	};
 }

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -615,3 +615,26 @@ If upstream changes branch summary preparation or adds new branch summary data s
 ### Expected merge conflict zones
 
 - `packages/coding-agent/src/core/compaction/compaction.ts` settings type re-export near the module imports.
+
+## 2026-09-08 - Scale the summarization duration budget with the input size
+
+### What changed
+
+- `stream-watchdog.ts`: new `summarizationMaxDurationMs()` computes the per-attempt wall-clock budget as the larger of the 120s floor and 2ms per estimated input token, clamped to a 30-minute cap, with an optional explicit override.
+- `compaction.ts`: `completeSummarization()` estimates the context being summarized and applies the scaled budget instead of the fixed `DEFAULT_SUMMARIZATION_MAX_DURATION_MS`; `generateSummary()` and `generateSummaryWithUsage()` accept an optional override that flows from the resolved compaction settings.
+- `compaction-execution.ts`: `compact()` forwards `settings.summarizationMaxDurationMs` to history and turn-prefix summaries.
+- `compaction-settings.ts`: the resolved settings contract gains the optional `summarizationMaxDurationMs` override.
+- `compaction-settings-access.ts` / `compaction-settings-resolver.ts`: new optional `compaction.summarizationMaxDurationMs` setting; non-positive and non-finite values fall back to the adaptive default.
+
+### Why
+
+- #1068: a 257k-token session summarization on a slower provider exceeds the hardcoded 120s budget while still streaming, so every compaction attempt is rejected and the session cannot drop below its compaction threshold. At a 1M context window the automatic threshold fires only when the summarizable input is already hundreds of thousands of tokens, so the fixed 120s budget guarantees failure exactly when compaction becomes mandatory.
+
+### Why an extension could not handle it
+
+- `completeSummarization()` is the shared core choke point for every summarization stream; the extension policy layer reaches it only through this function's options, and the budget must apply per attempt inside the core watchdog.
+
+### Expected merge conflict zones
+
+- LOW: `compaction.ts` around `completeSummarization` and the `generateSummary*` signatures.
+- LOW: `compaction-settings.ts`, `compaction-settings-access.ts`, and `compaction-settings-resolver.ts` settings contracts.

--- a/packages/coding-agent/src/core/compaction/compaction-execution.ts
+++ b/packages/coding-agent/src/core/compaction/compaction-execution.ts
@@ -115,6 +115,7 @@ export async function compact(
 					sourceContext: cacheFriendly?.sourceContext,
 					requestOptions: cacheFriendly?.requestOptions,
 				},
+				settings.summarizationMaxDurationMs,
 			);
 			historyText = historyResult.text;
 			historyUsage = historyResult.usage;
@@ -138,6 +139,7 @@ export async function compact(
 				sourceContext: cacheFriendly?.turnPrefixSourceContext,
 				requestOptions: cacheFriendly?.requestOptions,
 			},
+			settings.summarizationMaxDurationMs,
 		);
 		// Merge into single summary
 		summary = `${historyText}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.text}`;
@@ -165,6 +167,7 @@ export async function compact(
 				sourceContext: cacheFriendly?.sourceContext,
 				requestOptions: cacheFriendly?.requestOptions,
 			},
+			settings.summarizationMaxDurationMs,
 		);
 		summary = result.text;
 		summaryUsage = result.usage;
@@ -206,6 +209,7 @@ async function generateTurnPrefixSummary(
 	callbacks?: RetryCallbacks,
 	sessionId?: string,
 	cacheFriendly?: Pick<CacheFriendlySummaryOptions, "sourceContext" | "requestOptions">,
+	summarizationMaxDurationMs?: number,
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
@@ -251,6 +255,7 @@ async function generateTurnPrefixSummary(
 		streamFn,
 		retry,
 		callbacks,
+		summarizationMaxDurationMs,
 	);
 
 	const failure = getSummarizationFailure(response, "Turn prefix summarization");

--- a/packages/coding-agent/src/core/compaction/compaction-settings.ts
+++ b/packages/coding-agent/src/core/compaction/compaction-settings.ts
@@ -13,6 +13,8 @@ export interface CompactionSettings extends IdealCompactionSettings {
 	restorationMaxTotalTokens?: number;
 	restorationContextRatio?: number;
 	idleCompactionEnabled?: boolean;
+	/** Optional per-attempt wall-clock budget override for summarization (adaptive default). */
+	summarizationMaxDurationMs?: number;
 }
 
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -43,7 +43,7 @@ export { DEFAULT_COMPACTION_SETTINGS } from "./compaction-settings.ts";
 import {
 	consumeStreamWithIdleTimeout,
 	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
-	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+	summarizationMaxDurationMs,
 } from "./stream-watchdog.ts";
 import {
 	contentTextForSummary,
@@ -727,6 +727,7 @@ export async function completeSummarization(
 	streamFn?: SummarizationStreamFn,
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
+	summarizationMaxDurationMsOverride?: number,
 ): Promise<AssistantMessage> {
 	// Summary requests retain the fork's request-identity split: each request gets a
 	// fresh identity while affinity follows the caller. Cache-friendly callers may
@@ -738,6 +739,14 @@ export async function completeSummarization(
 		sessionId: uuidv7(),
 	};
 	const callerSignal = options.signal;
+	// The 120s floor was tuned for healthy summaries; a large session feeds the
+	// summarizer hundreds of thousands of tokens, which legitimately takes longer
+	// on slower providers (#1068). Scale the per-attempt budget with the estimated
+	// input size so compaction cannot deadlock purely on its own wall clock.
+	const maxDurationMs = summarizationMaxDurationMs(
+		estimateProviderContextTokens(context).tokens,
+		summarizationMaxDurationMsOverride,
+	);
 	const produce = async (): Promise<AssistantMessage> => {
 		// Request-local controller: the idle watchdog must be able to tear down a
 		// stalled summarization request without aborting the caller's own signal.
@@ -757,7 +766,7 @@ export async function completeSummarization(
 			);
 			await consumeStreamWithIdleTimeout(responseStream, {
 				idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
-				maxDurationMs: DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+				maxDurationMs,
 				abort: () => requestController.abort(),
 				signal: callerSignal,
 			});
@@ -832,6 +841,7 @@ export async function generateSummary(
 	callbacks?: RetryCallbacks,
 	sessionId?: string,
 	cacheFriendly?: Pick<CacheFriendlySummaryOptions, "sourceContext" | "requestOptions">,
+	summarizationMaxDurationMs?: number,
 ): Promise<string> {
 	return (
 		await generateSummaryWithUsage(
@@ -852,6 +862,7 @@ export async function generateSummary(
 			callbacks,
 			sessionId,
 			cacheFriendly,
+			summarizationMaxDurationMs,
 		)
 	).text;
 }
@@ -911,6 +922,7 @@ export async function generateSummaryWithUsage(
 	callbacks?: RetryCallbacks,
 	sessionId?: string,
 	cacheFriendly?: Pick<CacheFriendlySummaryOptions, "sourceContext" | "requestOptions">,
+	summarizationMaxDurationMs?: number,
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
@@ -972,6 +984,7 @@ export async function generateSummaryWithUsage(
 		streamFn,
 		retry,
 		callbacks,
+		summarizationMaxDurationMs,
 	);
 
 	const failure = getSummarizationFailure(response, "Summarization");

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -45,6 +45,44 @@ export const DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS = 300_000;
  */
 export const DEFAULT_SUMMARIZATION_MAX_DURATION_MS = 120_000;
 
+/**
+ * How much the wall-clock budget grows per estimated input token.
+ *
+ * The 120s floor covers healthy summaries. Large sessions summarize hundreds of
+ * thousands of tokens: a 257k-token input already exceeds 120s on slower
+ * providers while still streaming (#1068), so the budget scales with the amount
+ * being summarized. 2ms/token assumes a worst-case sustained throughput of ~500
+ * tokens/second; faster providers simply finish well inside the budget.
+ */
+export const SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS = 2;
+
+/**
+ * Absolute ceiling for one summarization attempt. The wall-clock budget exists
+ * to stop a slow-but-alive stream from holding the session forever; it must stay
+ * a bound, so size-scaled budgets are clamped here instead of growing linearly
+ * without limit.
+ */
+export const SUMMARIZATION_MAX_DURATION_CAP_MS = 1_800_000;
+
+/**
+ * Total time one summarization attempt may hold the session, sized to its input.
+ *
+ * The budget never shrinks below {@link DEFAULT_SUMMARIZATION_MAX_DURATION_MS};
+ * inputs small enough that `2ms/token` stays under that floor keep the exact
+ * 120s contract. Above ~60k estimated tokens the budget grows by
+ * {@link SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS} per token and is clamped to
+ * {@link SUMMARIZATION_MAX_DURATION_CAP_MS}. An explicit positive `overrideMs`
+ * (e.g. the `compaction.summarizationMaxDurationMs` setting) replaces the
+ * computed budget; non-finite and non-positive values are ignored.
+ */
+export function summarizationMaxDurationMs(estimatedInputTokens: number, overrideMs?: number): number {
+	if (overrideMs !== undefined && Number.isFinite(overrideMs) && overrideMs > 0) {
+		return Math.min(SUMMARIZATION_MAX_DURATION_CAP_MS, overrideMs);
+	}
+	const scaled = estimatedInputTokens * SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS;
+	return Math.min(SUMMARIZATION_MAX_DURATION_CAP_MS, Math.max(DEFAULT_SUMMARIZATION_MAX_DURATION_MS, scaled));
+}
+
 export interface ConsumeStreamWithIdleTimeoutOptions<T> {
 	/** Silence budget per read; the timer resets on every event. */
 	readonly idleTimeoutMs: number;

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,26 @@
 # changes.md — builtin compaction policy
 
+## Scale the speculative attempt budget and retry allowance with the input size (2026-09-08)
+
+### What changed
+
+- `speculative-summary.ts`: `generateSummaryMessage` applies `summarizationMaxDurationMs()` to the summarization stream (the size-adaptive default, or the resolved budget passed by the caller) instead of the fixed 120s default.
+- `speculative.ts`: computes one per-attempt budget from the summarization input and `compaction.summarizationMaxDurationMs`, passes it into `generateSummaryMessage`, and feeds the same value to the retry gate.
+- `summarization-retry.ts`: `allowSummarizationRetry()` now takes the attempt budget and keeps the "half of one attempt" total allowance (`summarizationRetryTotalBudgetMs()`), so large sessions keep proportional retry room instead of being disqualified after 60s of elapsed time.
+
+### Why
+
+- #1068: with a fixed 120s attempt budget, large sessions lose every summarization attempt to the wall-clock watchdog; the extension route's fixed 60s retry allowance compounds the deadlock by refusing retries after one slow attempt.
+
+### Why an extension could not handle it
+
+- The watchdog constants live in core; the extension route owns the attempt loop, so both sides must share one budget number.
+
+### Expected merge conflict zones
+
+- LOW: `speculative-summary.ts` options and stream consumption.
+- LOW: `speculative.ts` retry-loop budget computation.
+
 ## Recover fitting retained suffixes with consistent token accounting (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative-summary.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative-summary.ts
@@ -11,10 +11,11 @@ import {
 	type TextContent,
 } from "@earendil-works/pi-ai";
 import { stream } from "@earendil-works/pi-ai/compat";
+import { estimateTokens } from "../../../compaction/compaction.ts";
 import {
 	consumeStreamWithIdleTimeout,
 	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
-	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+	summarizationMaxDurationMs,
 } from "../../../compaction/stream-watchdog.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type { buildPrompt } from "./prompts.ts";
@@ -95,6 +96,8 @@ function summarizationStream(
 export async function generateSummaryMessage(options: {
 	context: SpeculativeCompactionContext;
 	forbidToolCalls?: boolean;
+	/** Resolved per-attempt duration budget; falls back to the size-adaptive default. */
+	maxDurationMs?: number;
 	messages: AgentMessage[];
 	onProgress?: CompactionProgressCallback;
 	prompt: ReturnType<typeof buildPrompt>;
@@ -129,6 +132,9 @@ export async function generateSummaryMessage(options: {
 				timestamp: Date.now(),
 			},
 		];
+		const maxDurationMs =
+			options.maxDurationMs ??
+			summarizationMaxDurationMs(requestMessages.reduce((total, message) => total + estimateTokens(message), 0));
 		const providerRequest = await options.context.prepareProviderRequest?.(requestMessages);
 		const requestContext = {
 			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
@@ -155,7 +161,7 @@ export async function generateSummaryMessage(options: {
 		});
 		await consumeStreamWithIdleTimeout(responseStream, {
 			idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
-			maxDurationMs: DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+			maxDurationMs,
 			abort: () => requestController.abort(),
 			signal: options.signal,
 			onEvent: (event) => {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -15,9 +15,14 @@ import {
 	type CompactionResult,
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
+	estimateTokens,
 	prepareCompaction,
 } from "../../../compaction/index.ts";
-import { StreamDurationBudgetError, StreamIdleTimeoutError } from "../../../compaction/stream-watchdog.ts";
+import {
+	StreamDurationBudgetError,
+	StreamIdleTimeoutError,
+	summarizationMaxDurationMs,
+} from "../../../compaction/stream-watchdog.ts";
 import {
 	createWarmAnchorSnapshot,
 	isWarmSummaryAnchorValid,
@@ -284,6 +289,14 @@ export async function runExtensionCompaction(
 		// inheritable so the next blocking route degrades on it instead of paying
 		// for a second request.
 		const retryEligible = snapshot.origin === "core-route" || snapshot.origin === "blocking";
+		// The attempt budget and the retry gate share one input-size-scaled number,
+		// so a large session gets both a proportional attempt deadline and room to
+		// retry transient failures without the 120s-era retry budget disqualifying
+		// every slow attempt (#1068).
+		const attemptBudgetMs = summarizationMaxDurationMs(
+			messages.reduce((total, message) => total + estimateTokens(message), 0),
+			snapshot.preparation.settings.summarizationMaxDurationMs,
+		);
 		try {
 			// The provider `error` stop is raised INSIDE the retried producer so a
 			// transient summarization failure spends the shared retry budget. The
@@ -294,6 +307,7 @@ export async function runExtensionCompaction(
 					const attempt = await generateSummaryMessage({
 						context,
 						forbidToolCalls: toolUseRetrySpent,
+						maxDurationMs: attemptBudgetMs,
 						messages: currentMessages,
 						onProgress,
 						prompt,
@@ -322,7 +336,7 @@ export async function runExtensionCompaction(
 				},
 				(error) =>
 					retryEligible &&
-					allowSummarizationRetry(Date.now() - retryStartedMs) &&
+					allowSummarizationRetry(Date.now() - retryStartedMs, attemptBudgetMs) &&
 					isRetryableSummaryAttempt(error),
 				DEFAULT_SUMMARIZATION_RETRY_POLICY,
 				signal,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-retry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-retry.ts
@@ -14,15 +14,18 @@
  * retried; a failure that already burned the budget degrades as before.
  */
 import type { RetryPolicy } from "@earendil-works/pi-ai";
+import { DEFAULT_SUMMARIZATION_MAX_DURATION_MS } from "../../../compaction/stream-watchdog.ts";
 
 export const MAX_SUMMARIZATION_ATTEMPT_RETRIES = 3;
 
 /**
- * Total wall-clock all retried attempts of one summarization may consume.
- * Half of a single attempt's 120s budget: room for several fast upstream
+ * Total wall-clock all retried attempts of one summarization may consume:
+ * half of a single attempt's budget. Room for several fast upstream
  * rejections, never room to add another full deadline to the turn.
  */
-export const SUMMARIZATION_RETRY_TOTAL_BUDGET_MS = 60_000;
+export function summarizationRetryTotalBudgetMs(attemptBudgetMs: number): number {
+	return attemptBudgetMs / 2;
+}
 
 /** Faster first retry than the provider default: this route blocks the turn. */
 export const DEFAULT_SUMMARIZATION_RETRY_POLICY: RetryPolicy = {
@@ -31,6 +34,15 @@ export const DEFAULT_SUMMARIZATION_RETRY_POLICY: RetryPolicy = {
 	baseDelayMs: 1_000,
 };
 
-export function allowSummarizationRetry(elapsedMs: number): boolean {
-	return elapsedMs < SUMMARIZATION_RETRY_TOTAL_BUDGET_MS;
+/**
+ * Whether a retry may start given the wall clock already spent on the current
+ * attempt set. The total budget tracks the attempt budget: a large session
+ * whose single attempt legitimately spans minutes keeps proportional room to
+ * retry, while the invariant "never another full deadline" still holds.
+ */
+export function allowSummarizationRetry(
+	elapsedMs: number,
+	attemptBudgetMs: number = DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+): boolean {
+	return elapsedMs < summarizationRetryTotalBudgetMs(attemptBudgetMs);
 }

--- a/packages/coding-agent/test/compaction/idle-settings.test.ts
+++ b/packages/coding-agent/test/compaction/idle-settings.test.ts
@@ -24,3 +24,22 @@ describe("compaction model override setting", () => {
 		expect(sm.getCompactionSettings().model).toBe("deepseek/deepseek-chat");
 	});
 });
+
+describe("compaction summarizationMaxDurationMs setting", () => {
+	it("defaults to undefined so the size-adaptive budget applies", () => {
+		const sm = SettingsManager.inMemory();
+		expect(sm.getCompactionSettings().summarizationMaxDurationMs).toBeUndefined();
+	});
+
+	it("passes through a configured positive override", () => {
+		const sm = SettingsManager.inMemory({ compaction: { summarizationMaxDurationMs: 600_000 } });
+		expect(sm.getCompactionSettings().summarizationMaxDurationMs).toBe(600_000);
+	});
+
+	it("ignores non-positive and non-finite values", () => {
+		for (const value of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const sm = SettingsManager.inMemory({ compaction: { summarizationMaxDurationMs: value } });
+			expect(sm.getCompactionSettings().summarizationMaxDurationMs).toBeUndefined();
+		}
+	});
+});

--- a/packages/coding-agent/test/compaction/summarization-stream-watchdog.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-stream-watchdog.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	consumeStreamWithIdleTimeout,
 	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 	StreamIdleTimeoutError,
+	SUMMARIZATION_MAX_DURATION_CAP_MS,
+	SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS,
+	summarizationMaxDurationMs,
 } from "../../src/core/compaction/stream-watchdog.ts";
 
 /**
@@ -125,5 +129,41 @@ describe("consumeStreamWithIdleTimeout", () => {
 
 	it("exposes a 5 minute default aligned with the agent stream idle timeout", () => {
 		expect(DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS).toBe(300_000);
+	});
+});
+
+describe("summarizationMaxDurationMs", () => {
+	it("keeps the 120s floor for small inputs", () => {
+		expect(summarizationMaxDurationMs(0)).toBe(DEFAULT_SUMMARIZATION_MAX_DURATION_MS);
+		expect(summarizationMaxDurationMs(10_000)).toBe(DEFAULT_SUMMARIZATION_MAX_DURATION_MS);
+	});
+
+	it("scales with the estimated input size instead of deadlocking large sessions", () => {
+		// 257k tokens: the #1068 reproduction size, where 120s was exceeded while still streaming.
+		const budget = summarizationMaxDurationMs(257_000);
+		expect(budget).toBe(257_000 * SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS);
+		expect(budget).toBeGreaterThan(DEFAULT_SUMMARIZATION_MAX_DURATION_MS);
+	});
+
+	it("clamps the scaled budget at the absolute cap", () => {
+		const budget = summarizationMaxDurationMs(2_000_000);
+		expect(budget).toBe(SUMMARIZATION_MAX_DURATION_CAP_MS);
+	});
+
+	it("lets a positive override replace the computed budget", () => {
+		expect(summarizationMaxDurationMs(500_000, 300_000)).toBe(300_000);
+		expect(summarizationMaxDurationMs(10_000, 300_000)).toBe(300_000);
+	});
+
+	it("clamps an oversized override to the cap", () => {
+		expect(summarizationMaxDurationMs(10_000, 3_600_000)).toBe(SUMMARIZATION_MAX_DURATION_CAP_MS);
+	});
+
+	it("ignores non-finite and non-positive overrides", () => {
+		expect(summarizationMaxDurationMs(100_000, Number.NaN)).toBe(100_000 * SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS);
+		expect(summarizationMaxDurationMs(100_000, Number.POSITIVE_INFINITY)).toBe(
+			100_000 * SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS,
+		);
+		expect(summarizationMaxDurationMs(100_000, 0)).toBe(100_000 * SUMMARIZATION_MAX_DURATION_PER_TOKEN_MS);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the compaction deadlock in #1068: large sessions can never compact because the hardcoded 120s summarization wall-clock budget is shorter than a legitimate 200k+ token summary on slower providers. Every attempt is rejected, tokens never drop, and the session stays wedged above its compaction threshold.

The per-attempt budget is now sized to the input instead of being a fixed 120s:

- `summarizationMaxDurationMs()` computes `max(120s, 2ms per estimated input token)`, clamped to a 30-minute absolute cap.
- A 257k-token input (the #1068 reproduction size) now gets ~8.5 minutes instead of 2; small inputs keep the exact 120s contract.
- `compaction.summarizationMaxDurationMs` is a new optional setting that replaces the computed budget (positive finite values only).

## Changes

- `core/compaction/stream-watchdog.ts`: new constants and `summarizationMaxDurationMs()`.
- `core/compaction/compaction.ts`: `completeSummarization()` estimates the context it is summarizing and applies the scaled budget; `generateSummary()` / `generateSummaryWithUsage()` accept an optional override.
- `core/compaction/compaction-execution.ts`: `compact()` forwards `settings.summarizationMaxDurationMs` to history and turn-prefix summaries.
- `core/compaction/compaction-settings.ts`, `compaction-settings-access.ts`, `compaction-settings-resolver.ts`: the new setting in the settings contract.
- `extensions/builtin/compaction/speculative-summary.ts` + `speculative.ts`: the speculative route uses the same budget, computed once per attempt from the summarization input and the setting.
- `extensions/builtin/compaction/summarization-retry.ts`: `allowSummarizationRetry()` takes the attempt budget and keeps the "half of one attempt" total allowance, so large sessions keep proportional retry room instead of being disqualified after 60s of elapsed time.

The idle watchdog (300s per event) is unchanged; the duration budget stays a hard bound, so a trickling zombie stream still cannot hold a session forever.

## Why the size scaling

The 120s cap exists to stop a slow-but-alive stream from freezing the session. That is a real hazard, but a fixed cap cannot be right for both a 20k-token branch summary and a 400k-token session summary. Scaling with the estimated input size preserves the bound while letting legitimate large summaries finish.

## Verification

- `bun run --cwd packages/coding-agent test test/compaction`: 75 files, 559 tests passed.
- Root-level compaction tests (auto-compaction queue, checkpoint oneshot, serialization, summary reasoning, interactive-mode queue suites): 11 files, 120 tests passed.
- `tsc --noEmit -p tsconfig.json`: exit 0.
- `biome check` clean on all changed files; `scripts/check-ts-relative-imports.mjs` passes.
- New tests pin the budget function (floor, scaling at the 257k reproduction size, cap, override, invalid overrides) and the settings resolver pass-through.

Closes #1068

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction deadlock for large sessions: the summarization wall-clock budget now scales with input size instead of a fixed 120s, so a 257k-token summary on a slower provider gets ~8.5 minutes instead of failing every attempt and never compacting.

**Bug Fixes**
- The per-attempt budget is now `max(120s, 2ms per estimated input token)`, clamped at 30 minutes.
- New optional setting `compaction.summarizationMaxDurationMs` overrides the computed budget; invalid values fall back to the adaptive default.
- Retry allowance scales to half of one attempt, so large sessions keep proportional retry room instead of being disqualified after 60s.

<sup>Written for commit 560fa2d890ce5e602f02f27b4495fb25e3ffb061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

