### PR TITLE
fix(ai): bind an ephemeral port for the Anthropic OAuth callback when 53692 is taken

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Anthropic OAuth login no longer dead-ends on a browser page reading "State mismatch." when another senpi/omo process on the same machine still holds the callback port 53692: the login binds an ephemeral loopback port instead and carries that port through the auth URL and the token exchange. A callback that belongs to another login now explains that the login belongs to a different session and how to continue, and a login that gets neither a browser callback nor a pasted redirect URL for 10 minutes times out and releases its port instead of holding it indefinitely.
+
 - Anthropic mid-output server fallback now follows the configured abort/continue policy instead of raising an unsupported-fallback error. Continuing responses retain their serving-model identity and do not execute abandoned pre-fallback tools, including through text-tool recovery middleware.
 
 - `streamSimple` on the OpenAI Responses and Codex Responses adapters forwards the new `SimpleStreamOptions.serviceTier` into the request (`service_tier`) and tier-aware usage pricing; the simple path previously dropped it (code-yeongyu/oh-my-openagent#6795).

--- a/packages/ai/src/auth/oauth/anthropic-callback-listener.ts
+++ b/packages/ai/src/auth/oauth/anthropic-callback-listener.ts
@@ -1,0 +1,181 @@
+/**
+ * Loopback callback listener for the Anthropic OAuth flow.
+ *
+ * The OAuth client accepts any `localhost` port on the `/callback` path (the
+ * Claude Code CLI itself binds a random port per login), so the listener
+ * prefers the historical port 53692 and falls back to an ephemeral port when
+ * another login - in this process or in another one - still holds it. With a
+ * fixed port, a second login on the same machine sent its browser redirect to
+ * the OTHER process's listener, which could only answer "State mismatch".
+ *
+ * NOTE: Node-only (http.createServer); reached through the lazy OAuth loader.
+ */
+
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { formatErrorDetails } from "./error-details.ts";
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.ts";
+
+export type CallbackCode = { code: string; state: string };
+
+export type CallbackListener = {
+	/** Bound loopback port; `undefined` when no port could be bound (manual-only login). */
+	port?: number;
+	redirectUri: string;
+	callbackUnavailable?: { code: string };
+	waitForCode: () => Promise<CallbackCode | null>;
+	cancelWait: () => void;
+	close: () => Promise<void>;
+};
+
+export type CallbackListenerApis = {
+	createServer: typeof import("node:http").createServer;
+};
+
+export const PREFERRED_CALLBACK_PORT = 53692;
+export const CALLBACK_PATH = "/callback";
+const BIND_FAILURE_CODES = new Set(["EACCES", "EADDRINUSE", "EPERM"]);
+
+export function callbackRedirectUri(port: number): string {
+	return `http://localhost:${port}${CALLBACK_PATH}`;
+}
+
+function respondHtml(res: ServerResponse, status: number, html: string): void {
+	res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
+	res.end(html);
+}
+
+/**
+ * A callback whose `state` belongs to another login. Either a different
+ * session's login could not bind its own port and is waiting for a pasted
+ * redirect URL, or this tab belongs to an attempt that no longer exists.
+ */
+function foreignLoginHtml(requestUrl: string): string {
+	return oauthErrorHtml(
+		"This browser login belongs to a different session of this app, or to an earlier login attempt.",
+		[
+			"If a session is still waiting for this login (it shows a prompt to paste the redirect URL), copy the full address from the browser's address bar and paste it there.",
+			"Otherwise this attempt is stale: close this tab and run the login again from the session that needs it.",
+			"",
+			requestUrl,
+		].join("\n"),
+	);
+}
+
+function handleCallback(
+	req: IncomingMessage,
+	res: ServerResponse,
+	port: number,
+	expectedState: string,
+	settle: (value: CallbackCode) => void,
+): void {
+	try {
+		const url = new URL(req.url ?? "", `http://localhost:${port}`);
+		if (url.pathname !== CALLBACK_PATH) {
+			respondHtml(res, 404, oauthErrorHtml("Callback route not found."));
+			return;
+		}
+		const code = url.searchParams.get("code");
+		const state = url.searchParams.get("state");
+		const error = url.searchParams.get("error");
+		if (error) {
+			respondHtml(res, 400, oauthErrorHtml("Anthropic authentication did not complete.", `Error: ${error}`));
+			return;
+		}
+		if (!code || !state) {
+			respondHtml(res, 400, oauthErrorHtml("Missing code or state parameter."));
+			return;
+		}
+		if (state !== expectedState) {
+			respondHtml(res, 400, foreignLoginHtml(url.toString()));
+			return;
+		}
+		respondHtml(res, 200, oauthSuccessHtml("Anthropic authentication completed. You can close this window."));
+		settle({ code, state });
+	} catch {
+		res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+		res.end("Internal error");
+	}
+}
+
+function errorCode(error: unknown): string | undefined {
+	const code = (error as { code?: unknown } | null)?.code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function boundPort(server: Server): number | undefined {
+	const address = server.address();
+	return typeof address === "object" && address !== null ? address.port : undefined;
+}
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve) => {
+		server.close(() => resolve());
+		// Keep-alive connections from the browser would otherwise delay the close
+		// callback until they idle out.
+		server.closeAllConnections?.();
+	});
+}
+
+function bind(
+	apis: CallbackListenerApis,
+	port: number,
+	host: string,
+	expectedState: string,
+	settle: (value: CallbackCode) => void,
+): Promise<Server> {
+	return new Promise((resolve, reject) => {
+		const server = apis.createServer((req, res) => {
+			handleCallback(req, res, boundPort(server) ?? port, expectedState, settle);
+		});
+		server.on("error", reject);
+		server.listen(port, host, () => resolve(server));
+	});
+}
+
+/**
+ * Binds the preferred port, then an ephemeral one; when neither can be bound
+ * the login continues in manual mode with the registered preferred-port
+ * redirect URI, so a pasted redirect URL still exchanges.
+ */
+export async function startCallbackListener(
+	apis: CallbackListenerApis,
+	expectedState: string,
+	host: string,
+): Promise<CallbackListener> {
+	let settled = false;
+	let settle!: (value: CallbackCode | null) => void;
+	const waitForCodePromise = new Promise<CallbackCode | null>((resolve) => {
+		settle = (value) => {
+			if (settled) return;
+			settled = true;
+			resolve(value);
+		};
+	});
+	let lastBindFailure: string | undefined;
+	for (const port of [PREFERRED_CALLBACK_PORT, 0]) {
+		try {
+			const server = await bind(apis, port, host, expectedState, settle);
+			const actualPort = boundPort(server) ?? port;
+			return {
+				port: actualPort,
+				redirectUri: callbackRedirectUri(actualPort),
+				waitForCode: () => waitForCodePromise,
+				cancelWait: () => settle(null),
+				close: () => closeServer(server),
+			};
+		} catch (error) {
+			const code = errorCode(error);
+			if (code === undefined || !BIND_FAILURE_CODES.has(code)) {
+				throw new Error(`Could not open OAuth callback listener at ${host}:${port}: ${formatErrorDetails(error)}`);
+			}
+			lastBindFailure = code;
+		}
+	}
+	return {
+		redirectUri: callbackRedirectUri(PREFERRED_CALLBACK_PORT),
+		callbackUnavailable: { code: lastBindFailure ?? "EADDRINUSE" },
+		waitForCode: async () => null,
+		cancelWait: () => {},
+		close: async () => {},
+	};
+}

--- a/packages/ai/src/auth/oauth/anthropic.ts
+++ b/packages/ai/src/auth/oauth/anthropic.ts
@@ -5,28 +5,23 @@
  * It is only intended for CLI use, not browser environments.
  */
 
-import type { Server } from "node:http";
 import { getProviderEnvValue } from "../../utils/provider-env.ts";
 import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
-import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.ts";
+import {
+	type CallbackListenerApis,
+	PREFERRED_CALLBACK_PORT,
+	startCallbackListener,
+} from "./anthropic-callback-listener.ts";
+import { parseAuthorizationInput } from "./authorization-input.ts";
+import { formatErrorDetails } from "./error-details.ts";
 import { generatePKCE } from "./pkce.ts";
-
-type CallbackServerInfo = {
-	server?: Server;
-	redirectUri: string;
-	callbackUnavailable?: { code: string };
-	cancelWait: () => void;
-	waitForCode: () => Promise<{ code: string; state: string } | null>;
-};
 
 export function __setAnthropicOAuthNodeApisForTests(apis: NodeApis | null): void {
 	nodeApis = apis;
 	nodeApisPromise = null;
 }
 
-type NodeApis = {
-	createServer: typeof import("node:http").createServer;
-};
+type NodeApis = CallbackListenerApis;
 
 let nodeApis: NodeApis | null = null;
 let nodeApisPromise: Promise<NodeApis> | null = null;
@@ -36,9 +31,12 @@ const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 const CALLBACK_HOST = getProviderEnvValue("PI_OAUTH_CALLBACK_HOST") || "127.0.0.1";
-const CALLBACK_PORT = 53692;
-const CALLBACK_PATH = "/callback";
-const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+/**
+ * A login nobody finishes must not keep its listener (and its manual prompt)
+ * alive forever: the stale listener would answer a later login's browser
+ * redirect on this machine with "State mismatch".
+ */
+const LOGIN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 const SCOPES =
 	"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 async function getNodeApis(): Promise<NodeApis> {
@@ -53,138 +51,6 @@ async function getNodeApis(): Promise<NodeApis> {
 	}
 	nodeApis = await nodeApisPromise;
 	return nodeApis;
-}
-
-function parseAuthorizationInput(input: string): { code?: string; state?: string } {
-	const value = input.trim();
-	if (!value) return {};
-
-	try {
-		const url = new URL(value);
-		return {
-			code: url.searchParams.get("code") ?? undefined,
-			state: url.searchParams.get("state") ?? undefined,
-		};
-	} catch {
-		// not a URL
-	}
-
-	if (value.includes("#")) {
-		const [code, state] = value.split("#", 2);
-		return { code, state };
-	}
-
-	if (value.includes("code=")) {
-		const params = new URLSearchParams(value);
-		return {
-			code: params.get("code") ?? undefined,
-			state: params.get("state") ?? undefined,
-		};
-	}
-
-	return { code: value };
-}
-
-function formatErrorDetails(error: unknown): string {
-	if (error instanceof Error) {
-		const details: string[] = [`${error.name}: ${error.message}`];
-		const errorWithCode = error as Error & { code?: string; errno?: number | string; cause?: unknown };
-		if (errorWithCode.code) details.push(`code=${errorWithCode.code}`);
-		if (typeof errorWithCode.errno !== "undefined") details.push(`errno=${String(errorWithCode.errno)}`);
-		if (typeof error.cause !== "undefined") {
-			details.push(`cause=${formatErrorDetails(error.cause)}`);
-		}
-		if (error.stack) {
-			details.push(`stack=${error.stack}`);
-		}
-		return details.join("; ");
-	}
-	return String(error);
-}
-
-async function startCallbackServer(expectedState: string): Promise<CallbackServerInfo> {
-	const { createServer } = await getNodeApis();
-
-	return new Promise((resolve, reject) => {
-		let settleWait: ((value: { code: string; state: string } | null) => void) | undefined;
-		const waitForCodePromise = new Promise<{ code: string; state: string } | null>((resolveWait) => {
-			let settled = false;
-			settleWait = (value) => {
-				if (settled) return;
-				settled = true;
-				resolveWait(value);
-			};
-		});
-
-		const server = createServer((req, res) => {
-			try {
-				const url = new URL(req.url || "", "http://localhost");
-				if (url.pathname !== CALLBACK_PATH) {
-					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Callback route not found."));
-					return;
-				}
-
-				const code = url.searchParams.get("code");
-				const state = url.searchParams.get("state");
-				const error = url.searchParams.get("error");
-
-				if (error) {
-					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Anthropic authentication did not complete.", `Error: ${error}`));
-					return;
-				}
-
-				if (!code || !state) {
-					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Missing code or state parameter."));
-					return;
-				}
-
-				if (state !== expectedState) {
-					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("State mismatch."));
-					return;
-				}
-
-				res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-				res.end(oauthSuccessHtml("Anthropic authentication completed. You can close this window."));
-				settleWait?.({ code, state });
-			} catch {
-				res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
-				res.end("Internal error");
-			}
-		});
-
-		server.on("error", (err) => {
-			const code = (err as NodeJS.ErrnoException).code;
-			if (code === "EACCES" || code === "EADDRINUSE" || code === "EPERM") {
-				resolve({
-					redirectUri: REDIRECT_URI,
-					callbackUnavailable: { code },
-					cancelWait: () => {},
-					waitForCode: async () => null,
-				});
-				return;
-			}
-			reject(
-				new Error(
-					`Could not open OAuth callback listener at ${CALLBACK_HOST}:${CALLBACK_PORT}: ${formatErrorDetails(err)}`,
-				),
-			);
-		});
-
-		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
-			resolve({
-				server,
-				redirectUri: REDIRECT_URI,
-				cancelWait: () => {
-					settleWait?.(null);
-				},
-				waitForCode: () => waitForCodePromise,
-			});
-		});
-	});
 }
 
 async function postJson(url: string, body: Record<string, string | number>, signal: AbortSignal): Promise<string> {
@@ -253,17 +119,24 @@ async function exchangeAuthorizationCode(
 
 async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAuthCredential> {
 	const { verifier, challenge } = await generatePKCE();
-	const server = await startCallbackServer(verifier);
+	const listener = await startCallbackListener(await getNodeApis(), verifier, CALLBACK_HOST);
 	const manualAbort = new AbortController();
+	let timedOut = false;
 	// Cancelling the login must release BOTH waits: the callback listener and the
-	// manual prompt. In manual-only mode (callback port unavailable) the prompt is
-	// the only thing keeping the login alive, so leaving it open would hang cleanup.
-	const onAbort = () => {
-		server.cancelWait();
+	// manual prompt. In manual-only mode (no callback port could be bound) the
+	// prompt is the only thing keeping the login alive, so leaving it open would
+	// hang cleanup.
+	const releaseWaits = () => {
+		listener.cancelWait();
 		manualAbort.abort();
 	};
-	interaction.signal.addEventListener("abort", onAbort, { once: true });
-	if (interaction.signal.aborted) onAbort();
+	interaction.signal.addEventListener("abort", releaseWaits, { once: true });
+	if (interaction.signal.aborted) releaseWaits();
+	const idleTimer = setTimeout(() => {
+		timedOut = true;
+		releaseWaits();
+	}, LOGIN_IDLE_TIMEOUT_MS);
+	idleTimer.unref?.();
 	let code: string | undefined;
 	let state: string | undefined;
 	let manualInput: string | undefined;
@@ -274,7 +147,7 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 			code: "true",
 			client_id: CLIENT_ID,
 			response_type: "code",
-			redirect_uri: REDIRECT_URI,
+			redirect_uri: listener.redirectUri,
 			scope: SCOPES,
 			code_challenge: challenge,
 			code_challenge_method: "S256",
@@ -283,8 +156,8 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 		interaction.notify({
 			type: "auth_url",
 			url: `${AUTHORIZE_URL}?${authParams.toString()}`,
-			instructions: server.callbackUnavailable
-				? `The local OAuth callback port ${CALLBACK_PORT} could not be opened (${server.callbackUnavailable.code}). Complete login in your browser, then copy the final redirect URL from the address bar and paste it here.`
+			instructions: listener.callbackUnavailable
+				? `No local OAuth callback port could be opened (port ${PREFERRED_CALLBACK_PORT} and an ephemeral port both failed: ${listener.callbackUnavailable.code}). Complete login in your browser, then copy the final redirect URL from the address bar and paste it here.`
 				: "Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
 		});
 
@@ -292,19 +165,20 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 			.prompt({
 				type: "manual_code",
 				message: "Complete login in your browser, or paste the authorization code / redirect URL here:",
-				placeholder: REDIRECT_URI,
+				placeholder: listener.redirectUri,
 				signal: manualAbort.signal,
 			})
 			.then((input) => {
 				manualInput = input;
-				server.cancelWait();
+				listener.cancelWait();
 			})
 			.catch((error) => {
 				manualError = error instanceof Error ? error : new Error(String(error));
-				server.cancelWait();
+				listener.cancelWait();
 			});
 
-		const result = await server.waitForCode();
+		const result = await listener.waitForCode();
+		if (timedOut) throw new Error(loginTimedOutMessage());
 		if (manualError) throw manualError;
 		if (result?.code) {
 			code = result.code;
@@ -318,6 +192,7 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 
 		if (!code) {
 			await manualPromise;
+			if (timedOut) throw new Error(loginTimedOutMessage());
 			if (manualError) throw manualError;
 			if (manualInput) {
 				const parsed = parseAuthorizationInput(manualInput);
@@ -330,12 +205,18 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 		if (!code) throw new Error("Missing authorization code");
 		if (!state) throw new Error("Missing OAuth state");
 		interaction.notify({ type: "progress", message: "Exchanging authorization code for tokens..." });
-		return exchangeAuthorizationCode(code, state, verifier, REDIRECT_URI, interaction.signal);
+		return await exchangeAuthorizationCode(code, state, verifier, listener.redirectUri, interaction.signal);
 	} finally {
-		interaction.signal.removeEventListener("abort", onAbort);
+		clearTimeout(idleTimer);
+		interaction.signal.removeEventListener("abort", releaseWaits);
 		manualAbort.abort();
-		server.server?.close();
+		await listener.close();
 	}
+}
+
+function loginTimedOutMessage(): string {
+	const minutes = Math.round(LOGIN_IDLE_TIMEOUT_MS / 60_000);
+	return `Anthropic login timed out after ${minutes} minutes without a browser callback or a pasted redirect URL. Run the login again.`;
 }
 
 /**

--- a/packages/ai/src/auth/oauth/authorization-input.ts
+++ b/packages/ai/src/auth/oauth/authorization-input.ts
@@ -1,0 +1,30 @@
+/** Parses a pasted redirect URL, `code#state` pair, query string, or bare code. */
+export function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+	const value = input.trim();
+	if (!value) return {};
+
+	try {
+		const url = new URL(value);
+		return {
+			code: url.searchParams.get("code") ?? undefined,
+			state: url.searchParams.get("state") ?? undefined,
+		};
+	} catch {
+		// not a URL
+	}
+
+	if (value.includes("#")) {
+		const [code, state] = value.split("#", 2);
+		return { code, state };
+	}
+
+	if (value.includes("code=")) {
+		const params = new URLSearchParams(value);
+		return {
+			code: params.get("code") ?? undefined,
+			state: params.get("state") ?? undefined,
+		};
+	}
+
+	return { code: value };
+}

--- a/packages/ai/src/auth/oauth/error-details.ts
+++ b/packages/ai/src/auth/oauth/error-details.ts
@@ -1,0 +1,17 @@
+/** Flattens an error (with `code`, `errno`, `cause`, and stack) into one diagnostic line. */
+export function formatErrorDetails(error: unknown): string {
+	if (error instanceof Error) {
+		const details: string[] = [`${error.name}: ${error.message}`];
+		const errorWithCode = error as Error & { code?: string; errno?: number | string; cause?: unknown };
+		if (errorWithCode.code) details.push(`code=${errorWithCode.code}`);
+		if (typeof errorWithCode.errno !== "undefined") details.push(`errno=${String(errorWithCode.errno)}`);
+		if (typeof error.cause !== "undefined") {
+			details.push(`cause=${formatErrorDetails(error.cause)}`);
+		}
+		if (error.stack) {
+			details.push(`stack=${error.stack}`);
+		}
+		return details.join("; ");
+	}
+	return String(error);
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -503,6 +503,29 @@
 
 - LOW: `utils/retry.ts` provider timeout pattern.
 
+## 2026-09-09 - Anthropic OAuth callback listener: ephemeral port fallback and idle timeout
+
+### What changed
+
+- `auth/oauth/anthropic.ts`: the login now binds its callback listener through `auth/oauth/anthropic-callback-listener.ts` (new, fork-only). The listener still prefers `127.0.0.1:53692`, but when that port is already held (EADDRINUSE, EACCES, EPERM) it binds an ephemeral loopback port instead of dropping into manual mode; the auth URL `redirect_uri`, the manual-prompt placeholder, and the token-exchange `redirect_uri` all carry the port that was actually bound. Manual-only mode (registered `http://localhost:53692/callback` redirect, paste the redirect URL) is now reached only when neither the preferred nor an ephemeral port can be bound.
+- `auth/oauth/anthropic.ts`: a login that receives neither a browser callback nor a pasted redirect URL for 10 minutes rejects with a timeout error and closes its listener, instead of holding the port and the manual prompt open indefinitely.
+- `auth/oauth/anthropic-callback-listener.ts`: a callback whose `state` belongs to another login answers HTTP 400 with a page that says the login belongs to a different session or an earlier attempt and tells the user to paste the address-bar URL into the session that is waiting (or to restart the login), instead of the bare "State mismatch." page.
+- `auth/oauth/authorization-input.ts` and `auth/oauth/error-details.ts` (new, fork-only): `parseAuthorizationInput` and `formatErrorDetails` moved out of `anthropic.ts` unchanged.
+
+### Why
+
+- Two senpi/omo processes on one machine (a second TUI session, an RPC host whose login prompt was never answered, an abandoned `/login`) could not both log in: the second login hit EADDRINUSE, fell back to manual mode while still advertising `localhost:53692`, and the browser redirect landed on the first process's stale listener, which rendered "State mismatch." on every retry (omo Discord report, 2026-09-09). The OAuth client is registered for any localhost port on `/callback` - the Claude Code CLI itself binds a random port - so a fixed port was never required.
+- A pending login had no deadline, so one abandoned attempt kept the port for the life of the process.
+
+### Why an extension could not handle it
+
+- The callback listener, the redirect URI it advertises, and the token exchange are created and owned inside the provider OAuth implementation before any auth interaction event reaches an extension; an extension can neither pick the port nor change the redirect URI the exchange must match.
+
+### Expected merge conflict zones
+
+- MEDIUM: `src/auth/oauth/anthropic.ts` callback listener startup, auth URL construction, manual prompt, cleanup (listener code moved out of the file).
+- LOW: `test/anthropic-oauth.test.ts` callback listener coverage.
+
 ## 2026-09-02 - Anthropic OAuth callback bind fallback
 
 ### What changed

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,8 +1,10 @@
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAnthropicOAuthNodeApisForTests, anthropicOAuth } from "../src/auth/oauth/anthropic.ts";
 import type { AuthEvent, AuthPrompt } from "../src/auth/types.ts";
 
 const neverAbortedSignal = new AbortController().signal;
+const PREFERRED_CALLBACK_PORT = 53692;
 
 function jsonResponse(body: unknown, status: number = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -239,5 +241,158 @@ describe.sequential("Anthropic OAuth", () => {
 		expect(prompts.some((p) => p.type === "manual_code")).toBe(true);
 		// the prompt's signal is aborted once login settles, so UIs can dismiss it
 		expect(manualSignal?.aborted).toBe(true);
+	});
+});
+
+type PortHold = { bound: boolean; close: () => Promise<void> };
+
+/** Holds a loopback port with a real listener; `bound` is false when something else already owns it. */
+function occupyPort(port: number): Promise<PortHold> {
+	return new Promise((resolve) => {
+		const server: Server = createServer((_req, res) => {
+			res.writeHead(503);
+			res.end("occupied");
+		});
+		server.once("error", () => resolve({ bound: false, close: async () => {} }));
+		server.listen(port, "127.0.0.1", () =>
+			resolve({
+				bound: true,
+				close: () => new Promise<void>((done) => server.close(() => done())),
+			}),
+		);
+	});
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+/** A manual-code prompt that stays open until the login aborts it. */
+function pendingPrompt(prompt: AuthPrompt): Promise<string> {
+	return new Promise<string>((_resolve, reject) => {
+		prompt.signal?.addEventListener("abort", () => reject(new Error("prompt aborted")), { once: true });
+	});
+}
+
+type StartedLogin = { login: Promise<{ access: string }>; authUrl: Promise<URL> };
+
+function startLogin(signal: AbortSignal = neverAbortedSignal): StartedLogin {
+	const authUrl = deferred<URL>();
+	const login = anthropicOAuth.login({
+		signal,
+		notify: (event) => {
+			if (event.type === "auth_url") authUrl.resolve(new URL(event.url));
+		},
+		prompt: pendingPrompt,
+	});
+	return { login, authUrl: authUrl.promise };
+}
+
+function redirectOf(authUrl: URL): URL {
+	const redirect = authUrl.searchParams.get("redirect_uri");
+	if (!redirect) throw new Error("auth URL carries no redirect_uri");
+	return new URL(redirect);
+}
+
+/** Token-exchange fake that lets loopback callback requests through to the real listener. */
+function stubTokenExchange(): { exchanges: Record<string, string>[]; loopbackFetch: typeof fetch } {
+	const realFetch = globalThis.fetch;
+	const exchanges: Record<string, string>[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.startsWith("http://127.0.0.1:")) return realFetch(url, init);
+			exchanges.push(getJsonBody(init));
+			return jsonResponse({
+				access_token: `access-${exchanges.length}`,
+				refresh_token: "refresh",
+				expires_in: 3600,
+			});
+		}),
+	);
+	return { exchanges, loopbackFetch: realFetch };
+}
+
+describe.sequential("Anthropic OAuth callback listener", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it("binds an ephemeral loopback port when 53692 is already taken", async () => {
+		const occupied = await occupyPort(PREFERRED_CALLBACK_PORT);
+		const { exchanges, loopbackFetch } = stubTokenExchange();
+		try {
+			const started = startLogin();
+			const authUrl = await started.authUrl;
+			const redirect = redirectOf(authUrl);
+			expect(redirect.port).not.toBe(String(PREFERRED_CALLBACK_PORT));
+			const callback = await loopbackFetch(
+				`http://127.0.0.1:${redirect.port}/callback?code=browser-code&state=${authUrl.searchParams.get("state")}`,
+			);
+			expect(callback.status).toBe(200);
+			const credential = await started.login;
+			expect(credential.access).toBe("access-1");
+			expect(exchanges).toHaveLength(1);
+			expect(exchanges[0]?.code).toBe("browser-code");
+			expect(exchanges[0]?.redirect_uri).toBe(`http://localhost:${redirect.port}/callback`);
+		} finally {
+			await occupied.close();
+		}
+	});
+
+	it("keeps two concurrent logins in one process independent", async () => {
+		const { exchanges, loopbackFetch } = stubTokenExchange();
+		const first = startLogin();
+		const second = startLogin();
+		const [firstUrl, secondUrl] = await Promise.all([first.authUrl, second.authUrl]);
+		const firstPort = redirectOf(firstUrl).port;
+		const secondPort = redirectOf(secondUrl).port;
+		expect(secondPort).not.toBe(firstPort);
+		const secondCallback = await loopbackFetch(
+			`http://127.0.0.1:${secondPort}/callback?code=code-second&state=${secondUrl.searchParams.get("state")}`,
+		);
+		expect(secondCallback.status).toBe(200);
+		const firstCallback = await loopbackFetch(
+			`http://127.0.0.1:${firstPort}/callback?code=code-first&state=${firstUrl.searchParams.get("state")}`,
+		);
+		expect(firstCallback.status).toBe(200);
+		const [firstCredential, secondCredential] = await Promise.all([first.login, second.login]);
+		expect(secondCredential.access).toBe("access-1");
+		expect(firstCredential.access).toBe("access-2");
+		expect(exchanges.map((exchange) => [exchange.code, exchange.redirect_uri])).toEqual([
+			["code-second", `http://localhost:${secondPort}/callback`],
+			["code-first", `http://localhost:${firstPort}/callback`],
+		]);
+	});
+
+	it("times out an idle login after 10 minutes and releases its listener", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const controller = new AbortController();
+		const started = startLogin(controller.signal);
+		let outcome: string | undefined;
+		void started.login.then(
+			() => {
+				outcome = "resolved";
+			},
+			(error: unknown) => {
+				outcome = error instanceof Error ? error.message : String(error);
+			},
+		);
+		try {
+			const port = Number(redirectOf(await started.authUrl).port);
+			await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+			await vi.waitFor(() => expect(outcome).toMatch(/timed out/i), { timeout: 5000 });
+			const released = await occupyPort(port);
+			expect(released.bound).toBe(true);
+			await released.close();
+		} finally {
+			controller.abort();
+		}
 	});
 });

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -36,6 +36,10 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.senpi/agent/auth.js
 
 Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party harness usage draws from [extra usage](https://claude.ai/settings/usage) and is billed per token, not against Claude plan limits.
 
+- Run `/login anthropic` to open the browser flow. The login listens on loopback port 53692 when it is free and on an ephemeral port otherwise, so a second session on the same machine (another TUI, an RPC host, an abandoned login) can log in at the same time; the auth URL always names the port that is actually listening.
+- If the browser lands on a page saying the login belongs to a different session or an earlier attempt, that page's address was sent to another login's listener: paste the full address from the address bar into the session whose prompt is still waiting, or run the login again from that session.
+- A login that receives neither the browser callback nor a pasted redirect URL for 10 minutes fails with a timeout and releases its port; run `/login anthropic` again.
+
 ### Claude SDK OAuth
 
 The `claude-sdk-oauth` provider routes LLM calls through the official [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) - it spawns the real Claude Code engine - while senpi executes every tool itself. Subscription usage flows through Anthropic's official Claude Code surface.


### PR DESCRIPTION
## Summary

Fixes #1503.

Fixes the Anthropic OAuth login dead-end reported on Discord (2026-09-09): `/claude-account add` / `/login anthropic` ended on a browser page reading **"Authentication failed - State mismatch."** on every retry.

**Root cause.** `packages/ai/src/auth/oauth/anthropic.ts` bound a fixed loopback port (`127.0.0.1:53692`). When another senpi/omo process on the same machine still held that port (a second TUI session, an RPC host whose login prompt was never answered, an abandoned `/login`), the new login got `EADDRINUSE`, silently switched to manual mode, but kept advertising `redirect_uri=http://localhost:53692/callback`. The browser redirect therefore landed on the *other* process's stale listener, whose expected `state` differed, so it rendered "State mismatch." A pending login never timed out, so one abandoned attempt kept the port for the life of that process.

The OAuth client is registered for any `localhost` port on `/callback` (the Claude Code CLI itself binds a random port per login), so the fixed port was never required.

## Changes

- `anthropic-callback-listener.ts` (new): binds 53692 when free, otherwise an ephemeral loopback port; the auth URL `redirect_uri`, the manual-prompt placeholder, and the token-exchange `redirect_uri` all carry the port actually bound. Manual-only mode (registered 53692 redirect, paste the URL) is reached only when neither port can be bound.
- A callback whose `state` belongs to another login answers HTTP 400 with a page that says the login belongs to a different session or an earlier attempt and tells the user to paste the address-bar URL into the waiting session (or restart the login).
- A login that gets neither a browser callback nor a pasted redirect URL for 10 minutes rejects with a timeout and closes its listener.
- `parseAuthorizationInput` / `formatErrorDetails` moved out of `anthropic.ts` unchanged (file size).
- Trackers: `packages/ai/src/changes.md`, `packages/ai/CHANGELOG.md` [Unreleased], `docs/providers.md`.

## Evidence

- vitest `packages/ai/test/anthropic-oauth.test.ts` on mengmotaMac: RED 3 failed / 8 passed before the fix (`expected '53692' not to be '53692'`, idle outcome undefined) -> GREEN 11/11. Regression set: `anthropic-oauth` + `openai-codex-oauth` 19/19, coding-agent `rpc-login-interactive-prompts` + `claude-sdk-oauth-account-command` 9/9.
- Real surface (RPC, `--mode rpc --no-extensions`, isolated agent dir, dummy server holding 53692): `auth_login_url` advertised `http://localhost:50476/callback`; `GET /callback?code=FAKE-OTHER&state=other` -> HTTP 400 with the new guidance page; `GET /callback?code=FAKE-CODE&state=<state>` -> HTTP 200; `auth_login_end` carried the token-exchange failure naming `redirect_uri=http://localhost:50476/callback` (Anthropic answered `invalid_grant` on the fake code, not a redirect-URI rejection); port released afterwards.
- `bun run check` exit 0; changelog gate exit 0.
