### PR TITLE
fix(ai): cover shipped OpenGateway Astra catalog

### DIFF
--- a/packages/ai/test/gpt-6-astra-context-window.test.ts
+++ b/packages/ai/test/gpt-6-astra-context-window.test.ts
@@ -58,6 +58,7 @@ describe("GPT-6 Astra series catalog context window", () => {
 			"openai-codex.json",
 			"openai.json",
 			"opencode.json",
+			"opengateway.json",
 			"openrouter.json",
 			"vercel-ai-gateway.json",
 		]);


### PR DESCRIPTION
## Summary
Add `opengateway.json` to the exact expected provider list in the Astra catalog regression test. Release `d5ba44e48` shipped OpenGateway's `openai/gpt-6-astra` with the correct 600000 context window, but the coverage assertion still expected seven providers instead of eight.

This is a one-line test-only fix based on freshly fetched main `fe1b15dc54c97323328b76882b9118bfa9b30714`. No production catalogs, discovery logic, context assertions, or skips change. The dynamically discovered entries must still all declare exactly 600000, including entries in any future provider catalog.

## QA & Evidence
Executed remotely on the approved Gorky compute host using Bun 1.3.14 and the package-pinned Vitest 4.1.11. The isolated snapshot contains the actual committed provider catalogs, actual test, and actual Vitest configuration (no mocked catalog data).

Command from the snapshot's `packages/ai` directory:
```sh
bun ../../node_modules/vitest/vitest.mjs run test/gpt-6-astra-context-window.test.ts
```

- **RED, fresh main:** 1 passed / 1 failed, exit 1. The context invariant passes; line 55 rejects the additional `opengateway.json` provider.
- **GREEN, this patch:** 2 passed / 0 failed, exit 0, on the first run.
- **Negative mutation, isolated copy only:** changing `opengateway.json:openai-completions/openai/gpt-6-astra` from 600000 to 1050000 produces 1 passed / 1 failed, exit 1. The unchanged context assertion rejects exactly `opengateway.json:openai-completions/openai/gpt-6-astra=1050000`; provider coverage still passes.
- Changed-file TypeScript language-server diagnostics: clean. `git diff --check`: clean.
- Local evidence directory: `/Users/yeongyu/sisyphuslabs/artifacts/st_01a08258/` (`red.log`, `green.log`, `mutation.log`). Sanitized transcripts will also be attached as a PR comment.

## Risks & Residuals
No runtime behavior changes. Full repository CI is tracked by this PR; focused remote validation is not a claim that the entire suite passed. The RED run emitted a Vite module-type warning from the minimal harness; setting the harness package type to module removed it for GREEN and mutation runs without changing shipped code.

This also explains the Astra failure on PR #1499's synthetic merge: its head `0a3d6bd8d` lacks OpenGateway Astra entries, whereas current main ships them. This PR does not modify that worktree or branch.

**Do not merge as part of this task.**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Astra catalog regression test to include `opengateway.json` in the expected provider list, covering the shipped OpenGateway GPT-6 Astra entry and making the test pass.

<sup>Written for commit a8d7d46607b2f4d6bc52cc87f2d8c04f6947278d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

