### PR TITLE
fix(models): admit compaction-eligible restored transcripts on session resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Resumed sessions in the compaction band open cleanly again: `projectModelUsabilityBudget` on `admission: "resume"` now admits compaction-eligible restored transcripts when the uncompacted context fits within the model's summarization capacity and the post-compaction context fits execution reserves, rather than charging full output generation reserves against the uncompacted transcript before auto-compaction can run.
+
 - Large sessions can compact again: the summarization wall-clock budget scales with the estimated input (`max(120s, 2ms per token)`, capped at 30 minutes) instead of a fixed 120 seconds, so a 200k+ token summary on a slower provider is no longer rejected while still streaming and the session no longer stays wedged above its compaction threshold. Small inputs keep the exact 120-second contract, the idle watchdog is unchanged, and the retry allowance stays at half of one attempt ([#1068](https://github.com/code-yeongyu/senpi/issues/1068), [#1501](https://github.com/code-yeongyu/senpi/pull/1501)).
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,25 @@
 # changes.md — builtin compaction policy
 
+## Allow compaction-eligible restored transcripts during resumed-session admission (2026-09-09)
+
+### What changed
+
+- `projectModelUsabilityBudget`: on `admission: "resume"`, when compaction is enabled and speculation lead is omitted, transcripts whose uncompacted tokens would exceed the target window due to full output generation reserves are now admitted if the uncompacted context fits within the model's summarization capacity (`liveContextTokens + compactionReserveTokens + safetyMarginTokens <= contextWindow`) and the post-compaction context fits for execution (`effectiveKeepRecentTokens + baseRequiredTokens <= contextWindow`).
+- `test/suite/model-usability-budget.test.ts`: added tests covering resume admission for uncompacted transcripts requiring compaction (such as 346k tokens on a 400k model with 128k output reserve) and confirming rejection when compaction is disabled.
+
+### Why
+
+- Resuming a session with a high-context model (e.g. `gpt-6-astra` with a 400,000 window and 128,000 maxTokens output reserve) charged the full output generation reserve (128,000) against the uncompacted transcript (e.g. 346,286 tokens) on startup admission.
+- The resulting 520,291-token requirement threw `ModelUsabilityBudgetError` before the session could open, preventing the compaction extension from running its automatic `before_agent_start` compaction and permanently locking the session.
+
+### Why an extension could not handle it
+
+- `createAgentSession` evaluates model usability during session construction before extension event hooks are wired.
+
+### Expected merge conflict zones
+
+- `model-usability-budget.ts` projection calculation; `test/suite/model-usability-budget.test.ts`.
+
 ## Scale the speculative attempt budget and retry allowance with the input size (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/model-usability-budget.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/model-usability-budget.ts
@@ -1,7 +1,8 @@
 import { type Api, estimateContextTokens, type Model, type Tool } from "@earendil-works/pi-ai";
-import type { CompactionPreparation } from "../../../compaction/index.ts";
+import { type CompactionPreparation, DEFAULT_COMPACTION_SETTINGS } from "../../../compaction/index.ts";
 import { getPromptContextWindow } from "./extension-wiring.ts";
 import { resolveCompactionGeometry } from "./orchestration.ts";
+import { baseThresholdRatioForWindow, computeEffectiveKeepRecentTokens } from "./policy.ts";
 
 interface ModelSafetyMarginProfile {
 	readonly id: string;
@@ -90,16 +91,44 @@ export function projectModelUsabilityBudget<TApi extends Api>(
 			? geometry.leadTokens
 			: 0;
 	const safetyMargin = resolveSafetyMarginProfile(input.model);
-	const requiredTokens =
-		liveContextTokens +
+	const baseRequiredTokens =
 		systemPromptTokens +
 		activeToolSchemaTokens +
 		outputReserveTokens +
 		compactionReserveTokens +
 		speculationLeadTokens +
 		safetyMargin.tokens;
-	const shortfallTokens = Math.max(0, requiredTokens - input.model.contextWindow);
+	const uncompactedRequiredTokens = liveContextTokens + baseRequiredTokens;
 	const admission = input.admission ?? (liveContextTokens > 0 ? "switch" : "start");
+
+	let requiredTokens = uncompactedRequiredTokens;
+	let shortfallTokens = Math.max(0, requiredTokens - input.model.contextWindow);
+	let usable = shortfallTokens === 0;
+
+	if (!usable && admission === "resume" && input.compaction.enabled && !includeSpeculationLead) {
+		const compactionRequiredTokens =
+			liveContextTokens +
+			systemPromptTokens +
+			activeToolSchemaTokens +
+			compactionReserveTokens +
+			safetyMargin.tokens;
+		const keepRecentSetting = input.compaction.keepRecentTokens ?? DEFAULT_COMPACTION_SETTINGS.keepRecentTokens;
+		const effectiveKeepRecentTokens = computeEffectiveKeepRecentTokens(
+			keepRecentSetting,
+			input.model.contextWindow,
+			baseThresholdRatioForWindow(input.model.contextWindow),
+		);
+		const postCompactionRequiredTokens = effectiveKeepRecentTokens + baseRequiredTokens;
+
+		if (
+			compactionRequiredTokens <= input.model.contextWindow &&
+			postCompactionRequiredTokens <= input.model.contextWindow
+		) {
+			requiredTokens = Math.max(compactionRequiredTokens, postCompactionRequiredTokens);
+			shortfallTokens = 0;
+			usable = true;
+		}
+	}
 
 	return {
 		model: `${input.model.provider}/${input.model.id}`,

--- a/packages/coding-agent/test/suite/model-usability-budget.test.ts
+++ b/packages/coding-agent/test/suite/model-usability-budget.test.ts
@@ -333,6 +333,68 @@ describe("model usability budget", () => {
 		resumed.session.dispose();
 	});
 
+	it("resumes a restored transcript whose uncompacted context requires compaction to hold output reserves", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "astra-shaped", contextWindow: 400_000, maxTokens: 128_000 }],
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		const sessionManager = SessionManager.inMemory(harness.tempDir);
+		const liveTokens = 346_286;
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "! ".repeat(liveTokens * 2) }],
+			timestamp: Date.now(),
+		});
+
+		// when
+		const resumed = await createAgentSession({
+			cwd: harness.tempDir,
+			agentDir: join(harness.tempDir, "astra-resume"),
+			model,
+			sessionManager,
+		});
+
+		// then
+		expect(resumed.session.agent.state.messages).toHaveLength(1);
+		resumed.session.dispose();
+	});
+
+	it("rejects an uncompacted transcript on resume when compaction is disabled", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "astra-shaped", contextWindow: 400_000, maxTokens: 128_000 }],
+			settings: { compaction: { enabled: false } },
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		const sessionManager = SessionManager.inMemory(harness.tempDir);
+		const liveTokens = 346_286;
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "! ".repeat(liveTokens * 2) }],
+			timestamp: Date.now(),
+		});
+
+		// when / then
+		await expect(
+			createAgentSession({
+				cwd: harness.tempDir,
+				agentDir: join(harness.tempDir, "astra-disabled-resume"),
+				model,
+				sessionManager,
+				settingsManager: harness.settingsManager,
+			}),
+		).rejects.toMatchObject({
+			name: "ModelUsabilityBudgetError",
+			projection: {
+				usable: false,
+				admission: "resume",
+			},
+		});
+	});
+
 	it("keeps fresh and fitting resumed sessions accepted", async () => {
 		// given
 		const harness = await createHarness({


### PR DESCRIPTION
## Summary

Resuming a session with a model whose output reserve is large (such as `opencodex/gpt-6-astra` with a 400,000 context window and 128,000 maxTokens output reserve) charged the full output generation reserve (`128,000`) against the uncompacted transcript on startup admission. When the restored transcript accumulated context in its normal compaction band (e.g. `346,286` tokens), `projectModelUsabilityBudget` calculated:
`346,286 (live) + 128,000 (output) + 16,384 (compaction) + 8,192 (safety) + 21,429 (prompt/tools) = 520,291 tokens`
resulting in a 120,291 token shortfall against the 400,000 window and throwing `ModelUsabilityBudgetError`.

Because this check ran during `createAgentSession` construction before extension hooks were wired, the compaction extension's automatic `before_agent_start` compaction could never execute, permanently locking the user out of their session.

## What changed

- **`projectModelUsabilityBudget`**: On `admission: "resume"` with compaction enabled and speculation lead omitted (`!includeSpeculationLead`), transcripts whose uncompacted context would exceed the target window due to output generation reserves are admitted if:
  1. The uncompacted transcript fits within the model's summarization capacity (`liveContextTokens + compactionReserveTokens + safetyMarginTokens <= contextWindow`), and
  2. The post-compaction context fits execution reserves (`effectiveKeepRecentTokens + baseRequiredTokens <= contextWindow`).
- **Tests**: Added coverage in `test/suite/model-usability-budget.test.ts` verifying that an uncompacted transcript requiring compaction to hold output reserves resumes cleanly when compaction is enabled, and is rejected when compaction is disabled.
- **Documentation**: Recorded in `builtin/compaction/changes.md` and `CHANGELOG.md`.

## Verification

- `bun run --cwd packages/coding-agent test test/suite/model-usability-budget.test.ts` (14/14 passed)
- `bun run --cwd packages/coding-agent test test/compaction/` (484/484 passed across 70 files)
- `bun run check` (3658 files passed, locks in sync)
- `bun run build` (6 phases completed cleanly)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session resume for high-context models by admitting compaction-eligible restored transcripts before auto-compaction runs, so sessions no longer throw `ModelUsabilityBudgetError` and lock users out.

- `projectModelUsabilityBudget` on `admission: "resume"` now admits transcripts when the uncompacted context fits within the model's summarization capacity and the post-compaction context fits execution reserves.
- Added tests for resume admission with compaction enabled and rejection when disabled; updated `changes.md` and `CHANGELOG.md`.

<sup>Written for commit e9187adc9ef5ae81fbfd32ad545e3fdad19def43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

