### PR TITLE
fix(ai): keep Anthropic thinking stable across tool continuations (prompt-cache miss on every tool turn)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Anthropic prompt caching no longer breaks on every tool continuation: when the model answers a tool call without a thinking block (the normal adaptive-thinking outcome), the follow-up request keeps the same `thinking`/`output_config` instead of degrading to disabled thinking, so the cached prefix is read instead of re-written ("cache misses every second prompt"). Only a budget-thinking request replaying a tool turn produced by another API still degrades, the case Anthropic has rejected.
+
 ### Removed
 
 ## [2026.9.8] - 2026-09-08

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -2121,11 +2121,21 @@ function buildParams(
 		}
 	}
 
-	// Anthropic rejects a thinking-enabled request whose final assistant turn
-	// contains tool_use but does not begin with a thinking block. Cross-model
-	// histories lose their signed thinking blocks (demoted to text or dropped),
-	// so degrade thinking for this request instead of failing every turn.
-	if (params.thinking && params.thinking.type !== "disabled" && finalAssistantTurnStartsWithToolUse(params.messages))
+	// A budget-thinking request whose final assistant turn came from another API
+	// and starts with tool_use (its thinking demoted to text or dropped) is the
+	// history shape Anthropic has rejected with "final assistant message must
+	// start with a thinking block", so that request degrades thinking instead of
+	// failing every turn. Nothing else degrades: adaptive families accept a
+	// tool_use-first final turn (verified live 2026-09-09 on claude-opus-5,
+	// claude-opus-4-6 and claude-fable-5), the model itself skips thinking before
+	// trivial tool calls, and every change to `thinking` re-keys the prompt
+	// cache - degrading here re-wrote the whole cached prefix on each tool
+	// continuation (the "cache misses every second prompt" report).
+	if (
+		params.thinking?.type === "enabled" &&
+		finalAssistantTurnIsForeign(context.messages) &&
+		finalAssistantTurnStartsWithToolUse(params.messages)
+	)
 		disableThinkingForRequest(params, model, compat);
 
 	if (options?.metadata) {
@@ -2175,6 +2185,16 @@ type AnthropicMessageParam = MessageCreateParamsStreaming["messages"][number];
  * thinking/redacted_thinking block. Anthropic requires thinking-enabled
  * requests to start that turn with a thinking block.
  */
+/** True when the last assistant message was produced through a different wire API. */
+function finalAssistantTurnIsForeign(messages: Message[]): boolean {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message.role !== "assistant") continue;
+		return message.api !== "anthropic-messages";
+	}
+	return false;
+}
+
 function finalAssistantTurnStartsWithToolUse(messages: AnthropicMessageParam[]): boolean {
 	for (let index = messages.length - 1; index >= 0; index--) {
 		const message = messages[index];

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -503,6 +503,26 @@
 
 - LOW: `utils/retry.ts` provider timeout pattern.
 
+## 2026-09-09 - Keep Anthropic thinking parameters stable across tool continuations
+
+### What changed
+
+- `api/anthropic-messages.ts` `buildParams()`: the "final assistant turn starts with tool_use" guard now degrades thinking only for a budget-thinking request (`thinking.type: "enabled"`) whose final assistant turn came from a different wire API (`finalAssistantTurnIsForeign`, the Kimi/OpenAI replay shape the guard was written for). Adaptive requests, and native turns under budget thinking, keep the caller's `thinking` and `output_config.effort`.
+
+### Why
+
+- With adaptive thinking the model routinely answers a trivial tool call with `tool_use` and no thinking block. The old guard then sent the tool continuation with `thinking: {type: "disabled"}` (and no `output_config`), and Anthropic keys the prompt cache on the thinking parameters: the continuation missed the whole cached prefix and re-wrote it (2026-09-09 capture, claude-opus-5 through a logging proxy: turn 2 first call `cache_read 28114`, its tool continuation `cache_read 0 / cache_creation 28239`, next turn `cache_read 28181` from the adaptive line). That is the "cache misses every second prompt / burns the 5h limit" report; every tool-using turn paid a full cache write.
+- The premise no longer holds for the models that matter: replaying that exact continuation with `thinking` left adaptive returned HTTP 200 on claude-opus-5, claude-opus-4-6 and claude-fable-5 (and 200 on claude-sonnet-4-5 under `enabled` thinking). The remaining risk is the original incident shape only - foreign history under budget thinking - so that is the only case that still degrades.
+
+### Why an extension could not handle it
+
+- The degrade happens inside the provider request builder after every extension hook has run; no extension sees or can veto the `thinking` rewrite.
+
+### Expected merge conflict zones
+
+- LOW: `src/api/anthropic-messages.ts` thinking degrade guard in `buildParams()` and the `finalAssistantTurnIsForeign` helper next to `finalAssistantTurnStartsWithToolUse`.
+- LOW: `test/anthropic-cross-model-history.test.ts` (the Fable expectation flipped from `effort: low` to adaptive/high; two native-turn cases added).
+
 ## 2026-09-09 - Anthropic OAuth callback listener: ephemeral port fallback and idle timeout
 
 ### What changed

--- a/packages/ai/test/anthropic-cross-model-history.test.ts
+++ b/packages/ai/test/anthropic-cross-model-history.test.ts
@@ -142,10 +142,12 @@ describe("Anthropic cross-model history hardening", () => {
 		expect(assistantBlocks(payload).some((block) => block.type === "thinking")).toBe(false);
 	});
 
-	it("degrades to the lowest legal effort when thinking cannot be disabled", async () => {
-		// Claude Fable 5 rejects `thinking.type: "disabled"` outright, so a replayed
-		// foreign tool turn must fall back to the cheapest legal effort instead of
-		// failing every turn with a 400.
+	it("keeps adaptive thinking for a replayed foreign tool turn", async () => {
+		// Adaptive families accept a final assistant turn that starts with tool_use
+		// (verified live 2026-09-09 on claude-opus-5, claude-opus-4-6 and
+		// claude-fable-5: HTTP 200), and every change to `thinking` re-keys the
+		// prompt cache, so the request keeps the caller's effort instead of
+		// degrading to `effort: "low"`.
 		const fable = getModel("anthropic", "claude-fable-5");
 		const { assistant, results } = foreignToolTurn([{ id: "call_abc", name: "bash" }]);
 		const context: Context = {
@@ -154,8 +156,49 @@ describe("Anthropic cross-model history hardening", () => {
 
 		const payload = await capturePayload(fable, context, { reasoning: "high" });
 
-		expect(payload.thinking).toBeUndefined();
-		expect(payload.output_config).toEqual({ effort: "low" });
+		expect(payload.thinking?.type).toBe("adaptive");
+		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
+	it("keeps adaptive thinking when the model itself answered with tool_use and no thinking block", async () => {
+		// The prompt-cache regression behind "cache misses every second prompt":
+		// with adaptive thinking the model often skips thinking before a trivial
+		// tool call; degrading the continuation to `disabled` re-keyed the whole
+		// cached prefix on every tool turn (28k tokens re-written per turn in the
+		// 2026-09-09 capture).
+		const opus = getModel("anthropic", "claude-opus-5");
+		const { assistant, results } = foreignToolTurn([{ id: "toolu_native", name: "read" }]);
+		const nativeAssistant: AssistantMessage = {
+			...assistant,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-opus-5",
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "read it", timestamp: Date.now() - 3000 }, nativeAssistant, ...results],
+		};
+
+		const payload = await capturePayload(opus, context, { reasoning: "high" });
+
+		expect(payload.thinking?.type).toBe("adaptive");
+		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
+	it("keeps budget thinking when a native tool turn has no thinking block", async () => {
+		const { assistant, results } = foreignToolTurn([{ id: "toolu_native", name: "read" }]);
+		const nativeAssistant: AssistantMessage = {
+			...assistant,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "read it", timestamp: Date.now() - 3000 }, nativeAssistant, ...results],
+		};
+
+		const payload = await capturePayload(model, context, { reasoning: "high" });
+
+		expect(payload.thinking?.type).toBe("enabled");
 	});
 
 	it("keeps thinking enabled when the final turn does not require replayed thinking", async () => {


### PR DESCRIPTION
## Summary

Fixes the "opus 5 is unusable in omo - cache misses every second prompt / burns my 5h limit" report (Discord, 2026-09-08; also seen on k3).

**Root cause.** `packages/ai/src/api/anthropic-messages.ts` `buildParams()` degraded thinking to `{type: "disabled"}` whenever the final assistant turn started with `tool_use` and no thinking block. With adaptive thinking the model routinely answers a trivial tool call without thinking, so this fired on the continuation of nearly every tool-using turn. Anthropic keys the prompt cache on the thinking parameters, so that continuation missed the entire cached prefix and re-wrote it: in a vanilla omo-native beta.49 capture through a logging proxy (claude-opus-5, effort high) the turn's first call read `cache_read_input_tokens 28114`, its tool continuation read `0` and wrote `cache_creation_input_tokens 28239`, and the next turn read `28181` from the adaptive line again. Every tool turn paid a full cache write - and users on a 5h subscription limit burned through it.

The guard's premise no longer holds for the models that matter: replaying that exact continuation with `thinking` left adaptive returned HTTP 200 on claude-opus-5, claude-opus-4-6 and claude-fable-5, and 200 on claude-sonnet-4-5 under `enabled` (budget) thinking.

## Change

- The degrade now fires only for a budget-thinking request (`thinking.type: "enabled"`) whose final assistant turn came from a different wire API (`finalAssistantTurnIsForeign`) - the Kimi/OpenAI replay shape the guard was written for. Adaptive requests, and native turns under budget thinking, keep the caller's `thinking` and `output_config.effort`.
- `test/anthropic-cross-model-history.test.ts`: the Fable case flips from `effort: low` to adaptive/high; two native-turn cases added (adaptive opus-5, budget sonnet-4-5).
- Trackers: `packages/ai/src/changes.md`, `packages/ai/CHANGELOG.md` [Unreleased].

## Evidence

- RED (mengmotaMac, vitest): 3 failed / 4 passed - the new cases fail on main. GREEN: anthropic-cross-model-history + anthropic-thinking-disable + anthropic-force-adaptive-thinking + anthropic-provider-native-replay: 54 passed, 1 skipped (pre-existing).
- Live re-capture through the fixed engine (same omo plugin, same prompts): the tool continuation keeps `thinking: adaptive` and reads `cache_read 28192 / cache_creation 96` (was `0 / 28239`); every later turn reads 28288, 28345.
- `bun run check` and changelog gate results in the follow-up comment.

Refs: omo Discord report (heraldofshiza / samaronejr), senpi#1504 (k3 shows the same pattern under forceAdaptiveThinking).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic prompt-cache misses on every tool continuation by keeping `thinking`/`output_config` stable for adaptive-thinking requests. Previously `buildParams()` degraded thinking to `disabled` whenever the final assistant turn started with `tool_use` and had no thinking block, which re-keyed the prompt cache and re-wrote the full cached prefix on every tool turn. The degrade now fires only for a budget-thinking request replaying a foreign tool turn.

- Adds `finalAssistantTurnIsForeign` to detect replays from other wire APIs.
- Updates the Fable test expectation from `effort: low` to adaptive/high and adds native-turn cases.

<sup>Written for commit c8fc6999b674ac3b4c70a270b8b5022c07efa217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

