### PR TITLE
feat(coding-agent): add read classifiers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Added
 
+- Extensions can register compact read classifiers with `pi.registerReadClassifier()` or the public `registerReadClassifier()` export. Memory reads show a stable `✦ <headline> <label>` line with the existing expand hint; `SKILL.md` keeps precedence. Registrations return an unregister function, and the extension API also cleans them up on failed loads and runtime invalidation.
+
 - `compaction.summarizationMaxDurationMs` (settings) replaces the size-adaptive summarization wall-clock budget with a fixed one when set; positive finite values only, clamped to the 30-minute ceiling ([#1501](https://github.com/code-yeongyu/senpi/pull/1501)).
 
 ### Changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-09 - Export the compact read classifier API
+
+### What changed
+
+- `packages/coding-agent/src/index.ts`: re-exports `CompactReadClassification`, `ReadClassifier`, `registerReadClassifier`, and `classifyRead` from the shared read-classifier module alongside the core tool exports.
+
+### Why
+
+- `packages/coding-agent/src/index.ts` makes the classifier contract available to extensions and SDK consumers through the public package entry point, sharing the same registry used by the read renderer.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/index.ts` is the package's public export surface. An extension cannot expose host-owned types and functions from that entry point without a core export change.
+
+### Expected merge conflict zones
+
+- LOW: the core tool export block in `packages/coding-agent/src/index.ts`, immediately after the exports from `core/tools/index.ts`.
+
 ## 2026-09-08 - Construct shared RPC runtimes inside session workers
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,27 @@
 # Core Extensions Changes
 
+## 2026-09-09 - Register compact read classifiers through the extension API
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/types.ts`: adds `ExtensionAPI.registerReadClassifier(classifier): () => void`, using the shared `ReadClassifier` type.
+- `packages/coding-agent/src/core/extensions/loader.ts`: registers classifiers in the shared read registry and returns a tracked unregister function. Failed factory loads and runtime invalidation remove their registrations; stale APIs cannot register new classifiers.
+
+### Why
+
+- `packages/coding-agent/src/core/extensions/types.ts` gives extensions a typed way to classify memory paths without replacing the built-in read tool.
+- `packages/coding-agent/src/core/extensions/loader.ts` connects that API to the renderer's registry while preserving the existing failed-load and reload cleanup lifecycle.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/extensions/types.ts` defines the host-provided API; extensions cannot add methods to that public contract themselves.
+- `packages/coding-agent/src/core/extensions/loader.ts` owns API construction and runtime cleanup, so it must wire registrations into the shared registry and remove them when their owner becomes inactive.
+
+### Expected merge conflict zones
+
+- LOW: the `ReadClassifier` import and the rendering-registration methods next to `registerEntryRenderer` in `packages/coding-agent/src/core/extensions/types.ts`.
+- LOW: the registry import and `createExtensionAPI` registration block in `packages/coding-agent/src/core/extensions/loader.ts`.
+
 ## 2026-09-08 - Runner fallback for the goal backstop setting follows the 270s default
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -33,6 +33,7 @@ import { execCommand } from "../exec.ts";
 import { readPiManifest } from "../pi-manifest.ts";
 import { createSyntheticSourceInfo } from "../source-info.ts";
 import { time } from "../timings.ts";
+import { type ReadClassifier, registerReadClassifier } from "../tools/read-classifiers.ts";
 import { validateMcpServerDeclaration } from "./builtin/mcp/config-schema.ts";
 import type {
 	EntryRenderer,
@@ -486,6 +487,13 @@ function createExtensionAPI(
 			assertActive();
 			extension.entryRenderers ??= new Map();
 			extension.entryRenderers.set(customType, renderer as EntryRenderer);
+		},
+
+		registerReadClassifier(classifier: ReadClassifier): () => void {
+			assertActive();
+			const unregister = runtime.trackEventBusSubscription(registerReadClassifier(classifier));
+			if (state === "loading") loadingUnsubscribers.push(unregister);
+			return unregister;
 		},
 
 		registerMcpServer(name: string, config: RegisteredMcpServerDeclaration["config"]): void {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -87,6 +87,7 @@ import type {
 	ReadToolInput,
 	WriteToolInput,
 } from "../tools/index.ts";
+import type { ReadClassifier } from "../tools/read-classifiers.ts";
 import type { McpServerDeclaration } from "./builtin/mcp/config-schema.ts";
 
 export type { ExecOptions, ExecResult } from "../exec.ts";
@@ -1779,6 +1780,9 @@ export interface ExtensionAPI {
 
 	/** Register a custom renderer for CustomEntry. Custom entries do not participate in LLM context. */
 	registerEntryRenderer<T = unknown>(customType: string, renderer: EntryRenderer<T>): void;
+
+	/** Register a compact read classifier; removed on unregister, failed load, or runtime invalidation. */
+	registerReadClassifier(classifier: ReadClassifier): () => void;
 
 	// =========================================================================
 	// Actions

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -1,5 +1,26 @@
 # core/tools changes
 
+## Compact memory read classifications with stable headlines (2026-09-09)
+
+### What changed
+
+- `packages/coding-agent/src/core/tools/read.ts`: consults registered classifiers after the SKILL.md check and before pi docs and AGENTS/CLAUDE resource classification. Memory reads render an accent headline and label with the existing line range and expand hint; docs/resource/skill formatting is unchanged.
+- `packages/coding-agent/src/core/tools/read.ts`: caches classifications, including unclaimed paths, by raw path in each tool call's renderer state so redraws and expand/collapse do not choose another headline.
+- `packages/coding-agent/src/core/tools/read-classifiers.ts` (new, fork-only): defines the shared classification types and a first-claim registry with idempotent unregister functions. Throwing classifiers are reported and skipped.
+
+### Why
+
+- `packages/coding-agent/src/core/tools/read.ts` needs to recognize extension-owned memory paths without hardcoding memory storage layouts, while keeping SKILL.md precedence and stable transcript headlines.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/tools/read.ts` owns built-in compact classification and per-call rendering state. An extension could replace the whole read renderer, but could not previously contribute a classification while retaining the host's existing formats and expansion behavior.
+
+### Expected merge conflict zones
+
+- MEDIUM: imports, `ReadRenderState`, `getCompactReadClassification`, `formatCompactReadCall`, and `createReadToolDefinition` in `packages/coding-agent/src/core/tools/read.ts`. Preserve classifier priority and per-call memoization when taking upstream renderer changes.
+- LOW: `packages/coding-agent/src/core/tools/read-classifiers.ts` is a new fork-only module.
+
 ## Canonical identity is resolved, not guessed (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/read-classifiers.ts
+++ b/packages/coding-agent/src/core/tools/read-classifiers.ts
@@ -1,0 +1,35 @@
+export interface CompactReadClassification {
+	readonly kind: "docs" | "resource" | "skill" | "memory";
+	readonly label: string;
+	readonly headline?: string;
+}
+
+export type ReadClassifier = (input: {
+	readonly absolutePath: string;
+	readonly cwd: string;
+}) => CompactReadClassification | undefined;
+
+const classifiers: Array<{ classifier: ReadClassifier }> = [];
+
+/** Register a compact read classifier. The returned function removes this registration. */
+export function registerReadClassifier(classifier: ReadClassifier): () => void {
+	const entry = { classifier };
+	classifiers.push(entry);
+	return () => {
+		const index = classifiers.indexOf(entry);
+		if (index !== -1) classifiers.splice(index, 1);
+	};
+}
+
+/** First registered classifier to claim a path wins; a failed classifier cannot block later ones. */
+export function classifyRead(input: { absolutePath: string; cwd: string }): CompactReadClassification | undefined {
+	for (const { classifier } of classifiers) {
+		try {
+			const classification = classifier(input);
+			if (classification !== undefined) return classification;
+		} catch (error) {
+			console.warn("Read classifier failed:", error);
+		}
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -20,6 +20,7 @@ import type {
 } from "../extensions/types.ts";
 import { canonicalizeFilesystemPath } from "./filesystem-policy.ts";
 import { resolveReadPathAsync, resolveToCwd } from "./path-utils.ts";
+import { type CompactReadClassification, classifyRead } from "./read-classifiers.ts";
 import { getTextOutput, renderToolPath, replaceTabs, str } from "./render-utils.ts";
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.ts";
@@ -41,9 +42,8 @@ export interface ReadToolDetails {
 	truncation?: TruncationResult;
 }
 
-interface CompactReadClassification {
-	kind: "docs" | "resource" | "skill";
-	label: string;
+interface ReadRenderState {
+	classifications?: Map<string | null, CompactReadClassification | undefined>;
 }
 
 const COMPACT_RESOURCE_FILE_NAMES = new Set(["AGENTS.override.md", "AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]);
@@ -144,6 +144,9 @@ function getCompactReadClassification(
 		return { kind: "skill", label: basename(dirname(absolutePath)) || fileName };
 	}
 
+	const registeredClassification = classifyRead({ absolutePath, cwd });
+	if (registeredClassification) return registeredClassification;
+
 	const docsClassification = getPiDocsClassification(absolutePath);
 	if (docsClassification) return docsClassification;
 
@@ -163,6 +166,16 @@ function formatCompactReadCall(
 	if (classification.kind === "skill") {
 		return (
 			theme.fg("customMessageLabel", `\x1b[1m[skill]\x1b[22m `) +
+			theme.fg("customMessageText", classification.label) +
+			formatReadLineRange(args, theme) +
+			expandHint
+		);
+	}
+
+	if (classification.kind === "memory") {
+		return (
+			theme.fg("accent", `\x1b[1m✦ ${classification.headline ?? "Recalled"}\x1b[22m`) +
+			" " +
 			theme.fg("customMessageText", classification.label) +
 			formatReadLineRange(args, theme) +
 			expandHint
@@ -220,7 +233,7 @@ function formatReadResult(
 export function createReadToolDefinition(
 	cwd: string,
 	options?: ReadToolOptions,
-): ToolDefinition<typeof readSchema, ReadToolDetails | undefined> {
+): ToolDefinition<typeof readSchema, ReadToolDetails | undefined, ReadRenderState> {
 	const autoResizeImages = options?.autoResizeImages ?? true;
 	const ops = options?.operations ?? defaultReadOperations;
 	const filesystemPolicy = options?.filesystemPolicy;
@@ -357,9 +370,18 @@ export function createReadToolDefinition(
 				},
 			);
 		},
-		renderCall(args, theme, context) {
+		renderCall(args: ReadRenderArgs, theme, context) {
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			const classification = !context.expanded ? getCompactReadClassification(args, context.cwd) : undefined;
+			let classification: CompactReadClassification | undefined;
+			if (!context.expanded) {
+				const rawPath = str(args?.file_path ?? args?.path);
+				context.state.classifications ??= new Map();
+				const classifications = context.state.classifications;
+				if (!classifications.has(rawPath)) {
+					classifications.set(rawPath, getCompactReadClassification(args, context.cwd));
+				}
+				classification = classifications.get(rawPath);
+			}
 			text.setText(
 				classification
 					? formatCompactReadCall(classification, args, theme)

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -347,6 +347,12 @@ export {
 	withFileMutationQueue,
 } from "./core/tools/index.ts";
 export {
+	type CompactReadClassification,
+	classifyRead,
+	type ReadClassifier,
+	registerReadClassifier,
+} from "./core/tools/read-classifiers.ts";
+export {
 	hasTrustRequiringProjectResources,
 	type ProjectTrustDecision,
 	ProjectTrustStore,

--- a/packages/coding-agent/test/suite/read-classifiers.test.ts
+++ b/packages/coding-agent/test/suite/read-classifiers.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
+import { classifyRead, type ReadClassifier, registerReadClassifier } from "../../src/core/tools/read-classifiers.ts";
+import {
+	classifyRead as publicClassifyRead,
+	registerReadClassifier as publicRegisterReadClassifier,
+} from "../../src/index.ts";
+
+const input = { absolutePath: "/project/memory/preference.md", cwd: "/project" };
+const memory = { kind: "memory" as const, label: "preference", headline: "Remembered" };
+const unregisters: Array<() => void> = [];
+
+function register(classifier: ReadClassifier): () => void {
+	const unregister = registerReadClassifier(classifier);
+	unregisters.push(unregister);
+	return unregister;
+}
+
+afterEach(() => {
+	for (const unregister of unregisters.splice(0)) unregister();
+});
+
+describe("read classifiers", () => {
+	test("public exports share the core registry", () => {
+		expect(publicRegisterReadClassifier).toBe(registerReadClassifier);
+		expect(publicClassifyRead).toBe(classifyRead);
+	});
+
+	test("returns undefined when nothing claims the path", () => {
+		expect(classifyRead(input)).toBeUndefined();
+		register(() => undefined);
+		expect(classifyRead(input)).toBeUndefined();
+	});
+
+	test("passes the input through and stops at the first result", () => {
+		const decline = vi.fn(() => undefined);
+		const claim = vi.fn(() => memory);
+		const later = vi.fn(() => ({ kind: "docs" as const, label: "later" }));
+		register(decline);
+		register(claim);
+		register(later);
+		expect(classifyRead(input)).toEqual(memory);
+		expect(decline).toHaveBeenCalledExactlyOnceWith(input);
+		expect(claim).toHaveBeenCalledExactlyOnceWith(input);
+		expect(later).not.toHaveBeenCalled();
+	});
+
+	test("unregister removes only its own registration and is idempotent", () => {
+		const classifier = () => memory;
+		const first = register(classifier);
+		register(() => undefined);
+		const duplicate = register(classifier);
+		first();
+		first();
+		expect(classifyRead(input)).toEqual(memory);
+		duplicate();
+		expect(classifyRead(input)).toBeUndefined();
+	});
+
+	test("skips a throwing classifier", () => {
+		register(() => {
+			throw new Error("classifier failed");
+		});
+		expect(classifyRead(input)).toBeUndefined();
+		register(() => memory);
+		expect(classifyRead(input)).toEqual(memory);
+	});
+});
+
+describe("extension read classifier registration", () => {
+	test("registers during factory loading and removes classifiers on runtime invalidation", async () => {
+		const runtime = createExtensionRuntime();
+		try {
+			await loadExtensionFromFactory(
+				(pi) => {
+					unregisters.push(pi.registerReadClassifier(() => memory));
+				},
+				input.cwd,
+				createEventBus(),
+				runtime,
+			);
+			expect(classifyRead(input)).toEqual(memory);
+			runtime.invalidate();
+			expect(classifyRead(input)).toBeUndefined();
+		} finally {
+			runtime.invalidate();
+		}
+	});
+
+	test("discards registrations when a factory fails and rejects its stale API", async () => {
+		const runtime = createExtensionRuntime();
+		let api: ExtensionAPI | undefined;
+		try {
+			await expect(
+				loadExtensionFromFactory(
+					(pi) => {
+						api = pi;
+						unregisters.push(pi.registerReadClassifier(() => memory));
+						throw new Error("factory failed");
+					},
+					input.cwd,
+					createEventBus(),
+					runtime,
+				),
+			).rejects.toThrow("factory failed");
+			expect(classifyRead(input)).toBeUndefined();
+			expect(() => api?.registerReadClassifier(() => memory)).toThrow();
+		} finally {
+			runtime.invalidate();
+		}
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -3,12 +3,16 @@ import { Container, Text, type TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getReadmePath } from "../src/config.ts";
+import { createEventBus } from "../src/core/event-bus.ts";
 import { registerTodoTool, type TODO_PARAMS_SCHEMA } from "../src/core/extensions/builtin/todotools/tools/todo.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.ts";
 import type { ExtensionAPI, ToolDefinition } from "../src/core/extensions/types.ts";
 import { type BashOperations, createBashToolDefinition } from "../src/core/tools/bash.ts";
 import { renderToolDiff } from "../src/core/tools/diff-render.ts";
 import { createReadTool, createReadToolDefinition } from "../src/core/tools/read.ts";
+import type { ReadClassifier } from "../src/core/tools/read-classifiers.ts";
 import { createWriteToolDefinition } from "../src/core/tools/write.ts";
+import { keyText } from "../src/modes/interactive/components/keybinding-hints.ts";
 import {
 	TODO_STRIKE_FRAME_INTERVAL_MS,
 	TODO_STRIKE_TOTAL_FRAMES,
@@ -29,6 +33,21 @@ function createBaseToolDefinition(name = "custom_tool"): ToolDefinition {
 			details: {},
 		}),
 	};
+}
+
+async function registerReadClassifierThroughExtension(classifier: ReadClassifier): Promise<() => void> {
+	let api: ExtensionAPI | undefined;
+	await loadExtensionFromFactory(
+		(pi) => {
+			api = pi;
+		},
+		process.cwd(),
+		createEventBus(),
+		createExtensionRuntime(),
+	);
+	if (!api) throw new Error("Expected extension API");
+	expect(api.registerReadClassifier).toBeTypeOf("function");
+	return api.registerReadClassifier(classifier);
 }
 
 function createFakeTui(): TUI {
@@ -262,10 +281,7 @@ describe("ToolExecutionComponent parity", () => {
 	test("bash execute emits an initial empty partial update before output arrives", async () => {
 		const updates: Array<{ content: Array<{ type: string; text?: string }>; details?: unknown }> = [];
 		const operations: BashOperations = {
-			exec: async () => {
-				await new Promise((resolve) => setTimeout(resolve, 10));
-				return { exitCode: 0 };
-			},
+			exec: async () => ({ exitCode: 0 }),
 		};
 		const tool = createBashToolDefinition(process.cwd(), { operations, exposeSessionEnvironment: false });
 		const promise = tool.execute(
@@ -781,6 +797,132 @@ describe("ToolExecutionComponent parity", () => {
 			expect(collapsed.indexOf(":120-329")).toBeLessThan(collapsed.indexOf("to expand"));
 		});
 	}
+
+	for (const headline of ["Remembered", undefined]) {
+		test(`renders classified memory reads with ${headline ?? "the default headline"}`, async () => {
+			const args = { path: "memory/preference.md", offset: 2, limit: 3 };
+			const classifier = vi.fn(() => ({ kind: "memory" as const, label: "preference", headline }));
+			const unregister = await registerReadClassifierThroughExtension(classifier);
+			try {
+				const component = new ToolExecutionComponent(
+					"read",
+					"tool-memory-read",
+					args,
+					{},
+					createReadToolDefinition(process.cwd()),
+					createFakeTui(),
+					process.cwd(),
+				);
+				component.updateResult(
+					{ content: [{ type: "text", text: "hidden memory" }], details: undefined, isError: false },
+					false,
+				);
+				const collapsed = component.render(120).join("\n");
+				expect(stripAnsi(collapsed)).toContain(
+					`✦ ${headline ?? "Recalled"} preference:2-4 (${keyText("app.tools.expand")} to expand)`,
+				);
+				expect(collapsed).toContain(theme.fg("accent", `\x1b[1m✦ ${headline ?? "Recalled"}\x1b[22m`));
+				expect(collapsed).toContain(theme.fg("customMessageText", "preference"));
+				expect(stripAnsi(collapsed)).not.toContain("hidden memory");
+				expect(classifier).toHaveBeenCalledExactlyOnceWith({
+					absolutePath: resolve(process.cwd(), args.path),
+					cwd: process.cwd(),
+				});
+
+				component.setExpanded(true);
+				const expanded = stripAnsi(component.render(120).join("\n"));
+				expect(expanded).toContain("memory/preference.md:2-4");
+				expect(expanded).toContain("hidden memory");
+				expect(expanded).not.toContain("✦");
+				component.setExpanded(false);
+				expect(component.render(120).join("\n")).toBe(collapsed);
+				expect(classifier).toHaveBeenCalledTimes(1);
+			} finally {
+				unregister();
+			}
+		});
+	}
+
+	test("keeps SKILL.md ahead of registered read classifiers", async () => {
+		const classifier = vi.fn(() => ({ kind: "memory" as const, label: "not a skill" }));
+		const unregister = await registerReadClassifierThroughExtension(classifier);
+		try {
+			const component = new ToolExecutionComponent(
+				"read",
+				"tool-memory-skill-precedence",
+				{ path: join(process.cwd(), "attio", "SKILL.md") },
+				{},
+				createReadToolDefinition(process.cwd()),
+				createFakeTui(),
+				process.cwd(),
+			);
+			expect(stripAnsi(component.render(120).join("\n"))).toContain("[skill] attio");
+			expect(classifier).not.toHaveBeenCalled();
+		} finally {
+			unregister();
+		}
+	});
+
+	for (const path of [getReadmePath(), join(process.cwd(), "AGENTS.md")]) {
+		test(`registered read classifiers take precedence over built-in classification for ${path}`, async () => {
+			const unregister = await registerReadClassifierThroughExtension(() => ({ kind: "memory", label: "claimed" }));
+			try {
+				const component = new ToolExecutionComponent(
+					"read",
+					"tool-memory-builtin-precedence",
+					{ path },
+					{},
+					createReadToolDefinition(process.cwd()),
+					createFakeTui(),
+					process.cwd(),
+				);
+				expect(stripAnsi(component.render(120).join("\n"))).toContain("✦ Recalled claimed");
+			} finally {
+				unregister();
+			}
+		});
+	}
+
+	test("memoizes read classification by raw path in shared renderCall state", async () => {
+		let calls = 0;
+		const classifier = vi.fn(() => ({ kind: "memory" as const, label: "preference", headline: `Recall ${++calls}` }));
+		const unregister = await registerReadClassifierThroughExtension(classifier);
+		try {
+			const args = { path: "memory/preference.md" };
+			const tool = createReadToolDefinition(process.cwd());
+			const context: Parameters<NonNullable<typeof tool.renderCall>>[2] = {
+				args,
+				toolCallId: "tool-stable-memory",
+				invalidate: () => {},
+				lastComponent: undefined,
+				state: {},
+				cwd: process.cwd(),
+				executionStarted: false,
+				argsComplete: true,
+				isPartial: false,
+				expanded: false,
+				showImages: false,
+				isError: false,
+			};
+			const first = tool.renderCall!(args, theme, context).render(120).join("\n");
+			const second = tool.renderCall!(args, theme, { ...context })
+				.render(120)
+				.join("\n");
+			expect(second).toBe(first);
+			expect(stripAnsi(first)).toContain("✦ Recall 1 preference");
+			expect(classifier).toHaveBeenCalledTimes(1);
+
+			const otherArgs = { path: "memory/other.md" };
+			const other = tool.renderCall!(otherArgs, theme, { ...context, args: otherArgs })
+				.render(120)
+				.join("\n");
+			expect(stripAnsi(other)).toContain("✦ Recall 2 preference");
+			expect(tool.renderCall!(args, theme, context).render(120).join("\n")).toBe(first);
+			expect(classifier).toHaveBeenCalledTimes(2);
+		} finally {
+			unregister();
+		}
+	});
 
 	test("animates completed todo tasks through the strike reveal and settles", () => {
 		vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- Add the public `CompactReadClassification`, `ReadClassifier`, `registerReadClassifier`, and `classifyRead` API, plus `ExtensionAPI.registerReadClassifier`.
- Preserve classification priority: SKILL.md, registered classifiers, pi docs, AGENTS/CLAUDE resources. First registered claim wins; throwing classifiers are reported and skipped. Unregister is idempotent and removes only its registration.
- Render memory reads as `✦ <headline> <label>` with line range and the existing expand hint. Cache classifications by raw path in each tool call's renderer state so redraws and expand/collapse do not pick another headline.
- Reuse loader cleanup for failed factories and runtime invalidation. Add an `[Unreleased]` changelog entry.

A shared registry with renderer-state caching was chosen over replacing the read renderer: extensions only classify paths, while the existing docs/resource/skill render branches remain unchanged.

## Test-first evidence

All tests ran remotely on **gorky (Linux x86_64)** through bunshin. No local test runner was used. The remote scratch used Bun 1.4.0 because the host's Bun 1.3.14 cannot parse this checkout's lockfile version. The host installation was not changed.

**RED, before production edits**

`CI=1 bun run --cwd packages/coding-agent test test/tool-execution-component.test.ts`

```text
AssertionError: expected undefined to be type of 'function'
Expected: "function"
Received: "undefined"
expect(api.registerReadClassifier).toBeTypeOf("function");

Test Files  1 failed (1)
     Tests  6 failed | 41 passed (47)
```

**GREEN, one run**

`CI=1 bun run --cwd packages/coding-agent test test/tool-execution-component.test.ts test/suite/read-classifiers.test.ts test/extensions-loader.test.ts test/read-tool-local-uri.test.ts`

```text
Test Files  4 passed (4)
     Tests  67 passed (67)
```

Coverage includes custom/default memory headlines, styling and expand hint, SKILL.md priority, docs/resource override priority, same-state headline stability, duplicate/idempotent unregister, throwing classifier fallback, public export identity, failed factory cleanup, and runtime invalidation. The existing test file's fixed sleep was removed in favor of a deterministic immediate async result.

## Verification

- Local `bunx tsgo --noEmit -p tsconfig.json`: exit 0 (source and tests).
- Local `bunx tsgo --noEmit -p packages/coding-agent/tsconfig.build.json`: exit 0.
- Biome check of all seven changed TypeScript files: exit 0, no fixes needed. There is no package lint script.
- Coding-agent declaration/JavaScript build with `tsgo` and `copy-assets`, after building its workspace dependencies: exit 0.
- Remote CLI `--help`: exit 0.
- Manual real-file read through `ToolExecutionComponent`: collapsed and re-collapsed rows both showed `✦ Recall 1 Workspace preferences:2-3 (ctrl+o to expand)`; expanded view showed the file contents; classifier call count was 1.
- LSP diagnostics were requested for every changed TypeScript file. Final requests for the public barrel and registry test timed out; the full source-and-test typecheck passed.
- `git diff --check`: clean.

## Changelog gate: resolved

The scope amendment authorized the required `changes.md` trackers. Follow-up commit `a3b321da3e183acf7c6c2aae1095a7eaea17dfe1` adds all four canonical sections for the four modified upstream-owned source paths in their nearest trackers:

- `packages/coding-agent/src/core/extensions/changes.md`
- `packages/coding-agent/src/core/tools/changes.md`
- `packages/coding-agent/src/changes.md`

`CHANGELOG_GATE_BASE=096615afeb833c5aaff538c6d41f61aafc579e9f bun scripts/check-pr-changelog.mjs` exits 0:

```text
changelog-gate: PASS - changes.md coverage complete (4 production path(s) covered); changelog entry updated (packages/coding-agent/CHANGELOG.md)
```

The follow-up changes only these three Markdown trackers; no additional runtime edits or test runs were needed. No omo files, dependencies, or lockfiles were changed. This PR is intentionally left open and unmerged as requested.

The original linked worktree's mounted Git metadata became inaccessible (`Operation not permitted`), so this follow-up was committed and validated in a separate local clone of the same PR branch at `/Users/yeongyu/tmp/senpi-wt/read-classifier-trackers`. The original worktree remains untouched after that failure.

## Cleanup and receipts

Remote receipt:

```json
{"host":"gorky","directory":"/tmp/memrecall-n2-20260909","removed":true,"taskPids":[],"checked":"/proc cmdline and cwd","at":"2026-09-09T02:27:39.335Z"}
```

Local evidence: `/tmp/memrecall-n2-evidence-20260909/` (`red.txt`, `green.txt`, `typecheck.log`, `package-typecheck.log`, `biome.log`, build logs, `manual-render.log`, `cli-help.log`, `changelog-gate.log`, `changelog-gate-followup.log`, `tracker-followup.diff`, `cleanup.json`, and `staged.diff`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public read classification API so extensions can assign compact labels to memory reads, rendering them as `✦ <headline> <label>` with the existing expand hint.

**Behavior**

- Classification priority is `SKILL.md`, registered classifiers, pi docs, `AGENTS`/`CLAUDE` resources; first claim wins and throwing classifiers are skipped.
- Classifications are memoized per raw path in each tool call's render state so redraws keep the same headline.
- `registerReadClassifier` returns an idempotent unregister function; registrations are cleaned up on failed loads and runtime invalidation.
- Changelog gate is covered by the `[Unreleased]` entry and `changes.md` trackers for the modified source paths.

<sup>Written for commit a3b321da3e183acf7c6c2aae1095a7eaea17dfe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

