### PR TITLE
fix(test): stabilize model catalog and RPC reservation coverage

### DIFF
--- a/packages/ai/test/gpt-6-astra-context-window.test.ts
+++ b/packages/ai/test/gpt-6-astra-context-window.test.ts
@@ -53,6 +53,7 @@ describe("GPT-6 Astra series catalog context window", () => {
 	it("keeps every provider catalog that ships Astra covered", () => {
 		const files = [...new Set(collectAstraEntries().map((entry) => entry.file))].sort();
 		expect(files).toEqual([
+			"amazon-bedrock.json",
 			"azure-openai-responses.json",
 			"github-copilot.json",
 			"openai-codex.json",

--- a/packages/coding-agent/test/suite/rpc-worker-reservation-support.ts
+++ b/packages/coding-agent/test/suite/rpc-worker-reservation-support.ts
@@ -26,12 +26,19 @@ export async function reservationPhase<T>(name: string, signal: Promise<T>): Pro
 }
 
 /** Real workers and production routing; only the observation sink is in memory. */
-export function reservationHost(cwd: string, agentDir: string) {
+export function reservationHost(cwd: string, agentDir: string, extension?: string) {
 	const records: unknown[] = [];
 	const writer = new SessionEventWriter(() => {});
 	const registry = new WorkerSessionRegistry({
 		configuration: {
-			parsed: parseArgs(["--mode", "rpc", "--no-extensions", "--no-skills", "--no-context-files"]),
+			parsed: parseArgs([
+				"--mode",
+				"rpc",
+				"--no-extensions",
+				"--no-skills",
+				"--no-context-files",
+				...(extension ? ["--extension", extension] : []),
+			]),
 			cwd,
 			agentDir,
 			appMode: "rpc",

--- a/packages/coding-agent/test/suite/rpc-worker-reservations.test.ts
+++ b/packages/coding-agent/test/suite/rpc-worker-reservations.test.ts
@@ -15,16 +15,30 @@ it.each(["close", "deadline"])(
 		const agentDir = join(scratch, "agent");
 		await mkdir(cwd);
 		await mkdir(agentDir);
-		const fifo = join(scratch, "blocked.jsonl");
+		const sessionFile = join(scratch, "blocked.jsonl");
+		const fifo = join(scratch, "native-gate");
+		const armed = join(scratch, "block-next-open");
+		const extension = join(scratch, "native-gate.mjs");
 		const alias = join(scratch, "alias.jsonl");
 		const siblingFile = join(scratch, "sibling.jsonl");
 		const header = (id: string) =>
 			`${JSON.stringify({ type: "session", version: 3, id, timestamp: new Date(0).toISOString(), cwd })}\n`;
-		await symlink(fifo, alias);
+		await writeFile(sessionFile, header("blocked-durable"));
+		await symlink(sessionFile, alias);
 		await writeFile(siblingFile, header("sibling-durable"));
+		await writeFile(
+			extension,
+			`import { execFileSync } from "node:child_process";
+import { existsSync, unlinkSync } from "node:fs";
+export default function () {
+	if (!existsSync(${JSON.stringify(armed)})) return;
+	unlinkSync(${JSON.stringify(armed)});
+	execFileSync(process.execPath, ["-e", "require('node:fs').readFileSync(process.argv[1])", ${JSON.stringify(fifo)}], { stdio: "ignore" });
+}`,
+		);
 		vi.stubEnv("PATH", "/usr/bin:/bin");
 		vi.stubEnv("SENPI_OFFLINE", "1");
-		const host = reservationHost(cwd, agentDir);
+		const host = reservationHost(cwd, agentDir, extension);
 		const epochs = [host];
 		host.connect("sibling");
 		host.connect("control");
@@ -35,7 +49,8 @@ it.each(["close", "deadline"])(
 			for (let round = 0; round < 3; round++) {
 				if (round > 0) await unlink(fifo);
 				execFileSync("mkfifo", [fifo]);
-				const canonical = await realpath(fifo);
+				await writeFile(armed, "");
+				const canonical = await realpath(sessionFile);
 				const durable = `retry-${action}-${round}`;
 				let gate: Awaited<ReturnType<typeof open>> | undefined;
 				let releasing: Promise<void> | undefined;
@@ -47,6 +62,7 @@ it.each(["close", "deadline"])(
 						try {
 							await unlink(fifo);
 							await writeFile(fifo, header(durable));
+							await writeFile(sessionFile, header(durable));
 							await rescue.write(header(durable));
 						} finally {
 							await Promise.all([gate?.close(), rescue.close()]);
@@ -56,8 +72,13 @@ it.each(["close", "deadline"])(
 				const oldPeer = `opening-${round}`;
 				host.connect(oldPeer);
 				if (action === "deadline") vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
-				const opening = host.send(oldPeer, { id: oldPeer, type: "open_session", cwd, sessionPath: fifo });
-				gate = await waitForFifoReader(fifo);
+				// A worker's own FIFO open is not a stable native gate: writer-open
+				// releases open(2), so termination can win before read(2). Here the
+				// child's FIFO entry proves the worker is already in execFileSync;
+				// it cannot leave that native call until we release the child.
+				const reader = waitForFifoReader(fifo);
+				const opening = host.send(oldPeer, { id: oldPeer, type: "open_session", cwd, sessionPath: sessionFile });
+				gate = await reader;
 				const handle = host.registry.list().find((entry) => entry.sessionPath === canonical)?.sessionId;
 				if (!handle) throw new Error("Blocked worker is missing");
 				firstHandle ??= handle;
@@ -88,7 +109,9 @@ it.each(["close", "deadline"])(
 				const allocated = host.workers.size;
 				for (let attempt = 0; attempt < 4; attempt++) {
 					await phase("repeat-cancel", host.registry.close(handle));
-					expect(await host.send("control", { type: "open_session", cwd, sessionPath: fifo })).toMatchObject({
+					expect(
+						await host.send("control", { type: "open_session", cwd, sessionPath: sessionFile }),
+					).toMatchObject({
 						success: false,
 						error: expect.stringContaining("session_path_in_use"),
 					});
@@ -178,7 +201,7 @@ it.each(["close", "deadline"])(
 			epochs.push(next);
 			next.connect("replacement-0");
 			next.connect("epoch-survivor");
-			await next.send("replacement-0", { type: "open_session", cwd, sessionPath: fifo });
+			await next.send("replacement-0", { type: "open_session", cwd, sessionPath: sessionFile });
 			const replacement = next.registry.list()[0];
 			expect(replacement.sessionId).toBe(firstHandle);
 			await next.send("epoch-survivor", { type: "open_session", cwd, sessionPath: replacement.sessionPath });


### PR DESCRIPTION
## Summary
Fix the two regressions reported by the main CI aggregate.

## Root cause
- Run `34304791869` failed the Astra catalog enumeration after release commit `79c18f6cc` regenerated `amazon-bedrock.json` with intentional GPT-6 Astra entries. The generator's models.dev Bedrock path emits tool-capable Bedrock models, and the common Astra metadata pass sets their context window to 600,000.
- The reservation failure from test commit `feb6f9d66` was a test race, not a reservation defect. Its FIFO writer-open observation only proved that the worker entered `open(2)`; it did not prove the worker had reached the blocking `read(2)`. Under the fake deadline clock, the old worker could exit and release its reservation while the alias challenger was still starting.

## Changes
- Enumerate `amazon-bedrock.json` in the sorted Astra catalog coverage expectation.
- Make the reservation fixture await a child FIFO-open signal while the real worker is inside a synchronous native call. This keeps the production reservation and quarantine implementation unchanged and preserves the late-exit ownership assertions.

## Verification
All tests were run remotely on `gorky` (Linux x86_64, 8 cores, Node `v24.20.0`) with CI-matching Bun `1.4.2` first in `PATH`. The preferred `mengmotaMac` was unavailable (`machine_unavailable`, `home_in_use`). The checkout was `/tmp/senpi-main-fix-20260909/`, installed with `npm ci --ignore-scripts`, and initially built with `npm run build` (exit 0).

### Reservation failure-rate table (B)

| Fixture | Iterations | Failures | Failure rate | Load condition |
| --- | ---: | ---: | ---: | --- |
| Original `ba397dda6` reservation test | 20 | 10 | 50% | Sequential loop on `gorky`; the host also carried unrelated existing mesh activity and the first diagnostic trace run overlapped the early iterations |
| Fixed `77e760da6` reservation test | 20 | 0 | 0% | Sequential loop concurrently with one full `npx vitest run --shard=3/3` process |

The trace captured the race directly: in the failing run, the old worker reserved at `56454.5 ms`, the alias challenger began preparing at `56456.3 ms`, the old worker exited at `56470.4 ms`, and the challenger prepared/reserved at `59013.9/59021.6 ms` and blocked until cleanup. The fixed loop passed all 20 iterations (20/20).

Remote commands and results:
- `bun run --cwd packages/ai test`: 270 files passed, 26 skipped; 2,610 tests passed, 884 skipped; exit 0.
- `bun run --cwd packages/ai test test/gpt-6-astra-context-window.test.ts test/gpt-6-astra-catalog.test.ts`: 2 files and 14 tests passed.
- `npx vitest run test/suite/rpc-worker-reservations.test.ts` in the 20-iteration fixed loop: 20 passed, 0 failed.
- `npx vitest run --shard=3/3` was attempted once under the same loaded host. It reached 415 files / 3,126 tests passed, but the host run hit `ENOSPC` in three quarantine-directory setup cases and three unrelated lifecycle/stdio assertions; this is recorded as an environment-pressure result. The GitHub CI shard passed.
- `npm run check`: exit 0.
- `npm run build`: exit 0.
- A real built CLI RPC exercise passed 6 responses covering protocol info, open, alias attach, one attachment close, survivor state, and final close.

Remote cleanup removed `/tmp/senpi-main-fix-20260909/` and verified the path was absent.

PR CI run: https://github.com/code-yeongyu/senpi/actions/runs/34307568861
- `Check and test`: pass (fan-in run https://github.com/code-yeongyu/senpi/actions/runs/34307568861/job/102329144197)
- Static checks: pass
- Test (coding-agent 1/3): pass
- Test (coding-agent 2/3): pass
- Test (coding-agent 3/3): pass
- Test (workspaces + scripts): pass
- Hooks trust storage (Windows): pass
- RPC named pipes (Windows): pass
