### PR TITLE
fix(claude-sdk-oauth): classify multi-message cold starts as bootstrap

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fresh `claude-sdk-oauth` sessions with injected context and multiple first-turn user messages now report continuity `bootstrap` instead of a false `registry_miss` loss; sessions that have a prior assistant message still flatten on a genuine registry miss.
+
 ### Removed
 
 ## [2026.9.9] - 2026-09-09

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,24 @@
 # claude-sdk-oauth
 
+## 2026-09-09 - Classify multi-message cold starts as bootstrap
+
+### What changed
+
+- `session-stream.ts`: `createResidentAttempt` now identifies a first turn by the absence of any prior assistant message in `input.context.messages`, while retaining the no-resident-entry and no-persisted-binding checks. A fresh context can therefore bootstrap even when injected context and the actual prompt produce multiple transmitted user messages; a cold start after an assistant turn remains `flatten` with `registry_miss`.
+- `claude-sdk-oauth-bootstrap-classification.test.ts` covers both observations through the resident session-stream fake SDK boundary.
+
+### Why
+
+- A multi-message first turn was incorrectly shown as `Session continuity lost - resent the full conversation (registry_miss)` even though no SDK session existed and nothing could have been lost. This was reported on Discord by samaronejr on 2026-09-09 while opening a second concurrent OmO session.
+
+### Why an extension could not handle it
+
+- The `firstTurn` predicate is private to the builtin resident admission path, before any extension-facing stream result or continuity observation is emitted.
+
+### Expected merge conflict zones
+
+- LOW: `session-stream.ts` next to the `createResidentAttempt` `firstTurn` predicate and the focused bootstrap classification test.
+
 ## 2026-09-08 - `/claude-account add` relays login prompts through the shared account-command interaction
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-stream.ts
@@ -57,6 +57,10 @@ const OBSERVED_KIND: Record<ContinuityDecision["kind"], "incremental" | "resume"
 	bootstrap: "cold-seed",
 };
 
+function contextHasPriorAssistantMessage(context: Context): boolean {
+	return context.messages.some((message) => message.role === "assistant");
+}
+
 function entrySnapshot(entry: ClaudeSdkOauthSessionEntry, hashes: readonly string[]) {
 	return {
 		sdkSessionId: entry.sdkSessionId,
@@ -95,7 +99,8 @@ async function createResidentAttempt(
 		crossAccountResumeSupported: auth.authLane !== "config-dir",
 		idleExpired: existing ? isIdleExpired(existing) : false,
 	});
-	const firstTurn = existing === undefined && getBinding(sessionId) === undefined && hashes.length <= 1;
+	const firstTurn =
+		existing === undefined && getBinding(sessionId) === undefined && !contextHasPriorAssistantMessage(input.context);
 	let observedReason =
 		"reason" in decision ? decision.reason : decision.kind === "bootstrap" ? "registry_miss" : undefined;
 	let observedKind: "incremental" | "resume" | "cold-seed" = OBSERVED_KIND[decision.kind];

--- a/packages/coding-agent/test/claude-sdk-oauth-bootstrap-classification.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-bootstrap-classification.test.ts
@@ -1,0 +1,186 @@
+import type { Api, AssistantMessage, Context, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	overrideSdkBoundary,
+	resetSdkBoundary,
+	type SDKMessage,
+	type SDKUserMessage,
+	type SdkQuery,
+	type SdkQueryHandle,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import type { ContinuityObservation } from "../src/core/extensions/builtin/claude-sdk-oauth/session-observability.ts";
+import {
+	overrideContinuityObservabilityBoundary,
+	resetContinuityObservabilityBoundary,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-observability.ts";
+import {
+	closeSession,
+	overrideSessionRegistryBoundary,
+	resetSessionRegistryBoundary,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts";
+import { streamClaudeSdkOauth } from "../src/core/extensions/builtin/claude-sdk-oauth/stream.ts";
+
+const model: Model<Api> = {
+	id: "claude-test",
+	name: "Claude test",
+	api: "claude-sdk-oauth",
+	provider: "claude-sdk-oauth",
+	baseUrl: "claude-sdk-oauth",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+function sdkMessage(value: unknown): SDKMessage {
+	return value as SDKMessage;
+}
+
+class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
+	private readonly queued: SDKMessage[] = [];
+	private readonly readers: Array<(value: IteratorResult<SDKMessage>) => void> = [];
+
+	constructor(prompt: AsyncIterable<SDKUserMessage>) {
+		void this.consume(prompt);
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<SDKMessage> {
+		return this;
+	}
+
+	next(): Promise<IteratorResult<SDKMessage>> {
+		const value = this.queued.shift();
+		if (value) return Promise.resolve({ value, done: false });
+		return new Promise((resolve) => this.readers.push(resolve));
+	}
+
+	async initializationResult(): Promise<Record<string, never>> {
+		return {};
+	}
+
+	async interrupt(): Promise<void> {}
+
+	close(): void {
+		for (const reader of this.readers.splice(0)) reader({ value: undefined, done: true });
+	}
+
+	private emit(message: SDKMessage): void {
+		const reader = this.readers.shift();
+		if (reader) reader({ value: message, done: false });
+		else this.queued.push(message);
+	}
+
+	private async consume(prompt: AsyncIterable<SDKUserMessage>): Promise<void> {
+		let index = 0;
+		for await (const message of prompt) {
+			index++;
+			const uuid = message.uuid ?? `submitted-${index}`;
+			this.emit(sdkMessage({ ...message, uuid, isReplay: true }));
+			this.emit(
+				sdkMessage({
+					type: "assistant",
+					message: { id: `message-${uuid}`, type: "message", role: "assistant", content: [] },
+					parent_tool_use_id: null,
+					uuid: `assistant-${uuid}`,
+					session_id: message.session_id,
+				}),
+			);
+			this.emit(
+				sdkMessage({
+					type: "result",
+					subtype: "success",
+					result: `answer-${index}`,
+					user_message_uuid: uuid,
+					uuid: `result-${uuid}`,
+					session_id: message.session_id,
+				}),
+			);
+		}
+	}
+}
+
+function residentBoundary(): void {
+	const query: SdkQuery = (input) => {
+		if (typeof input.prompt === "string") throw new Error("Expected streaming input");
+		return new ResidentQuery(input.prompt);
+	};
+	overrideSdkBoundary({ query });
+	overrideSessionRegistryBoundary({ queryFactory: query });
+}
+
+function assistant(text: string, timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "claude-sdk-oauth",
+		provider: "claude-sdk-oauth",
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp,
+	};
+}
+
+const sessionIds = new Set<string>();
+
+function mainOptions(sessionId: string) {
+	sessionIds.add(sessionId);
+	return { sessionId, streamKind: "main" as const };
+}
+
+function observations(): ContinuityObservation[] {
+	const result: ContinuityObservation[] = [];
+	overrideContinuityObservabilityBoundary({ emit: (observation) => result.push(observation) });
+	return result;
+}
+
+afterEach(() => {
+	for (const sessionId of sessionIds) closeSession(sessionId, "test_cleanup");
+	sessionIds.clear();
+	resetSessionRegistryBoundary();
+	resetSdkBoundary();
+	resetContinuityObservabilityBoundary();
+});
+
+describe("Claude SDK OAuth bootstrap classification", () => {
+	it("bootstraps a fresh multi-message first turn with no prior assistant", async () => {
+		residentBoundary();
+		const observed = observations();
+		const sessionId = "bootstrap-multi-message";
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "injected context", timestamp: 1 },
+				{ role: "user", content: "actual prompt", timestamp: 2 },
+			],
+		};
+
+		await streamClaudeSdkOauth(model, context, mainOptions(sessionId)).result();
+
+		expect(observed).toContainEqual(expect.objectContaining({ kind: "bootstrap", reason: "registry_miss" }));
+	});
+
+	it("flattens a fresh context that already has an assistant message", async () => {
+		residentBoundary();
+		const observed = observations();
+		const sessionId = "bootstrap-prior-assistant";
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "injected context", timestamp: 1 },
+				assistant("prior answer", 2),
+				{ role: "user", content: "actual prompt", timestamp: 3 },
+			],
+		};
+
+		await streamClaudeSdkOauth(model, context, mainOptions(sessionId)).result();
+
+		expect(observed).toContainEqual(expect.objectContaining({ kind: "flatten", reason: "registry_miss" }));
+	});
+});


### PR DESCRIPTION
## Summary

`createResidentAttempt` previously defined `firstTurn` as:

```ts
existing === undefined && getBinding(sessionId) === undefined && hashes.length <= 1
```

That made a genuinely fresh session with injected context plus the actual prompt (two transmitted user messages) report `flatten` / `registry_miss`, which the TUI renders as a continuity loss even though no SDK session existed and nothing was lost. This matches the Discord report from samaronejr on 2026-09-09: `Session continuity lost - resent the full conversation (registry_miss) - sent 19.2KB` when opening a second concurrent OmO session.

The fix keeps the resident-entry and persisted-binding checks and replaces the message-count condition with the absence of any prior assistant message in `input.context.messages`. A cold start with a prior assistant message still reports `flatten`, `reason: "registry_miss"`.

## Regression proof

- RED: `claude-sdk-oauth-bootstrap-classification.test.ts` failed 1 test / passed 1. The failing assertion received:
  - expected `ObjectContaining { kind: "bootstrap", reason: "registry_miss" }`
  - received `{ kind: "flatten", reason: "registry_miss", deltaMessages: 2, payloadBytes: 275, collapsedDirectives: 0 }`
- GREEN focused: 1 file, 2 tests passed.
- GREEN cluster: `bunx vitest run test/claude-sdk-oauth-` -> 57 files passed, 467 tests passed, 3 skipped (470 total).
- `bun scripts/check-pr-changelog.mjs --base origin/main`: PASS.
- `bun run check`: exit 0.

## Scope

Only the `firstTurn` predicate changed in production. `decideNativeContinuity` is untouched. The dated extension tracker entry and `[Unreleased]` changelog bullet are included.

The SDK lane was not exercised live (no Claude subscription on this host); the reproduction is unit-level.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `claude-sdk-oauth` cold start classification so fresh sessions with injected context and a prompt report `bootstrap` instead of a false `registry_miss` continuity loss. Previously `firstTurn` used a message-count check; now it uses the absence of prior assistant messages, keeping `flatten` for sessions that actually had an assistant turn.

- Changes the `firstTurn` predicate in `createResidentAttempt` to check for no prior assistant message in `input.context.messages`.
- Adds tests covering both a multi-message first turn without assistant and a cold start with a prior assistant message.

<sup>Written for commit d71b2a4a003dd1c487ede4e07ac9fc53c7f470e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

