### PR TITLE
fix(coding-agent): expose shared host policy to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Extensions can inspect the effective shared-host capability during registration, allowing RPC-dependent tools to stay absent when shared-host support is disabled and available when it is enabled.
+
 - Fresh `claude-sdk-oauth` sessions with injected context and multiple first-turn user messages now report continuity `bootstrap` instead of a false `registry_miss` loss; sessions that have a prior assistant message still flatten on a genuine registry miss.
 
 ### Removed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-09 - Forward shared-host policy to extension loading
+
+### What changed
+
+- `packages/coding-agent/src/main.ts` supplies the shared-host policy when constructing CLI runtime resources.
+
+### Why
+
+- `packages/coding-agent/src/main.ts` knows the application mode and branded environment used by the shared-host decision.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/main.ts` owns CLI mode selection and runtime service creation before extension factories execute.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/main.ts`: `createCliRuntimeFactory` resource-loader configuration.
+
 ## 2026-09-09 - Upgrade generate_image to GPT Image 2.5
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,21 @@
+## Registration-time shared-host capability (2026-09-09)
+
+### What changed
+
+- `packages/coding-agent/src/core/resource-loader.ts` forwards the shared-host policy through extension-loading options.
+
+### Why
+
+- `packages/coding-agent/src/core/resource-loader.ts` owns the effective settings and extension discovery lifecycle needed for capability-gated tool registration.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/resource-loader.ts` loads factories before extensions can access bound session actions.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/resource-loader.ts`: resource-loader options, constructor, and extension-set assembly.
+
 ## Size-adaptive summarization duration budget setting (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,27 @@
 # Core Extensions Changes
 
+## 2026-09-09 - Expose shared-host policy during extension registration
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/types.ts` adds the read-only `ExtensionAPI.sharedHostEnabled` capability.
+- `packages/coding-agent/src/core/extensions/loader.ts` forwards the loading policy into extension factories.
+
+### Why
+
+- `packages/coding-agent/src/core/extensions/types.ts` lets RPC-dependent tools distinguish enabled and disabled hosts before registering.
+- `packages/coding-agent/src/core/extensions/loader.ts` makes the decision available before a factory registers searchable tools.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/extensions/types.ts` defines the host-owned registration API.
+- `packages/coding-agent/src/core/extensions/loader.ts` constructs that API before session events or bound runtime actions are available.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/extensions/types.ts`: registration-time context fields.
+- `packages/coding-agent/src/core/extensions/loader.ts`: factory initialization and loading options.
+
 ## 2026-09-09 - Register compact read classifiers through the extension API
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -363,6 +363,7 @@ function createExtensionAPI(
 	runtime: ExtensionRuntime,
 	cwd: string,
 	eventBus: EventBus,
+	sharedHostEnabled: boolean,
 ): { api: ExtensionAPI; commit: () => void; discard: () => void } {
 	const pendingFlagValues = new Map<string, boolean | string>();
 	const pendingRuntimeChanges: Array<() => void> = [];
@@ -386,6 +387,7 @@ function createExtensionAPI(
 
 	const api = {
 		cwd,
+		sharedHostEnabled,
 
 		// Registration methods - write to extension
 		on(event: string, handler: HandlerFn): void {
@@ -760,9 +762,10 @@ async function initializeExtension(
 	cwd: string,
 	eventBus: EventBus,
 	runtime: ExtensionRuntime,
+	sharedHostEnabled: boolean,
 ): Promise<Extension> {
 	const extension = createExtension(extensionPath, resolvedPath, cwd);
-	const load = createExtensionAPI(extension, runtime, cwd, eventBus);
+	const load = createExtensionAPI(extension, runtime, cwd, eventBus, sharedHostEnabled);
 	try {
 		await factory(load.api);
 		load.commit();
@@ -782,6 +785,7 @@ async function loadExtension(
 	getImporter: () => ExtensionModuleImporter,
 	factoryResolver?: ExtensionFactoryResolver,
 	cacheToken?: ExtensionCacheToken,
+	sharedHostEnabled = false,
 ): Promise<{ extension: Extension | null; error: string | null }> {
 	const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
 
@@ -794,7 +798,7 @@ async function loadExtension(
 			return { extension: null, error: `Extension does not export a valid factory function: ${extensionPath}` };
 		}
 
-		const extension = await initializeExtension(factory, extensionPath, resolvedPath, cwd, eventBus, runtime);
+		const extension = await initializeExtension(factory, extensionPath, resolvedPath, cwd, eventBus, runtime, sharedHostEnabled);
 		return { extension, error: null };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -811,9 +815,10 @@ export async function loadExtensionFromFactory(
 	eventBus: EventBus,
 	runtime: ExtensionRuntime,
 	extensionPath = "<inline>",
+	sharedHostEnabled = false,
 ): Promise<Extension> {
 	const resolvedCwd = resolvePath(cwd);
-	return initializeExtension(factory, extensionPath, extensionPath, resolvedCwd, eventBus, runtime);
+	return initializeExtension(factory, extensionPath, extensionPath, resolvedCwd, eventBus, runtime, sharedHostEnabled);
 }
 
 /**
@@ -824,7 +829,7 @@ async function loadExtensionsInternal(
 	cwd: string,
 	eventBus?: EventBus,
 	runtime?: ExtensionRuntime,
-	options?: { factoryResolver?: ExtensionFactoryResolver },
+	options?: { factoryResolver?: ExtensionFactoryResolver; sharedHostEnabled?: boolean },
 	useCache = false,
 ): Promise<LoadExtensionsResult> {
 	const extensions: Extension[] = [];
@@ -848,6 +853,7 @@ async function loadExtensionsInternal(
 			getImporter,
 			options?.factoryResolver,
 			cacheToken,
+			options?.sharedHostEnabled ?? false,
 		);
 
 		if (error) {
@@ -873,7 +879,7 @@ export async function loadExtensions(
 	cwd: string,
 	eventBus?: EventBus,
 	runtime?: ExtensionRuntime,
-	options?: { factoryResolver?: ExtensionFactoryResolver },
+	options?: { factoryResolver?: ExtensionFactoryResolver; sharedHostEnabled?: boolean },
 ): Promise<LoadExtensionsResult> {
 	return loadExtensionsInternal(paths, cwd, eventBus, runtime, options);
 }

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1644,6 +1644,8 @@ export interface ExtensionAPI {
 
 	/** Absolute cwd of the session this extension instance was loaded for. */
 	readonly cwd: string;
+	/** Effective shared-host capability for registration-time extension decisions. */
+	readonly sharedHostEnabled: boolean;
 
 	// =========================================================================
 	// Event Subscription

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -325,6 +325,7 @@ export interface DefaultResourceLoaderOptions {
 	cwd: string;
 	agentDir: string;
 	settingsManager?: SettingsManager;
+	sharedHostEnabled?: boolean;
 	eventBus?: EventBus;
 	additionalExtensionPaths?: string[];
 	additionalSkillPaths?: string[];
@@ -361,6 +362,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private cwd: string;
 	private agentDir: string;
 	private settingsManager: SettingsManager;
+	private sharedHostEnabled: boolean;
 	private eventBus: EventBus;
 	private packageManager: DefaultPackageManager;
 	private additionalExtensionPaths: string[];
@@ -423,6 +425,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.cwd = resolvePath(options.cwd);
 		this.agentDir = resolvePath(options.agentDir);
 		this.settingsManager = options.settingsManager ?? SettingsManager.create(this.cwd, this.agentDir);
+		this.sharedHostEnabled = options.sharedHostEnabled ?? this.settingsManager.getExperimentalSharedHost();
 		this.eventBus = options.eventBus ?? createEventBus();
 		this.packageManager = new DefaultPackageManager({
 			cwd: this.cwd,
@@ -793,10 +796,14 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 	}
 
-	private buildGlobalDefaultExtensionLoadOptions(): { factoryResolver: ExtensionFactoryResolver } {
+	private buildGlobalDefaultExtensionLoadOptions(): {
+		factoryResolver: ExtensionFactoryResolver
+		sharedHostEnabled: boolean
+	} {
 		return {
 			factoryResolver: (_extensionPath, resolvedPath) =>
 				resolveGeneratedGlobalDefaultExtensionFactory(resolvedPath, this.agentDir),
+			sharedHostEnabled: this.sharedHostEnabled,
 		};
 	}
 

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -828,7 +828,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 			return extensionsResult;
 		}
 
-		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime);
+		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, this.sharedHostEnabled);
 		extensionsResult.extensions.push(...inlineExtensions.extensions);
 		extensionsResult.errors.push(...inlineExtensions.errors);
 		return extensionsResult;
@@ -850,7 +850,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 				undefined,
 				this.buildGlobalDefaultExtensionLoadOptions(),
 			);
-			const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime);
+			const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, this.sharedHostEnabled);
 			extensionsResult.extensions.unshift(...inlineExtensions.extensions);
 			this.rebuildExtensionFlagDefaults(extensionsResult);
 			extensionsResult.errors.push(...inlineExtensions.errors);
@@ -1305,7 +1305,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 	}
 
-	private async loadExtensionFactories(runtime: ExtensionRuntime): Promise<{
+	private async loadExtensionFactories(runtime: ExtensionRuntime, sharedHostEnabled: boolean): Promise<{
 		extensions: Extension[];
 		errors: Array<{ path: string; error: string }>;
 	}> {
@@ -1326,6 +1326,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 					this.eventBus,
 					runtime,
 					extensionPath,
+					sharedHostEnabled,
 				);
 				extensions.push(extension);
 			} catch (error) {
@@ -1349,6 +1350,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 						this.eventBus,
 						runtime,
 						extensionPath,
+						sharedHostEnabled,
 					);
 					extensions.push(extension);
 					continue;
@@ -1373,7 +1375,13 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 
 		if (bundledExtensionPaths.length > 0) {
-			const bundledResult = await loadExtensions(bundledExtensionPaths, this.cwd, this.eventBus, runtime);
+			const bundledResult = await loadExtensions(
+				bundledExtensionPaths,
+				this.cwd,
+				this.eventBus,
+				runtime,
+				{ sharedHostEnabled },
+			);
 			extensions.push(...bundledResult.extensions);
 			errors.push(...bundledResult.errors);
 		}
@@ -1383,7 +1391,14 @@ export class DefaultResourceLoader implements ResourceLoader {
 			const factory = isNamed ? input.factory : input;
 			const extensionPath = `<inline:${isNamed ? input.name : index + 1}>`;
 			try {
-				const extension = await loadExtensionFromFactory(factory, this.cwd, this.eventBus, runtime, extensionPath);
+				const extension = await loadExtensionFromFactory(
+					factory,
+					this.cwd,
+					this.eventBus,
+					runtime,
+					extensionPath,
+					sharedHostEnabled,
+				);
 				extension.hidden = isNamed && input.hidden;
 				extensions.push(extension);
 			} catch (error) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -774,6 +774,10 @@ export function createCliRuntimeFactory(
 					}
 				: undefined,
 			resourceLoaderOptions: {
+				sharedHostEnabled: shouldJoinSharedHost(appMode, {
+					enableEnv: isTruthyEnvFlag(envValue("ENABLE_SHARED_HOST")),
+					settingEnabled: runtimeSettingsManager.getExperimentalSharedHost(),
+				}),
 				additionalExtensionPaths: resolvedExtensionPaths,
 				additionalSkillPaths: resolvedSkillPaths,
 				additionalPromptTemplatePaths: resolvedPromptTemplatePaths,

--- a/packages/coding-agent/test/extensions-loader.test.ts
+++ b/packages/coding-agent/test/extensions-loader.test.ts
@@ -57,6 +57,22 @@ describe("extension loader", () => {
 		expect(capturedApi?.cwd).toBe(sessionCwd);
 	});
 
+	it("exposes the effective shared-host policy during extension registration", async () => {
+		let capturedPolicy: boolean | undefined;
+		const extensionFactory: ExtensionFactory = (pi) => {
+			capturedPolicy = (pi as ExtensionAPI & { readonly sharedHostEnabled?: boolean }).sharedHostEnabled;
+		};
+		const importExtension = vi.fn(async () => extensionFactory);
+		const createJiti = vi.fn(() => ({ import: importExtension }));
+
+		vi.doMock("jiti/static", () => ({ createJiti }));
+		const { loadExtensions } = await import("../src/core/extensions/loader.ts");
+
+		await loadExtensions(["first.js"], "/tmp", undefined, undefined, { sharedHostEnabled: true });
+
+		expect(capturedPolicy).toBe(true);
+	});
+
 	it("prefers bundled package aliases when the local coding-agent package carries dependencies", async () => {
 		// given a linked local senpi install where dependencies live under
 		// packages/coding-agent/node_modules instead of the workspace root


### PR DESCRIPTION
Expose the effective shared-host capability during extension registration. The loader forwards a registration-time boolean from ResourceLoader to ExtensionAPI, and main computes it with the existing shouldJoinSharedHost policy. Adds an extension-loader regression test. Focused test: 9/9 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the effective shared-host policy to extensions at registration time so they can make policy-aware decisions.

- The loader forwards a `sharedHostEnabled` boolean from `ResourceLoader` to `ExtensionAPI`, covering builtin, bundled, and inline extensions.
- Main computes the value using the existing `shouldJoinSharedHost` policy; otherwise the loader falls back to the experimental shared-host setting.
- Adds a regression test and documents the capability in the changelog and change notes.

<sup>Written for commit 6837ac6a7c7d3230bfd744f572cce0dc552dc3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

