### PR TITLE
fix(compaction): resume oversized sessions into compaction-required admission instead of refusing (#1511)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Extensions can inspect the effective shared-host capability during registration, allowing RPC-dependent tools to stay absent when shared-host support is disabled and available when it is enabled.
 
+- Oversized resumed sessions now open in a required-compaction state and compact before the first prompt instead of failing constructor-time model-budget admission ([#1511](https://github.com/code-yeongyu/senpi/issues/1511)).
 - Fresh `claude-sdk-oauth` sessions with injected context and multiple first-turn user messages now report continuity `bootstrap` instead of a false `registry_miss` loss; sessions that have a prior assistant message still flatten on a genuine registry miss.
 
 ### Removed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -112,6 +112,7 @@ import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
 	type ModelUsabilityAdmission,
 	ModelUsabilityBudgetError,
+	type ModelUsabilityBudgetProjection,
 	projectModelUsabilityBudget,
 } from "./extensions/builtin/compaction/model-usability-budget.ts";
 import {
@@ -119,6 +120,10 @@ import {
 	resolveReserveTokens,
 	shouldTriggerCompaction,
 } from "./extensions/builtin/compaction/policy.ts";
+import {
+	createResumeCompactionRequirement,
+	type ResumeCompactionRequirement,
+} from "./extensions/builtin/compaction/resume-admission.ts";
 import { WAKE_SOURCE_STATE_EVENT } from "./extensions/builtin/monitor-state-event.ts";
 import { CODEX_RESPONSES_API, type ServiceTier } from "./extensions/builtin/service-tier.ts";
 import { deriveExtensionRegistrationId } from "./extensions/builtin/tool-search/engine/marker.ts";
@@ -413,6 +418,11 @@ export type AgentSessionEvent =
 	| { type: "agent_settled" }
 	| { type: "agent_idle" }
 	| { type: "session_abort" }
+	| {
+			type: "resume_compaction_required";
+			projection: ModelUsabilityBudgetProjection;
+			notice: string;
+	  }
 	| { type: "continuation_error"; errorMessage: string }
 	| {
 			type: "skill_invocation";
@@ -1080,6 +1090,7 @@ export class AgentSession {
 	// into an assistant error message. Matching provider text alone is not proof
 	// that AgentSession initiated required-compaction recovery.
 	private _requiredCompactionTurnError: RequiredCompactionError | undefined;
+	private _resumeCompactionRequirement: ResumeCompactionRequirement | undefined;
 	// A retry continuation immediately follows an accepted compaction. Its first
 	// response must not retrigger threshold compaction from stale provider usage.
 	private _skipNextPostRetryCompactionCheck = false;
@@ -2873,6 +2884,13 @@ export class AgentSession {
 	 */
 	subscribe(listener: AgentSessionEventListener): () => void {
 		this._eventListeners.push(listener);
+		if (this._resumeCompactionRequirement !== undefined) {
+			listener({
+				type: "resume_compaction_required",
+				projection: this._resumeCompactionRequirement.projection,
+				notice: this._resumeCompactionRequirement.notice,
+			});
+		}
 		for (const source of this.settingsManager.getSelectedSettingsSources()) {
 			listener({ type: "settings_source_selected", ...source });
 		}
@@ -4716,6 +4734,11 @@ export class AgentSession {
 		if (!projection.usable) throw new ModelUsabilityBudgetError(projection);
 	}
 
+	/** Admit an oversized restored transcript so the normal pre-provider compaction can run. */
+	admitResumeCompactionRequired(projection: ModelUsabilityBudgetProjection): void {
+		this._resumeCompactionRequirement = createResumeCompactionRequirement(projection);
+	}
+
 	private _getDownswitchLiveContextTokens(model: Model<Api>): number {
 		const currentModel = this.model;
 		if (!currentModel) return 0;
@@ -6133,6 +6156,26 @@ export class AgentSession {
 
 		const settings = this._getCompactionSettings();
 		const model = this.model;
+		if (this._resumeCompactionRequirement !== undefined) {
+			if (!model) throw new RequiredCompactionError();
+			const compacted = await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, inlineReason);
+			if (!compacted) throw new RequiredCompactionError();
+			const currentContext = estimateContextTokens(
+				filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
+			).tokens;
+			const remainingProjection = projectModelUsabilityBudget({
+				model,
+				systemPrompt: this.agent.state.systemPrompt,
+				tools: this.agent.state.tools,
+				liveContextTokens: currentContext,
+				compaction: settings,
+				includeSpeculationLead: false,
+				admission: "resume",
+			});
+			if (!remainingProjection.usable) throw new RequiredCompactionError();
+			this._resumeCompactionRequirement = undefined;
+			return true;
+		}
 		const contextTokens = estimateContextTokens(
 			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
 		).tokens;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -16,6 +16,23 @@
 
 - `packages/coding-agent/src/core/resource-loader.ts`: resource-loader options, constructor, and extension-set assembly.
 
+## Resume oversized sessions into required compaction (2026-09-09)
+
+### What changed
+
+- `sdk.ts` admits only restored sessions whose projection remains unusable after the compaction-eligible resume branch, when compaction is enabled; `agent-session.ts` publishes that projection through the existing session event stream and forces compaction before the first provider prompt. Startup and model-switch assertions are unchanged.
+
+### Why
+
+- A restored transcript can fit the raw context window while system prompt, tool schemas, and output reserve make the first provider request fail. Deferring that admission lets the existing required-compaction route reduce the transcript instead of crashing the constructor.
+
+### Why an extension could not handle it
+
+- The projection is evaluated before extensions are wired, so only core can retain the shortfall and defer provider admission.
+
+### Expected merge conflict zones
+
+- MEDIUM in `sdk.ts` startup admission and `agent-session.ts` pre-provider compaction gate; LOW in the interactive event switch.
 ## Size-adaptive summarization duration budget setting (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,26 @@
 # changes.md — builtin compaction policy
 
+## Resume oversized sessions into required compaction (2026-09-09)
+
+### What changed
+
+- Resume admission now retains an unusable model-budget projection instead of throwing when compaction is enabled. The session emits the projection and a bounded notice through the existing session event stream, then forces the existing pre-provider compaction route before its first prompt.
+- Fresh startup and live model switches continue to reject unusable projections. `--no-tools` remains an explicit manual escape hatch.
+
+### Why
+
+- Restored context is projected with tool schemas and output reserves before extensions bind. That constructor-time projection can reject a session that the existing required-compaction path could reduce, leaving no way to reach `/compact` without disabling tools first.
+
+### Why an extension could not handle it
+
+- `createAgentSession` performs the resume projection before extension hooks are wired. Only core can retain the projection and defer provider admission until the existing compaction gate runs.
+
+### Expected merge conflict zones
+
+- MEDIUM: `sdk.ts` resume assertion and `agent-session.ts` required-compaction admission/event seams.
+- LOW: `resume-admission.ts`, the regression suite, and interactive event rendering.
+
+
 ## Allow compaction-eligible restored transcripts during resumed-session admission (2026-09-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/resume-admission.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/resume-admission.ts
@@ -1,0 +1,15 @@
+import type { ModelUsabilityBudgetProjection } from "./model-usability-budget.ts";
+
+export interface ResumeCompactionRequirement {
+	readonly projection: ModelUsabilityBudgetProjection;
+	readonly notice: string;
+}
+
+export function createResumeCompactionRequirement(
+	projection: ModelUsabilityBudgetProjection,
+): ResumeCompactionRequirement {
+	return {
+		projection,
+		notice: `Context exceeds the model budget by ${projection.shortfallTokens} tokens; compacting before the first prompt.`,
+	};
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -10,6 +10,7 @@ import { AuthStorage } from "./auth-storage.ts";
 import { estimateTokens } from "./compaction/compaction.ts";
 import { createSessionCursorExecBridge } from "./cursor-exec-bridge-session.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
+import { ModelUsabilityBudgetError } from "./extensions/builtin/compaction/model-usability-budget.ts";
 import { type ServiceTier, supportsServiceTier } from "./extensions/builtin/service-tier.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlmForTransport, TRANSPORT_IMAGE_BUDGET_BYTES } from "./messages.ts";
@@ -541,11 +542,23 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const liveContextTokens = hasExistingSession
 		? existingSession.messages.reduce((total, message) => total + estimateTokens(message), 0)
 		: 0;
-	session.assertModelUsable(
-		undefined,
-		liveContextTokens,
-		hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
-	);
+	try {
+		session.assertModelUsable(
+			undefined,
+			liveContextTokens,
+			hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
+		);
+	} catch (error) {
+		if (
+			!hasExistingSession ||
+			!(error instanceof ModelUsabilityBudgetError) ||
+			!session.settingsManager.getCompactionEnabled() ||
+			error.projection.liveContextTokens > error.projection.contextWindow
+		) {
+			throw error;
+		}
+		session.admitResumeCompactionRequired(error.projection);
+	}
 	sessionRef.current = session;
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,22 @@
 
+## 2026-09-09 - Surface required compaction after oversized resume
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: renders the existing session event notice when resume admission defers an unusable restored projection to required compaction.
+
+### Why
+
+- Users must be told that the first prompt will compact instead of seeing a constructor-time model budget refusal.
+
+### Why an extension could not handle it
+
+- The notice originates in core before extension hooks bind; interactive mode is the existing session-event presentation surface.
+
+### Expected merge conflict zones
+
+- LOW: the `handleEvent` switch beside other model and session notices.
+
 ## 2026-09-08 - Shortcut context exposes the effective service tier
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4520,6 +4520,10 @@ export class InteractiveMode {
 				this.showHighReasoningWarning(event);
 				break;
 
+			case "resume_compaction_required":
+				this.showWarning(event.notice);
+				break;
+
 			case "settings_source_selected":
 				this.showSettingsSourceSelected(event);
 				break;

--- a/packages/coding-agent/test/suite/regressions/1511-resume-oversized-session-compacts.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1511-resume-oversized-session-compacts.test.ts
@@ -1,0 +1,144 @@
+import { join } from "node:path";
+import { estimateContextTokens, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { projectModelUsabilityBudget } from "../../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import { createAgentSession } from "../../../src/core/sdk.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("#1511 oversized resume admission", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("opens an oversized resumed session and reports required compaction", async () => {
+		const harness = await createHarness({
+			models: [{ id: "resume", contextWindow: 100_000, maxTokens: 4_000 }],
+			persistSession: true,
+		});
+		harnesses.push(harness);
+		const sessionManager = harness.sessionManager;
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "! ".repeat(95_000 * 2) }],
+			timestamp: Date.now(),
+		});
+
+		const resumed = await createAgentSession({
+			cwd: harness.tempDir,
+			agentDir: join(harness.tempDir, "resume-agent"),
+			model: harness.getModel(),
+			sessionManager,
+		});
+		const events: unknown[] = [];
+		resumed.session.subscribe((event) => events.push(event));
+		await resumed.session.bindExtensions({});
+
+		expect(resumed.session.agent.state.messages).toHaveLength(1);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "resume_compaction_required",
+				projection: expect.objectContaining({ usable: false, admission: "resume" }),
+				notice: expect.stringContaining("compacting before the first prompt"),
+			}),
+		);
+		resumed.session.dispose();
+	});
+
+	it("compacts before the first provider request after oversized admission", async () => {
+		const harness = await createHarness({
+			models: [{ id: "resume", contextWindow: 100_000, maxTokens: 4_000 }],
+			settings: {
+				compaction: { enabled: true, speculativeEnabled: false, idleCompactionEnabled: false, keepRecentTokens: 1 },
+			},
+			extensionFactories: [
+				(pi) =>
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "restored context summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+						},
+					})),
+			],
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "restored context ".repeat(16_000) }],
+			timestamp: 1,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("restored answer", { timestamp: 2 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "last request" }],
+			timestamp: 2,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("restored answer", { timestamp: 3 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		const projection = projectModelUsabilityBudget({
+			model,
+			systemPrompt: harness.session.agent.state.systemPrompt,
+			tools: harness.session.agent.state.tools,
+			liveContextTokens: 80_000,
+			compaction: harness.settingsManager.getCompactionSettings(),
+			includeSpeculationLead: false,
+			admission: "resume",
+		});
+		expect(projection.usable).toBe(false);
+		harness.session.admitResumeCompactionRequired(projection);
+		harness.setResponses([fauxAssistantMessage("first answer")]);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("continue");
+
+		expect(harness.eventsOfType("compaction_end").some((event) => event.accepted === true)).toBe(true);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(harness.faux.getCallLog().length).toBeGreaterThan(0);
+		const providerCall = harness.faux.getCallLog().at(-1);
+		if (!providerCall) throw new Error("expected a provider request after required compaction");
+		expect(estimateContextTokens(providerCall.context).tokens).toBeLessThanOrEqual(
+			model.contextWindow - model.maxTokens,
+		);
+
+		// The resume requirement is consumed by the successful compaction, rather
+		// than recomputed from the live projection on every turn.
+		const compactionsAfterResume = harness.eventsOfType("compaction_end").length;
+		const noticesAfterResume = harness.eventsOfType("resume_compaction_required").length;
+		harness.appendResponses([fauxAssistantMessage("second answer")]);
+		await harness.session.prompt("second prompt");
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(compactionsAfterResume);
+		expect(harness.eventsOfType("resume_compaction_required")).toHaveLength(noticesAfterResume);
+	});
+
+	it("does not report compaction for a usable resumed session", async () => {
+		const harness = await createHarness({
+			models: [{ id: "resume", contextWindow: 100_000, maxTokens: 4_000 }],
+		});
+		harnesses.push(harness);
+		const resumed = await createAgentSession({
+			cwd: harness.tempDir,
+			agentDir: join(harness.tempDir, "usable-agent"),
+			model: harness.getModel(),
+			sessionManager: SessionManager.inMemory(harness.tempDir),
+		});
+		const events: unknown[] = [];
+		resumed.session.subscribe((event) => events.push(event));
+		await resumed.session.bindExtensions({});
+		expect(events.some((event) => (event as { type?: string }).type === "resume_compaction_required")).toBe(false);
+		resumed.session.dispose();
+	});
+});


### PR DESCRIPTION
## Root cause
`createAgentSession` projected restored context together with system prompt, tool schemas, output reserve, and safety margin before extensions were wired. When that projection was short, resume threw `ModelUsabilityBudgetError`, so the compaction extension and its required-compaction recovery path could never run.

## Design
`model-usability-budget.ts` is untouched in this PR. The earlier #1508 compaction-eligible resume branch remains authoritative: sessions it reports as `usable: true` resume unchanged with no notice and no forced compaction. The new path is reached strictly below that branch, only for resume projections it still reports `usable: false`, with compaction enabled and the restored context itself within the raw model window. Compaction-disabled resumes still refuse at construction with the existing actionable budget error.

Those remaining projections retain the complete shortfall projection and emit it through the existing `AgentSession.subscribe` event seam. RPC forwards the event as it does other session events, and interactive mode renders the bounded notice. The first provider-bound prompt forces the existing pre-provider compaction path. After a successful compaction, the full live projection is rechecked and the requirement is consumed exactly once; it is not recomputed as a session-lifetime latch. Fresh startup and live model switches still reject unusable projections. `--no-tools` remains unchanged.

## Verification
- RED: mutation-disabled admission produced the historical `ModelUsabilityBudgetError` (1 regression failed, usable-session case passed).
- GREEN: focused regression + main `model-usability-budget` suite: 17 passed, 0 failed, 49 expectations.
- Mutation check: restored the admission path after the RED run.
- Regression covers construction, projection/notice, first-prompt compaction, provider admission, usable resume behavior, and a second prompt with no forced compaction or repeated notice.
- RPC/interactive surface check: `resume_compaction_required` uses the existing session subscription path; interactive renders `showWarning`, RPC forwards the generic event.
- `bun scripts/check-pr-changelog.mjs --base origin/main`: PASS.
- `bun run check`: PASS.
- Requested compaction/model-usability cluster: 391 passed, 46 failed, 10 errors in untouched pre-existing tests due Bun/Vitest incompatibilities (`vi.setSystemTime`/timer APIs and circular `createCodingTools` imports).

Closes #1511
