### PR TITLE
fix(goal): stop automatic recovery after terminal policy rejection

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-fixture.ts
+++ b/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-fixture.ts
@@ -7,8 +7,13 @@ import type { ExtensionAPI, ExtensionContext } from "../../../../../packages/cod
 export default function policyRecoveryFixture(pi: ExtensionAPI): void {
 	const scenario = process.env.SENPI_QA_POLICY_CASE;
 	if (scenario !== "policy" && scenario !== "infrastructure") throw new Error("Unknown policy QA scenario");
+	// The faux provider stamps its own `api` onto every response, so the policy
+	// lane must register under the Codex API id: that identity is exactly what the
+	// predicate requires before trusting the unstructured diagnostic. The
+	// infrastructure lane keeps a non-Codex api, which also proves the identity
+	// gate does not swallow ordinary provider failures.
 	const faux = fauxProvider({
-		api: "faux-policy-qa",
+		api: scenario === "policy" ? "openai-codex-responses" : "faux-policy-qa",
 		provider: "faux-policy-qa",
 		models: [{ id: "policy-qa", contextWindow: 1_000_000, maxTokens: 4_096 }],
 	});

--- a/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-fixture.ts
+++ b/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-fixture.ts
@@ -1,0 +1,57 @@
+import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "../../../../../packages/ai/src/providers/faux.ts";
+import { readGoal } from "../../../../../packages/coding-agent/src/core/extensions/builtin/goal/store.ts";
+import { goalStoreRef } from "../../../../../packages/coding-agent/src/core/extensions/builtin/goal/store-ref.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../../../../packages/coding-agent/src/core/extensions/types.ts";
+
+// Only loaded explicitly by goal-policy-rejection-qa.mjs in its isolated CLI.
+export default function policyRecoveryFixture(pi: ExtensionAPI): void {
+	const scenario = process.env.SENPI_QA_POLICY_CASE;
+	if (scenario !== "policy" && scenario !== "infrastructure") throw new Error("Unknown policy QA scenario");
+	const faux = fauxProvider({
+		api: "faux-policy-qa",
+		provider: "faux-policy-qa",
+		models: [{ id: "policy-qa", contextWindow: 1_000_000, maxTokens: 4_096 }],
+	});
+	faux.setResponses([
+		fauxAssistantMessage(fauxToolCall("create_goal", { objective: "QA preserve unfinished work" }, { id: "qa-create" }), {
+			stopReason: "toolUse",
+		}),
+		fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: scenario === "policy"
+				? "Codex error: This request was blocked by our safety systems. Reason: Potentially unintended activity."
+				: "upstream connection closed",
+		}),
+		fauxAssistantMessage(fauxToolCall("update_goal", { status: "complete" }, { id: "qa-complete" }), {
+			stopReason: "toolUse",
+		}),
+		fauxAssistantMessage("QA_RECOVERY_COMPLETE"),
+	]);
+	pi.registerProvider(faux.provider);
+	let context: ExtensionContext | undefined;
+	let createdGoalId: string | undefined;
+	const endings: Array<{ stopReason?: string; errorMessage?: string; willRetry?: boolean }> = [];
+	pi.on("session_start", (_event, ctx) => { context = ctx; });
+	pi.on("agent_end", async (event, ctx) => {
+		context = ctx;
+		const goal = await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd));
+		createdGoalId ??= goal?.id;
+		const lastAssistant = event.messages.findLast((message) => message.role === "assistant");
+		if (lastAssistant?.role === "assistant") {
+			endings.push({ stopReason: lastAssistant.stopReason, errorMessage: lastAssistant.errorMessage, willRetry: event.willRetry });
+		}
+	});
+	pi.rpc.handle("qa.policy.snapshot", async () => {
+		if (context === undefined) throw new Error("QA session has not started");
+		const branch = context.sessionManager.getBranch();
+		return {
+			scenario,
+			calls: faux.state.callCount,
+			createdGoalId,
+			goal: await readGoal(goalStoreRef(context.sessionManager, context.cwd)),
+			endings,
+			continuations: branch.filter((entry) => entry.type === "custom_message" && entry.customType === "goal-continuation").length,
+			pending: context.hasPendingMessages(),
+		};
+	});
+}

--- a/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-qa.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// #1520: zero-token source-CLI QA. No server, real credentials, or provider calls.
+// node .agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-qa.mjs --self-test
+// Optional: --evidence <directory>. Captures receipts even on assertion failure.
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot } from "../lib/common.mjs";
+import { hermeticEnv } from "../lib/mock-loop-support.mjs";
+import { TargetRpcClient } from "../lib/target-rpc-client.mjs";
+
+const root = repoRoot();
+const evidenceIndex = process.argv.indexOf("--evidence");
+if (evidenceIndex >= 0 && !process.argv[evidenceIndex + 1]) throw new Error("--evidence needs a directory");
+const out = resolve(evidenceIndex >= 0 ? process.argv[evidenceIndex + 1] : join(root,
+	"local-ignore/qa-evidence/20260909-terminal-policy-goal-recovery/cli"));
+const fixture = join(dirname(fileURLToPath(import.meta.url)), "goal-policy-rejection-fixture.ts");
+const guard = guardRealAuth();
+installCleanupHooks();
+mkdirSync(out, { recursive: true });
+
+async function runScenario(scenario) {
+	const box = makeSandbox(`goal-policy-${scenario}`);
+	writeFileSync(join(box.agentDir, "settings.json"), JSON.stringify({ retry: { enabled: false }, compaction: { enabled: false } }));
+	const client = new TargetRpcClient({
+		targetRoot: root,
+		cwd: box.cwd,
+		env: { ...hermeticEnv(box.env), SENPI_QA_POLICY_CASE: scenario },
+		extraArgs: ["-e", fixture, "--provider", "faux-policy-qa", "--model", "policy-qa", "--no-model-fallback", "--approve"],
+	});
+	let receipt;
+	try {
+		const ready = await client.send({ type: "get_state" });
+		assert.equal(ready.success, true, JSON.stringify(ready));
+		// agent_idle is emitted only AFTER settlement's deferred turn claims drain.
+		// Unlike a quiet-window sleep, this fails even when a recovery starts slowly.
+		const idle = client.waitFor((event) => event.message.type === "agent_idle");
+		const prompted = await client.send({ type: "prompt", message: "Run the scripted goal QA" });
+		assert.equal(prompted.success, true, JSON.stringify(prompted));
+		await idle;
+		const snapshot = await client.send({ type: "extension_request", name: "qa.policy.snapshot", data: null });
+		assert.equal(snapshot.success, true, JSON.stringify(snapshot));
+		receipt = snapshot.data;
+		writeFileSync(join(out, `${scenario}.json`), JSON.stringify(receipt, null, 2));
+		assert.equal(receipt.pending, false);
+		assert.equal(receipt.goal.id, receipt.createdGoalId);
+		assert.equal(receipt.goal.objective, "QA preserve unfinished work");
+		assert.equal(receipt.endings[0].stopReason, "error");
+		assert.equal(receipt.endings[0].willRetry, false);
+		if (scenario === "policy") {
+			assert.equal(receipt.endings[0].errorMessage,
+				"Codex error: This request was blocked by our safety systems. Reason: Potentially unintended activity.");
+			assert.equal(receipt.calls, 2, "terminal rejection must not make a follow-up model call");
+			assert.equal(receipt.continuations, 0);
+			assert.equal(receipt.goal.status, "blocked");
+			assert.equal(receipt.goal.consecutiveContinuations, 0);
+			assert.equal(receipt.goal.unattendedContinuations, 0);
+		} else {
+			assert.equal(receipt.calls, 4, "infrastructure recovery must execute the completing tool turn");
+			assert.equal(receipt.continuations, 1);
+			assert.equal(receipt.goal.status, "complete");
+		}
+		console.log(`PASS ${scenario}: calls=${receipt.calls} continuations=${receipt.continuations} goal=${receipt.goal.status}`);
+		return receipt;
+	} finally {
+		await client.close();
+		writeFileSync(join(out, `${scenario}-events.json`), JSON.stringify(client.events.map(({ message }) => ({
+			type: message.type,
+			...(message.type === "message_end" ? { role: message.message?.role, customType: message.message?.customType } : {}),
+		})), null, 2));
+		writeFileSync(join(out, `${scenario}-stderr.txt`), client.stderr);
+		box.cleanup();
+		guard.assertUnchanged();
+		console.log(`CLEANUP ${scenario}: CLI closed, sandbox removed, real auth unchanged`);
+	}
+}
+
+const results = [];
+for (const scenario of ["policy", "infrastructure"]) results.push(await runScenario(scenario));
+writeFileSync(join(out, "result.json"), JSON.stringify({ passed: true, realProviderRequests: 0, results }, null, 2));
+console.log(`PASS goal-policy-rejection QA; evidence=${out}`);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- A provider-agnostic "Provider is not configured" style refusal no longer ends a goal as a Codex policy rejection. The gate now requires the Codex responses api id, so another provider or gateway emitting the same sentence keeps provider and system recovery instead of blocking the goal; the api id is pinned against the shipped model catalog so renaming it there cannot silently disarm the guard ([#1520](https://github.com/code-yeongyu/senpi/issues/1520))
+
 - A bare `.` submitted on a session that already has messages no longer renders as a user message in the TUI. It stays the manual-continue shortcut the session delivers as a hidden continuation, so nothing is painted for it while idle or while steering an active turn; a `.` on an empty session and a `.` carrying image attachments remain ordinary user input ([#1569](https://github.com/code-yeongyu/senpi/issues/1569))
 
 - A model switch the session refuses is now recorded instead of vanishing: every

--- a/packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts
@@ -1,7 +1,9 @@
 import type { AgentEndEvent, ExtensionContext } from "../../types.ts";
 import { isMalformedToolUseTurn } from "./continuation.ts";
 import type { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
-import { didTerminalProviderErrorEndTurn } from "./terminal-provider-error.ts";
+import { updateGoal } from "./store.ts";
+import { goalStoreRef } from "./store-ref.ts";
+import { didTerminalPolicyRejectionEndTurn, didTerminalProviderErrorEndTurn } from "./terminal-provider-error.ts";
 import type { Goal } from "./types.ts";
 
 interface GoalAgentEndOptions {
@@ -14,6 +16,16 @@ export async function continueGoalAfterAgentEnd(
 	monitor: MonitorAwareGoalContinuation,
 	options: GoalAgentEndOptions,
 ): Promise<Goal | null> {
+	if (options.goal?.status === "active" && didTerminalPolicyRejectionEndTurn(options.event)) {
+		const blocked = await updateGoal(goalStoreRef(options.ctx.sessionManager, options.ctx.cwd), {
+			status: "blocked",
+			reason: "provider policy rejection ended the turn",
+		});
+		// Cancel armed timers and staged recoveries; only an explicit goal resume
+		// may restart a policy-blocked goal, not an infrastructure recovery path.
+		monitor.syncGoal(blocked);
+		return blocked;
+	}
 	if (options.event.aborted === true && options.event.abortSource === "system") {
 		return monitor.afterSystemAbort({
 			ctx: options.ctx,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- `packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts`: distinguish terminal classifier refusals/sensitive stops and the Codex safety-block error diagnostic from infrastructure failures, only after the explicit retry owner reports `willRetry: false`.
+- `packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts`: distinguish terminal classifier refusals/sensitive stops and the Codex safety-block error diagnostic from infrastructure failures, only after the explicit retry owner reports `willRetry: false`. The unstructured Codex diagnostic carries no policy code, so it is trusted only on `api === "openai-codex-responses"`; another provider or gateway emitting the same sentence keeps the existing provider/system recovery path. Structured classifier refusals stay provider-independent because they carry their own policy details.
 - `packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts`: persist the active goal as blocked before recovery routing and synchronize the monitor to clear staged recoveries and armed timers. The goal identity/objective survive; no continuation is delivered or counted. This is not a mechanical block that unrelated input automatically resumes.
 
 ### Why

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,24 @@
 # goal Extension Changes
 
+## 2026-09-09 - Stop automatic goal recovery after terminal policy rejection (#1520)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts`: distinguish terminal classifier refusals/sensitive stops and the Codex safety-block error diagnostic from infrastructure failures, only after the explicit retry owner reports `willRetry: false`.
+- `packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts`: persist the active goal as blocked before recovery routing and synchronize the monitor to clear staged recoveries and armed timers. The goal identity/objective survive; no continuation is delivered or counted. This is not a mechanical block that unrelated input automatically resumes.
+
+### Why
+
+- `db6069f83` intentionally kept goals active after infrastructure retry exhaustion. Policy rejection was missing from that distinction, so settlement queued up to eight hidden follow-ups to an already rejected request. Non-policy provider/system recovery and explicit retry ownership remain unchanged.
+
+### Why an extension could not handle it
+
+- The builtin owns goal recovery routing, persistence, timers, and settlement admission. An external extension cannot veto its queued continuation.
+
+### Expected merge conflict zones
+
+- LOW: `agent-end-continuation.ts` routing/imports and `terminal-provider-error.ts` predicates.
+
 ## 2026-09-10 - Route user-only blockers through the question tool
 
 ### What changed
@@ -1155,7 +1174,6 @@ surface; no core extension API change is required.
 
 - LOW in `prompt.ts` if the standalone goal continuation wording changes.
 
-
 ## Overview
 Persistent per-thread goal tracking as an in-tree builtin. Ports the standalone
 `pi-goal` extension into senpi with no dependency on it, file-based persistence,
@@ -1429,7 +1447,6 @@ codex-aligned tool naming, and budget-driven behavior removed. An optional
   recovery while upstream owns the lifecycle persistence semantics.
 - MEDIUM: `index.ts`, `tool-registration.ts`, and `ui.ts` retain senpi's split
   registration, elapsed ticker, and core abort-event integration.
-
 
 ## Reload no longer auto-starts a stopped goal; gap-abort blocks active goal (2026-07-27)
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -6,6 +6,7 @@
 
 - `packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts`: distinguish terminal classifier refusals/sensitive stops and the Codex safety-block error diagnostic from infrastructure failures, only after the explicit retry owner reports `willRetry: false`. The unstructured Codex diagnostic carries no policy code, so it is trusted only on `api === "openai-codex-responses"`; another provider or gateway emitting the same sentence keeps the existing provider/system recovery path. Structured classifier refusals stay provider-independent because they carry their own policy details.
 - `packages/coding-agent/src/core/extensions/builtin/goal/agent-end-continuation.ts`: persist the active goal as blocked before recovery routing and synchronize the monitor to clear staged recoveries and armed timers. The goal identity/objective survive; no continuation is delivered or counted. This is not a mechanical block that unrelated input automatically resumes.
+- `packages/coding-agent/test/suite/goal-policy-rejection.test.ts`: the identity gate is a literal copy of an id owned by `packages/ai`, so the suite drives the same lifecycle once per api id in the shipped Codex catalog (`OPENAI_CODEX_MODELS`). Renaming that api fails the suite instead of silently disarming the guard while the hardcoded cases stay green.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
@@ -1,3 +1,4 @@
+import { isClassifierRefusal } from "@earendil-works/pi-ai";
 import type { AgentEndEvent } from "../../types.ts";
 import { lastAssistantMessage } from "./last-assistant-message.ts";
 
@@ -16,6 +17,21 @@ function isSdkOauthAccountExhaustion(
 		? message.content.map((part) => (part?.type === "text" ? part.text : "")).join("\n")
 		: "";
 	return SDK_OAUTH_EXHAUSTION_MARKERS.every((marker) => text.includes(marker));
+}
+
+// Codex backend type:error responses persist only the message, not the policy
+// code/payload. Match that diagnostic, never ordinary assistant text.
+const CODEX_POLICY_ERROR_PATTERN =
+	/^(?:Codex error: )?This request was blocked by our safety systems\.(?: Reason: .+)?$/i;
+
+export function didTerminalPolicyRejectionEndTurn(event: AgentEndEvent): boolean {
+	if (event.willRetry !== false) return false;
+	const message = lastAssistantMessage(event.messages);
+	if (message === undefined) return false;
+	return (
+		isClassifierRefusal(message) ||
+		(message.stopReason === "error" && CODEX_POLICY_ERROR_PATTERN.test(message.errorMessage ?? ""))
+	);
 }
 
 export function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
@@ -23,15 +23,27 @@ function isSdkOauthAccountExhaustion(
 // code/payload. Match that diagnostic, never ordinary assistant text.
 const CODEX_POLICY_ERROR_PATTERN =
 	/^(?:Codex error: )?This request was blocked by our safety systems\.(?: Reason: .+)?$/i;
+const CODEX_RESPONSES_API = "openai-codex-responses";
+
+/**
+ * The sentence above is a provider-agnostic string with no policy code, so it is
+ * only trustworthy as a terminal policy signal on the API that produces it.
+ * Another provider or gateway emitting the same text keeps the existing
+ * provider/system recovery path instead of being stranded as blocked.
+ */
+function isCodexPolicyRejection(message: { api?: string; stopReason?: string; errorMessage?: string }): boolean {
+	if (message.api !== CODEX_RESPONSES_API) return false;
+	if (message.stopReason !== "error") return false;
+	return CODEX_POLICY_ERROR_PATTERN.test(message.errorMessage ?? "");
+}
 
 export function didTerminalPolicyRejectionEndTurn(event: AgentEndEvent): boolean {
 	if (event.willRetry !== false) return false;
 	const message = lastAssistantMessage(event.messages);
 	if (message === undefined) return false;
-	return (
-		isClassifierRefusal(message) ||
-		(message.stopReason === "error" && CODEX_POLICY_ERROR_PATTERN.test(message.errorMessage ?? ""))
-	);
+	// Structured refusals carry their own provider-independent policy details;
+	// only the unstructured Codex diagnostic needs the identity check.
+	return isClassifierRefusal(message) || isCodexPolicyRejection(message);
 }
 
 export function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {

--- a/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
+++ b/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
@@ -1,0 +1,186 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import { goalStoreRef } from "../../src/core/extensions/builtin/goal/store-ref.ts";
+import type { AgentEndEvent } from "../../src/core/extensions/types.ts";
+import {
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+} from "./goal-monitor-test-harness.ts";
+
+const CODEX_POLICY_ERROR =
+	"Codex error: This request was blocked by our safety systems. Reason: Potentially unintended activity.";
+
+async function setupGoal() {
+	const harness = createGoalHarness();
+	const ctx = await makeGoalContext([], "policy-rejection");
+	const create = harness.tools.get("create_goal");
+	if (create === undefined) throw new Error("create_goal was not registered");
+	await create.execute("create", { objective: "Preserve unfinished work" }, undefined, undefined, ctx);
+	const goal = await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd));
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+	return { harness, ctx, goal };
+}
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await cleanupGoalMonitorTempDirs();
+});
+
+describe("terminal policy goal recovery", () => {
+	// Regression for #1520: exercise agent_end routing through the real monitor's
+	// agent_settled admission and sendMessage, not just the error predicate.
+	it.each([
+		[
+			"Codex backend policy error",
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: CODEX_POLICY_ERROR }),
+		],
+		["structured refusal", fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "refusal" } })],
+		[
+			"structured sensitive stop",
+			fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "sensitive" } }),
+		],
+		[
+			"refusal with empty toolUse",
+			fauxAssistantMessage("", { stopReason: "toolUse", stopDetails: { type: "refusal" } }),
+		],
+		[
+			"sensitive empty toolUse",
+			fauxAssistantMessage("", { stopReason: "toolUse", stopDetails: { type: "sensitive" } }),
+		],
+		[
+			"Anthropic policy error",
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage:
+					"This request triggered restrictions on output and was blocked under Anthropic's Usage Policy",
+			}),
+		],
+	])("blocks %s without consuming a continuation or losing the goal", async (_name, message) => {
+		const { harness, ctx, goal } = await setupGoal();
+		const event: AgentEndEvent = { type: "agent_end", messages: [message], willRetry: false };
+
+		await runGoalHandlers(harness.handlers, "agent_end", event, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		expect(harness.sent).toHaveLength(0);
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+			id: goal?.id,
+			objective: goal?.objective,
+			status: "blocked",
+			consecutiveContinuations: 0,
+			unattendedContinuations: 0,
+		});
+	});
+
+	it.each([
+		["overload", "overloaded_error", undefined],
+		["unknown infrastructure", "upstream connection closed", undefined],
+		["provider watchdog", "Idle timeout waiting for provider stream after 1000ms", "provider"],
+		["system recovery", "Provider stream start timed out after 1000ms", "system"],
+	] as const)("preserves one settled recovery for %s", async (_name, errorMessage, abortSource) => {
+		const { harness, ctx, goal } = await setupGoal();
+		const event: AgentEndEvent = {
+			type: "agent_end",
+			messages: [fauxAssistantMessage("", { stopReason: "error", errorMessage })],
+			willRetry: false,
+			abortSource,
+			aborted: abortSource !== undefined,
+		};
+
+		await runGoalHandlers(harness.handlers, "agent_end", event, ctx);
+		expect(harness.sent).toHaveLength(0);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.customType).toBe("goal-continuation");
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+			id: goal?.id,
+			status: "active",
+			consecutiveContinuations: 1,
+			unattendedContinuations: 1,
+		});
+	});
+
+	it.each([CODEX_POLICY_ERROR, "overloaded_error"])(
+		"leaves an explicit retry owner in control: %s",
+		async (errorMessage) => {
+			const { harness, ctx } = await setupGoal();
+			await runGoalHandlers(
+				harness.handlers,
+				"agent_end",
+				{
+					type: "agent_end",
+					messages: [fauxAssistantMessage("", { stopReason: "error", errorMessage })],
+					willRetry: true,
+				},
+				ctx,
+			);
+			await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+			expect(harness.sent).toHaveLength(0);
+			expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+				status: "active",
+				consecutiveContinuations: 0,
+			});
+		},
+	);
+
+	it("does not treat ordinary assistant text about safety blocks as a policy error", async () => {
+		const { harness, ctx } = await setupGoal();
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [fauxAssistantMessage(CODEX_POLICY_ERROR)],
+				willRetry: false,
+			},
+			ctx,
+		);
+		expect(harness.sent).toHaveLength(1);
+	});
+
+	it("disarms a live monitor backstop on policy rejection, including system abort provenance", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await setupGoal();
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [fauxAssistantMessage("Waiting")],
+				willRetry: false,
+			},
+			ctx,
+		);
+		expect(harness.events.emitted.some((event) => event.channel === "goal_continuation_scheduled")).toBe(true);
+
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{
+				type: "agent_end",
+				aborted: true,
+				abortSource: "system",
+				willRetry: false,
+				messages: [fauxAssistantMessage("", { stopReason: "error", errorMessage: CODEX_POLICY_ERROR })],
+			},
+			ctx,
+		);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+		await vi.runOnlyPendingTimersAsync();
+
+		expect(harness.sent).toHaveLength(0);
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+			status: "blocked",
+			consecutiveContinuations: 0,
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
+++ b/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
@@ -1,5 +1,6 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPENAI_CODEX_MODELS } from "../../../ai/src/providers/openai-codex.models.ts";
 import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import { goalStoreRef } from "../../src/core/extensions/builtin/goal/store-ref.ts";
 import type { AgentEndEvent } from "../../src/core/extensions/types.ts";
@@ -12,6 +13,12 @@ import {
 
 const CODEX_POLICY_ERROR =
 	"Codex error: This request was blocked by our safety systems. Reason: Potentially unintended activity.";
+
+// The predicate's Codex identity is a literal copy of the api id the shipped
+// Codex catalog stamps on every message. Reading the catalog back keeps the two
+// pinned together: renaming the api in `packages/ai` fails here instead of
+// silently disarming the #1520 guard while every hardcoded case stays green.
+const CODEX_CATALOG_APIS = [...new Set(Object.values(OPENAI_CODEX_MODELS).map((model) => model.api))];
 
 // `fauxAssistantMessage` hardcodes `api`, so the Codex identity this predicate
 // now requires has to be applied to the returned message.
@@ -159,6 +166,26 @@ describe("terminal policy goal recovery", () => {
 		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
 			id: goal?.id,
 			status: "active",
+		});
+	});
+
+	it.each(CODEX_CATALOG_APIS)("blocks the diagnostic on the shipped Codex catalog api %s", async (api) => {
+		const { harness, ctx, goal } = await setupGoal();
+		const event: AgentEndEvent = {
+			type: "agent_end",
+			messages: [{ ...codexPolicyMessage(), api }],
+			willRetry: false,
+		};
+
+		await runGoalHandlers(harness.handlers, "agent_end", event, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		expect(harness.sent).toHaveLength(0);
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+			id: goal?.id,
+			status: "blocked",
+			consecutiveContinuations: 0,
 		});
 	});
 

--- a/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
+++ b/packages/coding-agent/test/suite/goal-policy-rejection.test.ts
@@ -13,6 +13,15 @@ import {
 const CODEX_POLICY_ERROR =
 	"Codex error: This request was blocked by our safety systems. Reason: Potentially unintended activity.";
 
+// `fauxAssistantMessage` hardcodes `api`, so the Codex identity this predicate
+// now requires has to be applied to the returned message.
+function codexPolicyMessage() {
+	return {
+		...fauxAssistantMessage("", { stopReason: "error", errorMessage: CODEX_POLICY_ERROR }),
+		api: "openai-codex-responses" as const,
+	};
+}
+
 async function setupGoal() {
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext([], "policy-rejection");
@@ -33,10 +42,7 @@ describe("terminal policy goal recovery", () => {
 	// Regression for #1520: exercise agent_end routing through the real monitor's
 	// agent_settled admission and sendMessage, not just the error predicate.
 	it.each([
-		[
-			"Codex backend policy error",
-			fauxAssistantMessage("", { stopReason: "error", errorMessage: CODEX_POLICY_ERROR }),
-		],
+		["Codex backend policy error", codexPolicyMessage()],
 		["structured refusal", fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "refusal" } })],
 		[
 			"structured sensitive stop",
@@ -130,6 +136,32 @@ describe("terminal policy goal recovery", () => {
 		},
 	);
 
+	// The unstructured diagnostic is Codex-specific and carries no policy code, so
+	// matching it on any provider would strand an otherwise recoverable goal on a
+	// gateway that happens to emit the same sentence.
+	it.each([
+		["anthropic-messages", "anthropic-messages"],
+		["an unknown gateway", "openai-completions"],
+	])("recovers instead of blocking when %s reports the same diagnostic", async (_name, api) => {
+		const { harness, ctx, goal } = await setupGoal();
+		const event: AgentEndEvent = {
+			type: "agent_end",
+			messages: [{ ...codexPolicyMessage(), api }],
+			willRetry: false,
+		};
+
+		await runGoalHandlers(harness.handlers, "agent_end", event, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_settled", { type: "agent_settled" }, ctx);
+
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.customType).toBe("goal-continuation");
+		expect(await readGoal(goalStoreRef(ctx.sessionManager, ctx.cwd))).toMatchObject({
+			id: goal?.id,
+			status: "active",
+		});
+	});
+
 	it("does not treat ordinary assistant text about safety blocks as a policy error", async () => {
 		const { harness, ctx } = await setupGoal();
 		await runGoalHandlers(
@@ -170,7 +202,7 @@ describe("terminal policy goal recovery", () => {
 				aborted: true,
 				abortSource: "system",
 				willRetry: false,
-				messages: [fauxAssistantMessage("", { stopReason: "error", errorMessage: CODEX_POLICY_ERROR })],
+				messages: [codexPolicyMessage()],
 			},
 			ctx,
 		);


### PR DESCRIPTION
## Summary

Stop an active goal from automatically resubmitting a request after a terminal policy rejection. The reported Codex error was classified as non-retryable by ordinary retry handling, but goal recovery still submitted eight hidden continuations before hitting its cap. This change preserves the goal and blocks that recovery path immediately.

Closes #1520.

## Behavior and implementation

- Recognize existing structured classifier refusal/sensitive stops and the exact Codex backend safety diagnostic, only when the retry owner reports `willRetry: false`.
- Persist the active goal as blocked before provider/system recovery routing; synchronize the monitor to clear pending recovery and timers.
- Keep the goal ID, objective, and continuation counts. An explicit goal resume remains available; unrelated input does not automatically restart this policy-blocked goal.
- Preserve infrastructure recovery, explicit retry ownership, and ordinary assistant text that discusses a safety error.

The change is confined to two builtin goal modules, their change tracker, lifecycle tests, and a reusable offline CLI QA fixture/driver. It does not attempt to change the provider's safety decision.

## Verification

- **Failing first:** seven policy assertions failed before the patch; the same fourteen targeted cases passed afterward.
- **Related regression suite:** 127 tests passed.
- **Lead-run real source CLI:** `node .agents/skills/senpi-qa/scripts/scenarios/goal-policy-rejection-qa.mjs --self-test` passed. The policy scenario made the goal-creation call plus the rejected call, then **zero continuations**. The infrastructure control made **one continuation** and completed.
- Both CLI sandboxes and child clients were cleaned; the real authentication file was unchanged. The provider is an in-process faux fixture, with no external requests.
- Workspace `npm run build`, TypeScript, scoped Biome, and `bun run check` exited 0.
- Full coding-agent suite: 10,251 passed, four lifecycle tests failed, 39 existing skips. Re-running all four affected files without file parallelism passed all 93 tests. The full concurrent suite is **not** claimed green.

Sanitized local evidence is under `local-ignore/qa-evidence/20260909-terminal-policy-goal-recovery/`: `red.txt`, `green.txt`, `lead-cli/result.json`, `lead-build.txt`, `lead-check.txt`, `lead-package-tests-built.txt`, and `lead-failed-files-isolated.txt`. The committed QA driver makes the principal behavior reproducible.

## Risks and limits

The original provider response retained only a generic safety diagnostic, not the backend classifier rationale; the offending input remains unknown. This patch fixes repeated requests, not the initial server decision. OMO's separate plan-continuation hooks need their companion guard when those extensions are active.

`bun run check` autoformatted two untouched baseline files; those unrelated formatting changes were restored. LSP tooling is unavailable locally, so compiler and Biome checks are reported instead. No dependencies or lockfiles changed.

AI-assisted implementation and report; local evidence and production diff were independently inspected by the lead coding session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops active goals from auto-recovering after terminal policy rejections. Previously, a Codex safety block or classifier refusal let goal recovery queue up to eight hidden continuations; now the goal is persisted as blocked before recovery routing, and that recovery path is canceled. Closes #1520.

**Bug Fixes**
- Detects structured refusals and sensitive stops plus the exact Codex safety diagnostic, only when the retry owner reports `willRetry: false`.
- Trusts the unstructured Codex diagnostic only on the `openai-codex-responses` API; other providers or gateways emitting the same sentence keep infrastructure recovery.
- Pins that identity gate to the `OPENAI_CODEX_MODELS` catalog, so renaming the API id there fails the test suite instead of silently restoring the recovery loop.
- Preserves the goal ID, objective, and continuation counts; only an explicit goal resume restarts a policy-blocked goal.
- Leaves infrastructure recovery, explicit retry ownership, and ordinary assistant text about safety errors unchanged.

<sup>Written for commit b01734280ff60113b1d7c050a8548a2a1b0a73fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

