### PR TITLE
fix(coding-agent): record model switches the session refuses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,20 @@
 
 - A bare `.` submitted on a session that already has messages no longer renders as a user message in the TUI. It stays the manual-continue shortcut the session delivers as a hidden continuation, so nothing is painted for it while idle or while steering an active turn; a `.` on an empty session and a `.` carrying image attachments remain ordinary user input ([#1569](https://github.com/code-yeongyu/senpi/issues/1569))
 
+- A model switch the session refuses is now recorded instead of vanishing: every
+  guard (`setModel`/`setSessionModel`, the revalidation after `model_select`, and
+  favorite cycling) appends a `model_change_rejected` session entry carrying the
+  budget projection numbers and emits a matching event, and the refusal keeps its
+  compaction remedy only when there is context to compact. A refused favorite
+  cycle no longer records a `model_change` or writes the global default for a
+  model that never ran, so the session and every new session stay on the model
+  that is actually active. The new entry is bookkeeping everywhere it is
+  consumed: it never reaches the model, keeps Claude SDK OAuth continuity across
+  resume, renders and searches in `/tree`, crosses the RPC
+  `append_session_entry` seam, and stays out of RPC status snapshots
+  ([#1528](https://github.com/code-yeongyu/senpi/pull/1528) by
+  [@rlaope](https://github.com/rlaope))
+
 - Claude SDK OAuth reattach no longer closes a healthy resumed query when
   normal completed-request cleanup aborts the request controller; the
   initialization cancellation listener is detached once initialization settles,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4867,7 +4867,7 @@ export class AgentSession {
 	}
 
 	/**
-	 * #1526: both guards below reject before `_switchActiveModel` appends its
+	 * #1526: every switch guard rejects before `_switchActiveModel` appends its
 	 * `model_change`, so a refused switch used to leave no entry, no event, and
 	 * no log line - indistinguishable from a switch the user never attempted.
 	 * Record the refusal, then rethrow the original error unchanged.
@@ -4895,19 +4895,41 @@ export class AgentSession {
 		this._emit({ type: "model_change_rejected", model, reason, detail, ...numbers });
 	}
 
+	/**
+	 * The admission only selects wording, and the switch wording's remedy
+	 * ("Compact the session, ...") is executable only when there is context to
+	 * compact. `_setModel` is also reachable from `session_start` (the
+	 * `recommended-models` builtin switches the model there), so derive the
+	 * admission from the branch instead of hardcoding a switch: with conversation
+	 * context this is a switch, on an empty session it is still a cold start.
+	 */
+	private _modelSwitchAdmission(): ModelUsabilityAdmission {
+		return this.sessionManager.hasContextMessages() ? "switch" : "start";
+	}
+
+	/**
+	 * The single guard seam for a model switch (#1526): every site that can
+	 * refuse a switch - the `_setModel` pre-flight, the post-`model_select`
+	 * revalidation in `_switchActiveModel`, and both cycle guards - records the
+	 * refusal and rethrows the original error unchanged, so no refusal is
+	 * observable on one path and invisible on its sibling.
+	 */
+	private _assertModelUsableForSwitch(model: Model<Api>, liveContextTokens: number): void {
+		try {
+			this.assertModelUsable(model, liveContextTokens, { admission: this._modelSwitchAdmission() });
+		} catch (error) {
+			this._recordRejectedModelChange(model, error);
+			throw error;
+		}
+	}
+
 	private async _setModel(
 		model: Model<Api>,
 		updateGlobalDefaults: boolean,
 	): Promise<SystemPromptChangeEvent | undefined> {
-		try {
-			// Classify as a switch, not a cold start: only the "switch" admission
-			// names the remedy ("Compact the session, then revalidate and retry the
-			// model switch"), which is the whole point of the message here.
-			this.assertModelUsable(model, this._getDownswitchLiveContextTokens(model), { admission: "switch" });
-			if (!(await this._modelRuntime.checkAuth(model.provider))) {
-				throw new Error(`No API key for ${model.provider}/${model.id}`);
-			}
-		} catch (error) {
+		this._assertModelUsableForSwitch(model, this._getDownswitchLiveContextTokens(model));
+		if (!(await this._modelRuntime.checkAuth(model.provider))) {
+			const error = new Error(`No API key for ${model.provider}/${model.id}`);
 			this._recordRejectedModelChange(model, error);
 			throw error;
 		}
@@ -5000,7 +5022,7 @@ export class AgentSession {
 			const systemPromptChange = opts.emitModelSelect
 				? await this._emitModelSelect(model, previousModel, opts.modelSelectSource)
 				: undefined;
-			this.assertModelUsable(model, liveContextTokens);
+			this._assertModelUsableForSwitch(model, liveContextTokens);
 			if (opts.appendSessionEntry) {
 				this.sessionManager.appendModelChange(
 					model.provider,
@@ -5106,7 +5128,10 @@ export class AgentSession {
 			const alternatives = favoriteModels.filter((entry) => !modelsAreEqual(entry.model, currentModel));
 			const onlyAlternative = alternatives.length === 1 ? alternatives[0] : undefined;
 			if (onlyAlternative) {
-				this.assertModelUsable(onlyAlternative.model, this._getDownswitchLiveContextTokens(onlyAlternative.model));
+				this._assertModelUsableForSwitch(
+					onlyAlternative.model,
+					this._getDownswitchLiveContextTokens(onlyAlternative.model),
+				);
 			}
 			return {
 				model: currentModel,
@@ -5117,7 +5142,7 @@ export class AgentSession {
 		}
 		const next = favoriteModels[selectedIndex];
 		const liveContextTokens = this._getDownswitchLiveContextTokens(next.model);
-		this.assertModelUsable(next.model, liveContextTokens);
+		this._assertModelUsableForSwitch(next.model, liveContextTokens);
 		const invalidatesCompaction =
 			this._modelSelectionChangesContext(currentModel, next.model) ||
 			currentModel?.provider !== next.model.provider ||
@@ -5130,8 +5155,6 @@ export class AgentSession {
 		const thinking = this._getThinkingForModelSwitch(next.model, next.thinkingLevel, next.thinkingSelection);
 
 		this.agent.state.model = next.model;
-		this.sessionManager.appendModelChange(next.model.provider, next.model.id);
-		this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
 		const previousTier = this._currentServiceTier;
 		const previousFastMode = this.isFastModeActive();
 		this._currentServiceTier = this._resolveServiceTier(next.model, next.serviceTier);
@@ -5139,19 +5162,25 @@ export class AgentSession {
 		// Apply thinking level and provenance from the favorite projection or remembered preference.
 		this._setThinkingLevel(thinking.level, false, thinking.selection);
 
-		// Post-switch, same contract as _switchActiveModel: the level in force AFTER the cycle.
-		this._emit({
-			type: "model_changed",
-			model: next.model,
-			thinkingLevel: this.thinkingLevel,
-			source: "cycle",
-		});
-		this._emitServiceTierChangeIfNeeded(previousTier, previousFastMode);
-
 		const previousSystemPrompt = this.agent.state.systemPrompt;
 		try {
 			const systemPromptChange = await this._emitModelSelect(next.model, currentModel, "cycle");
-			this.assertModelUsable(next.model, liveContextTokens);
+			// #1526: the `model_select` hook may have grown the system prompt, so the
+			// switch is not decided yet. Nothing durable - no `model_change`, no global
+			// default - may be written before this guard accepts, or a refused cycle
+			// would resume on a model that never ran (the ordering `_switchActiveModel`
+			// already uses).
+			this._assertModelUsableForSwitch(next.model, liveContextTokens);
+			this.sessionManager.appendModelChange(next.model.provider, next.model.id);
+			this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+			// Post-switch, same contract as _switchActiveModel: the level in force AFTER the cycle.
+			this._emit({
+				type: "model_changed",
+				model: next.model,
+				thinkingLevel: this.thinkingLevel,
+				source: "cycle",
+			});
+			this._emitServiceTierChangeIfNeeded(previousTier, previousFastMode);
 
 			const cycleResult: ModelCycleResult = {
 				model: next.model,
@@ -5167,6 +5196,7 @@ export class AgentSession {
 			if (currentModel) this.agent.state.model = currentModel;
 			else delete (this.agent.state as { model?: Model<Api> }).model;
 			this.agent.state.systemPrompt = previousSystemPrompt;
+			this._currentServiceTier = previousTier;
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -492,6 +492,18 @@ export type AgentSessionEvent =
 			thinkingLevel: ThinkingLevel;
 			source: ModelSelectSource;
 	  }
+	/** A switch the session refused; recorded so the attempt survives (#1526). */
+	| {
+			type: "model_change_rejected";
+			model: Model<any>;
+			reason: "context-budget" | "auth";
+			detail: string;
+			contextWindow?: number;
+			liveContextTokens?: number;
+			requiredTokens?: number;
+			shortfallTokens?: number;
+			safetyMarginProfile?: string;
+	  }
 	| {
 			type: "model_change_skipped";
 			model: Model<any>;
@@ -4854,13 +4866,50 @@ export class AgentSession {
 		return this._setModel(model, false);
 	}
 
+	/**
+	 * #1526: both guards below reject before `_switchActiveModel` appends its
+	 * `model_change`, so a refused switch used to leave no entry, no event, and
+	 * no log line - indistinguishable from a switch the user never attempted.
+	 * Record the refusal, then rethrow the original error unchanged.
+	 */
+	private _recordRejectedModelChange(model: Model<Api>, error: unknown): void {
+		const budget = error instanceof ModelUsabilityBudgetError ? error.projection : undefined;
+		const detail = error instanceof Error ? error.message : String(error);
+		const reason = budget ? "context-budget" : "auth";
+		const numbers = budget
+			? {
+					contextWindow: budget.contextWindow,
+					liveContextTokens: budget.liveContextTokens,
+					requiredTokens: budget.requiredTokens,
+					shortfallTokens: budget.shortfallTokens,
+					safetyMarginProfile: budget.safetyMarginProfile,
+				}
+			: {};
+		this.sessionManager.appendModelChangeRejected({
+			provider: model.provider,
+			modelId: model.id,
+			reason,
+			detail,
+			...numbers,
+		});
+		this._emit({ type: "model_change_rejected", model, reason, detail, ...numbers });
+	}
+
 	private async _setModel(
 		model: Model<Api>,
 		updateGlobalDefaults: boolean,
 	): Promise<SystemPromptChangeEvent | undefined> {
-		this.assertModelUsable(model, this._getDownswitchLiveContextTokens(model));
-		if (!(await this._modelRuntime.checkAuth(model.provider))) {
-			throw new Error(`No API key for ${model.provider}/${model.id}`);
+		try {
+			// Classify as a switch, not a cold start: only the "switch" admission
+			// names the remedy ("Compact the session, then revalidate and retry the
+			// model switch"), which is the whole point of the message here.
+			this.assertModelUsable(model, this._getDownswitchLiveContextTokens(model), { admission: "switch" });
+			if (!(await this._modelRuntime.checkAuth(model.provider))) {
+				throw new Error(`No API key for ${model.provider}/${model.id}`);
+			}
+		} catch (error) {
+			this._recordRejectedModelChange(model, error);
+			throw error;
 		}
 
 		// A manual model change abandons any active fallback window; if a fallback

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -17,6 +17,26 @@
 
 - LOW: the manual-continue interception at the top of `prompt()`.
 
+## Record model switches the session refuses (2026-09-09)
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts` records a refused model switch before rethrowing: `_setModel` wraps its usability and auth guards, appends a `model_change_rejected` session entry, and emits a matching `model_change_rejected` event carrying the budget projection numbers. The same call now classifies the check as `admission: "switch"`, so the guard produces its switch-specific remedy instead of the cold-start wording.
+- `packages/coding-agent/src/core/session-manager.ts` adds the `ModelChangeRejectedEntry` type and `appendModelChangeRejected()`.
+
+### Why
+
+- Both guards reject before `_switchActiveModel` appends its `model_change`, so a refused switch left no entry, no event, and no log line; an attempted-and-rejected switch was indistinguishable from one the user never made (#1526). The `admission` default only infers `"switch"` when `liveContextTokens > 0`, which is not true on this path whenever the target's usable context is not smaller than the current model's, so the message told the user the model "cannot start" and omitted the compaction remedy.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/agent-session.ts` owns the switch guards and the session-entry append; an extension observes model changes only after they are applied and never sees the rejected path.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts`: the `AgentSessionEvent` union and the `_setModel` guard block.
+- `packages/coding-agent/src/core/session-manager.ts`: the `SessionEntry` union and the append helpers near `appendModelChange`.
+
 ## Leaf token and typed errors for assistant edits (2026-09-10)
 
 ### What changed
@@ -355,7 +375,6 @@
 
 - LOW: `resource-loader.ts` around skill path assembly and the former private package-identity helpers.
 
-
 ## 2026-09-07 - Dedupe skills from duplicate copies of one package
 
 ## 2026-09-07 - Overflow recovery outlives the auto-compaction flag; session-scoped toggle (#1422)
@@ -585,7 +604,6 @@
 
 - LOW: `skills.ts` renderer body and `skills.test.ts` location assertion.
 
-
 ## 2026-09-04 - Route bare "." submissions through a hidden manual-continue directive
 
 ### What changed
@@ -609,7 +627,6 @@
 - MEDIUM: `packages/coding-agent/src/core/agent-session.ts` — the top of `prompt()`'s `try` block (before the extension input emission), where queue-admission branches frequently change.
 - LOW: `packages/coding-agent/src/core/manual-continue.ts` (new file, no conflicts).
 - LOW: `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts` — the single assertion swap in the "dot retry" case.
-
 
 ## 2026-09-04 - Failed provider turns leave the LLM context on every lane
 
@@ -660,7 +677,6 @@
 ### Expected merge conflict zones
 
 - LOW: the `model` bookkeeping inside `getSessionContextSettings()` in `session-manager.ts`.
-
 
 ## 2026-09-04 - Gate next-turn compaction on real provider admission
 
@@ -919,7 +935,6 @@
 
 - LOW: the `activeToolNamesChanged` branch in `setActiveToolsByName()`.
 
-
 ## 2026-08-30 - Drop the classic host-UI no-op stub
 
 - `agent-session.ts`: `_emitEntryAppended` only fires while the session is bound in `rpc`
@@ -930,7 +945,6 @@
 - `agent-session-prompt.test.ts` binds `mode: "rpc"` before asserting durable prompt entries,
   so the new-behavior test exercises the lane the contract actually covers instead of the
   default print lane.
-
 
 ## 2026-08-30 - Experimental workflow eval-only policy
 
@@ -1681,7 +1695,6 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 
 - `auth-storage.ts` around `acquireLockSyncWithRetry` (line ~95).
 
-
 ## 2026-08-21 - Settings reads are lock-free; writes publish atomically via temp+rename
 
 ### What changed
@@ -1699,7 +1712,6 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 ### Expected merge conflict zones
 
 - `settings-manager.ts` around `withLock` (line ~555) and the `fs` import list (line ~5).
-
 
 ## 2026-08-21 - Settings-lock retry sleeps instead of spinning; retry-fallback canonicalization memoized
 
@@ -1719,7 +1731,6 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 ### Expected merge conflict zones
 
 - `settings-manager.ts` around `acquireLockSyncWithRetry` (line ~527). `retry-fallback/controller.ts` around `nextCandidate`/`hasConfiguredChain` and the new `canonicalChains` private method.
-
 
 ## 2026-08-20 - Resume picker caches exact streaming summaries
 
@@ -2096,7 +2107,6 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 - `core/agent-session.ts` `sendCustomMessage` wait condition, and the goal extension `session_start`
   suppressed-load branch in `core/extensions/builtin/goal/index.ts`.
 
-
 ## 2026-08-25 - Harden provider retry watchdog ownership and backoff
 
 ### What changed
@@ -2161,7 +2171,6 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 
 - `core/provider-timeout-retry.ts` plan construction, and the retry-bound constants in
   `test/suite/regressions/provider-idle-recovery.test.ts`.
-
 
 ## Queue typed input admitted during auto-compaction (2026-08-18)
 
@@ -5353,5 +5362,4 @@ unrelated fallback bus, silently disconnecting `pi.rpc.emit` on trust-requiring 
 - LOW: fallback switch admission in
   packages/coding-agent/src/core/agent-session.ts and candidate reservation in
   packages/coding-agent/src/core/retry-fallback/controller.ts.
-
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -19,22 +19,25 @@
 
 ## Record model switches the session refuses (2026-09-09)
 
+## Record model switches the session refuses (2026-09-10)
+
+
 ### What changed
 
-- `packages/coding-agent/src/core/agent-session.ts` records a refused model switch before rethrowing: `_setModel` wraps its usability and auth guards, appends a `model_change_rejected` session entry, and emits a matching `model_change_rejected` event carrying the budget projection numbers. The same call now classifies the check as `admission: "switch"`, so the guard produces its switch-specific remedy instead of the cold-start wording.
-- `packages/coding-agent/src/core/session-manager.ts` adds the `ModelChangeRejectedEntry` type and `appendModelChangeRejected()`.
+- `packages/coding-agent/src/core/agent-session.ts` records every refused model switch before rethrowing. `_assertModelUsableForSwitch()` is the single guard seam: the `_setModel` pre-flight, the post-`model_select` revalidation in `_switchActiveModel`, and both `_cycleFavoriteModel` guards (the sole-alternative case and the pre/post-`model_select` pair) now funnel through it, so each appends a `model_change_rejected` session entry, emits the matching event with the budget projection numbers, and rethrows the original error unchanged. The `_setModel` auth refusal records the same entry with `reason: "auth"`. `_modelSwitchAdmission()` derives the admission from the branch (`hasContextMessages()`) instead of hardcoding `"switch"`, so a refusal only promises the compaction remedy when there is context to compact. `_cycleFavoriteModel` no longer appends its `model_change`, writes the global default, or emits `model_changed`/`service_tier_changed` before the post-`model_select` guard accepts, and its catch restores the previous service tier.
+- `packages/coding-agent/src/core/session-manager.ts` adds the `ModelChangeRejectedEntry` type (documenting that it follows the shared pre-assistant `_persist` buffering contract) and `appendModelChangeRejected()`.
 
 ### Why
 
-- Both guards reject before `_switchActiveModel` appends its `model_change`, so a refused switch left no entry, no event, and no log line; an attempted-and-rejected switch was indistinguishable from one the user never made (#1526). The `admission` default only infers `"switch"` when `liveContextTokens > 0`, which is not true on this path whenever the target's usable context is not smaller than the current model's, so the message told the user the model "cannot start" and omitted the compaction remedy.
+- Every guard rejects before `_switchActiveModel` appends its `model_change`, so a refused switch left no entry, no event, and no log line; an attempted-and-rejected switch was indistinguishable from one the user never made (#1526). Recording it on one guard only would have left sibling calls of the same public API silent, and a refused *cycle* was strictly worse than silent: it appended a real `model_change` and wrote the global default before its post-`model_select` guard ran, so the session resumed - and every new session started - on a model that was refused and never answered. The `admission` default only infers `"switch"` when `liveContextTokens > 0`, so the message told the user the model "cannot start" and omitted the compaction remedy; hardcoding `"switch"` instead promised that remedy on the `session_start` caller (`recommended-models`), where there is nothing to compact.
 
 ### Why an extension could not handle it
 
-- `packages/coding-agent/src/core/agent-session.ts` owns the switch guards and the session-entry append; an extension observes model changes only after they are applied and never sees the rejected path.
+- `packages/coding-agent/src/core/agent-session.ts` owns the switch guards, the session-entry append, and the settings write; an extension observes model changes only after they are applied and never sees the rejected path.
 
 ### Expected merge conflict zones
 
-- `packages/coding-agent/src/core/agent-session.ts`: the `AgentSessionEvent` union and the `_setModel` guard block.
+- `packages/coding-agent/src/core/agent-session.ts`: the `AgentSessionEvent` union, the `_setModel` guard block, and the `_cycleFavoriteModel` commit block.
 - `packages/coding-agent/src/core/session-manager.ts`: the `SessionEntry` union and the append helpers near `appendModelChange`.
 
 ## Leaf token and typed errors for assistant edits (2026-09-10)
@@ -375,6 +378,7 @@
 
 - LOW: `resource-loader.ts` around skill path assembly and the former private package-identity helpers.
 
+
 ## 2026-09-07 - Dedupe skills from duplicate copies of one package
 
 ## 2026-09-07 - Overflow recovery outlives the auto-compaction flag; session-scoped toggle (#1422)
@@ -604,6 +608,7 @@
 
 - LOW: `skills.ts` renderer body and `skills.test.ts` location assertion.
 
+
 ## 2026-09-04 - Route bare "." submissions through a hidden manual-continue directive
 
 ### What changed
@@ -627,6 +632,7 @@
 - MEDIUM: `packages/coding-agent/src/core/agent-session.ts` — the top of `prompt()`'s `try` block (before the extension input emission), where queue-admission branches frequently change.
 - LOW: `packages/coding-agent/src/core/manual-continue.ts` (new file, no conflicts).
 - LOW: `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts` — the single assertion swap in the "dot retry" case.
+
 
 ## 2026-09-04 - Failed provider turns leave the LLM context on every lane
 
@@ -677,6 +683,7 @@
 ### Expected merge conflict zones
 
 - LOW: the `model` bookkeeping inside `getSessionContextSettings()` in `session-manager.ts`.
+
 
 ## 2026-09-04 - Gate next-turn compaction on real provider admission
 
@@ -935,6 +942,7 @@
 
 - LOW: the `activeToolNamesChanged` branch in `setActiveToolsByName()`.
 
+
 ## 2026-08-30 - Drop the classic host-UI no-op stub
 
 - `agent-session.ts`: `_emitEntryAppended` only fires while the session is bound in `rpc`
@@ -945,6 +953,7 @@
 - `agent-session-prompt.test.ts` binds `mode: "rpc"` before asserting durable prompt entries,
   so the new-behavior test exercises the lane the contract actually covers instead of the
   default print lane.
+
 
 ## 2026-08-30 - Experimental workflow eval-only policy
 
@@ -1695,6 +1704,7 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 
 - `auth-storage.ts` around `acquireLockSyncWithRetry` (line ~95).
 
+
 ## 2026-08-21 - Settings reads are lock-free; writes publish atomically via temp+rename
 
 ### What changed
@@ -1712,6 +1722,7 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 ### Expected merge conflict zones
 
 - `settings-manager.ts` around `withLock` (line ~555) and the `fs` import list (line ~5).
+
 
 ## 2026-08-21 - Settings-lock retry sleeps instead of spinning; retry-fallback canonicalization memoized
 
@@ -1731,6 +1742,7 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 ### Expected merge conflict zones
 
 - `settings-manager.ts` around `acquireLockSyncWithRetry` (line ~527). `retry-fallback/controller.ts` around `nextCandidate`/`hasConfiguredChain` and the new `canonicalChains` private method.
+
 
 ## 2026-08-20 - Resume picker caches exact streaming summaries
 
@@ -2107,6 +2119,7 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 - `core/agent-session.ts` `sendCustomMessage` wait condition, and the goal extension `session_start`
   suppressed-load branch in `core/extensions/builtin/goal/index.ts`.
 
+
 ## 2026-08-25 - Harden provider retry watchdog ownership and backoff
 
 ### What changed
@@ -2171,6 +2184,7 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 
 - `core/provider-timeout-retry.ts` plan construction, and the retry-bound constants in
   `test/suite/regressions/provider-idle-recovery.test.ts`.
+
 
 ## Queue typed input admitted during auto-compaction (2026-08-18)
 
@@ -5362,4 +5376,5 @@ unrelated fallback bus, silently disconnecting `pi.rpc.emit` on trust-requiring 
 - LOW: fallback switch admission in
   packages/coding-agent/src/core/agent-session.ts and candidate reservation in
   packages/coding-agent/src/core/retry-fallback/controller.ts.
+
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,23 @@
 # claude-sdk-oauth
 
+## Recording a refused model switch keeps the stored binding (2026-09-10)
+
+### What changed
+
+- `session-binding.ts`: `model_change_rejected` joins `LEDGER_ONLY_ENTRY_TYPES`.
+
+### Why
+
+- `bindingFromStoredBranch` fails closed on any entry after the committed assistant that the model could see. The new `model_change_rejected` entry (#1526) is never projected into the LLM context, but it was absent from the set, so recording a refused switch made a later resume discard the stored SDK session: fresh upstream session, full context re-send, prompt-cache loss - caused by an entry the model never sees.
+
+### Why an extension could not handle it
+
+- The set is the builtin's own resume-admission policy.
+
+### Expected merge conflict zones
+
+- LOW: `LEDGER_ONLY_ENTRY_TYPES`.
+
 ## 2026-09-10 - Detach completed resume initialization abort listeners
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
@@ -141,6 +141,9 @@ const LEDGER_ONLY_ENTRY_TYPES: ReadonlySet<string> = new Set([
 	"session_info",
 	"thinking_level_change",
 	"model_change",
+	// A refused switch (#1526) is bookkeeping the model never sees; omitting it
+	// here made recording the refusal destroy the stored binding on resume.
+	"model_change_rejected",
 	"configuration_update",
 ]);
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -129,6 +129,30 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	originalModelId?: string;
 }
 
+/**
+ * A model switch the session refused. Recorded because the refusal happens
+ * before any `model_change` is appended, which left an attempted-and-rejected
+ * switch indistinguishable from one the user never made (#1526).
+ */
+export interface ModelChangeRejectedEntry extends SessionEntryBase {
+	type: "model_change_rejected";
+	provider: string;
+	modelId: string;
+	reason: "context-budget" | "auth";
+	/**
+	 * The guard's own explanation, including its remedy. Named `detail` rather
+	 * than `message` so this entry stays structurally distinct from
+	 * `SessionMessageEntry`, whose `message` is an object.
+	 */
+	detail: string;
+	/** Budget numbers; present only for the context-budget reason. */
+	contextWindow?: number;
+	liveContextTokens?: number;
+	requiredTokens?: number;
+	shortfallTokens?: number;
+	safetyMarginProfile?: string;
+}
+
 export interface CompactionEntry<T = unknown> extends SessionEntryBase {
 	type: "compaction";
 	summary: string;
@@ -209,6 +233,7 @@ export type SessionEntry =
 	| ThinkingLevelChangeEntry
 	| ConfigurationUpdateEntry
 	| ModelChangeEntry
+	| ModelChangeRejectedEntry
 	| CompactionEntry
 	| BranchSummaryEntry
 	| CustomEntry
@@ -1237,6 +1262,24 @@ export class SessionManager {
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			reasoning: { effort },
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Append a refused model switch (#1526). The refusal happens before any
+	 * `model_change` is written, so without this the attempt leaves no trace.
+	 */
+	appendModelChangeRejected(
+		details: Omit<ModelChangeRejectedEntry, "type" | "id" | "parentId" | "timestamp">,
+	): string {
+		const entry: ModelChangeRejectedEntry = {
+			type: "model_change_rejected",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			...details,
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -133,6 +133,12 @@ export interface ModelChangeEntry extends SessionEntryBase {
  * A model switch the session refused. Recorded because the refusal happens
  * before any `model_change` is appended, which left an attempted-and-rejected
  * switch indistinguishable from one the user never made (#1526).
+ *
+ * Durability follows the shared session-file contract, it is not special-cased:
+ * `_persist` buffers every entry until the branch holds an assistant message,
+ * so a refusal recorded before the session's first assistant reply reaches the
+ * JSONL only when that reply flushes the buffer. A session that never gets one
+ * keeps the record in memory for its lifetime and never writes a file.
  */
 export interface ModelChangeRejectedEntry extends SessionEntryBase {
 	type: "model_change_rejected";

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -16,6 +16,24 @@
 
 - LOW: `OptimisticUserEchoController`, `InteractiveUserInput`, and the echo call sites in `setupEditorSubmitHandler` / `handleFollowUp`.
 
+## /tree renders a refused model switch (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/tree-selector.ts`: `model_change_rejected` gains a render case (`[model rejected: <id> (<reason>)]`, warning colour), search text (`model rejected <id> <reason>`), and membership in the settings/bookkeeping set hidden from the default view.
+
+### Why
+
+- Without the cases the entry fell to `default: result = ""`, so a refused switch (#1526) appeared in `/tree`'s default view as a blank, unsearchable row - the one entry browser the product ships could not reconstruct the incident the record exists for.
+
+### Why an extension could not handle it
+
+- The tree selector owns entry rendering, filtering and search text; extensions cannot contribute renderers for core entry types.
+
+### Expected merge conflict zones
+
+- LOW: the `isSettingsEntry` predicate, `entrySearchText`, and the entry render switch.
+
 ## 2026-09-10 - /tree edits carry the leaf token and reach shared hosts
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -360,6 +360,7 @@ class TreeList implements Component {
 				entry.type === "label" ||
 				entry.type === "custom" ||
 				entry.type === "model_change" ||
+				entry.type === "model_change_rejected" ||
 				entry.type === "thinking_level_change" ||
 				entry.type === "session_info";
 
@@ -601,6 +602,9 @@ class TreeList implements Component {
 			case "model_change":
 				parts.push("model", entry.modelId);
 				break;
+			case "model_change_rejected":
+				parts.push("model rejected", entry.modelId, entry.reason);
+				break;
 			case "thinking_level_change":
 				parts.push("thinking", entry.thinkingLevel);
 				break;
@@ -841,6 +845,9 @@ class TreeList implements Component {
 				break;
 			case "model_change":
 				result = theme.fg("dim", `[model: ${entry.modelId}]`);
+				break;
+			case "model_change_rejected":
+				result = theme.fg("warning", `[model rejected: ${entry.modelId} (${entry.reason})]`);
 				break;
 			case "thinking_level_change":
 				result = theme.fg("dim", `[thinking: ${entry.thinkingLevel}]`);

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## The refused-switch entry crosses the RPC seam and stays bookkeeping (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/rpc-input-validation.ts`: `validSessionEntry` accepts `model_change_rejected` (`provider`, `modelId` and `detail` must be strings), so an `append_session_entry` carrying the entry is no longer refused as malformed.
+- `packages/coding-agent/src/modes/rpc/connection-handler.ts`: the deferred-entry gate counts `model_change_rejected` as auto-appended bookkeeping next to `model_change`/`thinking_level_change`, so a session whose only content is a refused switch keeps shipping status snapshots without its entry list.
+
+### Why
+
+- `model_change_rejected` (#1526) is appended by the session itself on a refused switch. Without the validator branch the entry could not cross the `append_session_entry` seam `rpc-client.ts` exists for, and without the bookkeeping exclusion recording a refusal silently turned every `get_state` for that session into a full entry dump.
+
+### Why an extension could not handle it
+
+- Both are RPC-mode internals: the command validator runs before any extension sees the command, and the state snapshot is assembled by the connection handler.
+
+### Expected merge conflict zones
+
+- LOW: the `validSessionEntry` switch and the `entries` spread inside the state snapshot builder.
+
 ## An aborted question carries the extension's outcome (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -221,7 +221,12 @@ export function buildRpcSessionState(session: AgentSession, lastAbortSource?: Ag
 		!existsSync(session.sessionFile) &&
 		session.sessionManager
 			.getEntries()
-			.some((entry) => entry.type !== "model_change" && entry.type !== "thinking_level_change")
+			.some(
+				(entry) =>
+					entry.type !== "model_change" &&
+					entry.type !== "model_change_rejected" &&
+					entry.type !== "thinking_level_change",
+			)
 			? { entries: session.sessionManager.getEntries() }
 			: {}),
 		steering: typeof session.getSteeringMessages === "function" ? [...session.getSteeringMessages()] : [],

--- a/packages/coding-agent/src/modes/rpc/rpc-input-validation.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-input-validation.ts
@@ -42,6 +42,10 @@ function validSessionEntry(entry: unknown): boolean {
 			return typeof value.thinkingLevel === "string";
 		case "model_change":
 			return typeof value.provider === "string" && typeof value.modelId === "string";
+		case "model_change_rejected":
+			return (
+				typeof value.provider === "string" && typeof value.modelId === "string" && typeof value.detail === "string"
+			);
 		case "compaction":
 			return (
 				typeof value.summary === "string" &&

--- a/packages/coding-agent/test/claude-sdk-oauth-binding-anchor.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-binding-anchor.test.ts
@@ -161,6 +161,16 @@ describe("claude-sdk-oauth stored binding anchor", () => {
 		expect(bindingFromStoredBranch(branch, stored())).toMatchObject({ sdkSessionId: "sdk-1" });
 	});
 
+	// https://github.com/code-yeongyu/senpi/issues/1526
+	// The refused-switch entry is bookkeeping the model never sees; leaving it out
+	// of the ledger-only set made recording a refusal discard the stored binding on
+	// the next resume (fresh upstream session, full context re-send).
+	it("admits a refused model switch after the committed assistant", () => {
+		const branch = [marker(), assistantEntry(), { type: "model_change_rejected" as const, id: "refused-switch" }];
+
+		expect(bindingFromStoredBranch(branch, stored())).toMatchObject({ sdkSessionId: "sdk-1", sentCount: 2 });
+	});
+
 	it("admits custom ledger metadata of any type after the committed assistant", () => {
 		const branch = [
 			marker(),

--- a/packages/coding-agent/test/rpc-input-validation.test.ts
+++ b/packages/coding-agent/test/rpc-input-validation.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
 	MAX_RPC_MESSAGE_CHARACTERS,
+	rpcCommandPayloadError,
 	rpcCommandShapeError,
 	rpcMessageLengthError,
 } from "../src/modes/rpc/rpc-input-validation.ts";
+
+function appendEntryCommand(entry: Record<string, unknown>) {
+	return {
+		type: "append_session_entry",
+		entry: { id: "entry-1", parentId: null, timestamp: new Date().toISOString(), ...entry },
+	};
+}
 
 describe("RPC input validation", () => {
 	it.each([null, [], 42, "str", true])("rejects non-object command input: %j", (command) => {
@@ -24,6 +32,22 @@ describe("RPC input validation", () => {
 			);
 		},
 	);
+
+	// https://github.com/code-yeongyu/senpi/issues/1526
+	it("accepts a refused model switch entry and rejects one without its detail", () => {
+		const rejection = {
+			type: "model_change_rejected",
+			provider: "faux",
+			modelId: "too-small",
+			reason: "context-budget",
+			detail: 'Model "faux/too-small" cannot switch: ...',
+		};
+
+		expect(rpcCommandPayloadError(appendEntryCommand(rejection))).toBeUndefined();
+		expect(rpcCommandPayloadError(appendEntryCommand({ ...rejection, detail: undefined }))).toBe(
+			"append_session_entry entry is malformed.",
+		);
+	});
 
 	it("accepts the maximum text length and ignores non-message commands", () => {
 		expect(

--- a/packages/coding-agent/test/suite/agent-session-model-switch-rejection.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-switch-rejection.test.ts
@@ -1,11 +1,17 @@
+import { existsSync, readFileSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { ModelUsabilityBudgetError } from "../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { buildRpcSessionState } from "../../src/modes/rpc/connection-handler.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
 // https://github.com/code-yeongyu/senpi/issues/1526
-// A switch refused by the context-window guard threw before `_switchActiveModel`
-// ran, so nothing reached the session entries or the event stream: the attempt
-// was indistinguishable from never having been made.
+// A switch refused by the context-window or auth guard threw before
+// `_switchActiveModel` appended its `model_change`, so nothing reached the
+// session entries or the event stream: the attempt was indistinguishable from
+// never having been made. A refused *cycle* was worse: it appended a real
+// `model_change` and wrote the global default before its own post-`model_select`
+// guard ran, so the session resumed on a model that was refused and never ran.
 describe("rejected model switch", () => {
 	const harnesses: Harness[] = [];
 
@@ -13,26 +19,79 @@ describe("rejected model switch", () => {
 		for (const harness of harnesses.splice(0)) harness.cleanup();
 	});
 
-	async function oversizedHarness(): Promise<Harness> {
-		const harness = await createHarness({
-			models: [
-				{ id: "faux-roomy", name: "Roomy", contextWindow: 200_000 },
-				{ id: "faux-small", name: "Too Small", contextWindow: 5_120 },
-			],
-		});
-		harnesses.push(harness);
+	function seedUserContext(harness: Harness): void {
 		harness.sessionManager.appendMessage({
 			role: "user",
 			content: [{ type: "text", text: "context ".repeat(3_000) }],
 			timestamp: Date.now(),
 		});
+	}
+
+	function appendAssistant(harness: Harness, text: string): void {
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			stopReason: "stop",
+			usage: {
+				input: 10,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 11,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+	}
+
+	async function oversizedHarness(options: { persistSession?: boolean } = {}): Promise<Harness> {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-roomy", name: "Roomy", contextWindow: 200_000 },
+				{ id: "faux-small", name: "Too Small", contextWindow: 5_120 },
+				// A second admissible model: the "successful switch" case must move the
+				// session somewhere it was not already, or it proves nothing.
+				{ id: "faux-spacious", name: "Spacious", contextWindow: 200_000 },
+			],
+			...options,
+		});
+		harnesses.push(harness);
+		seedUserContext(harness);
 		return harness;
 	}
 
-	function tooSmall(harness: Harness) {
-		const model = harness.getModel("faux-small");
-		if (!model) throw new Error("expected the small-context faux model");
+	function modelOf(harness: Harness, modelId: string) {
+		const model = harness.getModel(modelId);
+		if (!model) throw new Error(`expected the ${modelId} faux model`);
 		return model;
+	}
+
+	function tooSmall(harness: Harness) {
+		return modelOf(harness, "faux-small");
+	}
+
+	/** A refusal that only the post-`model_select` guard can see: the hook grows the prompt. */
+	async function promptGrowingHarness(): Promise<Harness> {
+		const harness = await createHarness({
+			models: [
+				{ id: "current", contextWindow: 100_000, maxTokens: 4_000 },
+				{ id: "target", contextWindow: 100_000, maxTokens: 4_000 },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", (event) =>
+						event.model.id === "target" ? { systemPrompt: "large ".repeat(100_000) } : undefined,
+					);
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedUserContext(harness);
+		return harness;
 	}
 
 	it("#given a target that cannot hold the live context #when the switch is refused #then a rejection entry is appended", async () => {
@@ -40,8 +99,16 @@ describe("rejected model switch", () => {
 		const target = tooSmall(harness);
 		const before = harness.sessionManager.getBranch().length;
 
-		await expect(harness.session.setModel(target)).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+		const error = await harness.session.setModel(target).then(
+			() => undefined,
+			(reason: unknown) => reason,
+		);
 
+		expect(error).toBeInstanceOf(ModelUsabilityBudgetError);
+		if (!(error instanceof ModelUsabilityBudgetError)) throw new Error("expected a budget refusal");
+		// The admission is derived from the branch, not hardcoded: this session
+		// carries context, so the refusal is a switch and may name compaction.
+		expect(error.projection.admission).toBe("switch");
 		const appended = harness.sessionManager.getBranch().slice(before);
 		const rejection = appended.find((entry) => entry.type === "model_change_rejected");
 		expect(rejection).toMatchObject({
@@ -67,6 +134,8 @@ describe("rejected model switch", () => {
 		expect(typeof recorded.liveContextTokens).toBe("number");
 		// The remedy the guard already names must reach the durable record.
 		expect(recorded.detail).toContain("Compact the session");
+		// The record is bookkeeping: it must never become context the model sees.
+		expect(harness.sessionManager.buildSessionContext().messages).toHaveLength(1);
 	});
 
 	it("#given a refused switch #when subscribers observe the session #then a rejection event carries the same numbers", async () => {
@@ -88,18 +157,163 @@ describe("rejected model switch", () => {
 		await expect(harness.session.setModel(tooSmall(harness))).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
 
 		expect(harness.session.model?.id).toBe(roomy.id);
+		expect(harness.sessionManager.getBranch().filter((entry) => entry.type === "model_change")).toEqual([]);
 	});
 
-	it("#given an admissible target #when the switch succeeds #then no rejection is recorded", async () => {
+	it("#given a genuinely different admissible target #when the switch succeeds #then it is recorded as a change, not a refusal", async () => {
 		const harness = await oversizedHarness();
-		const roomy = harness.getModel();
+		const spacious = modelOf(harness, "faux-spacious");
+		expect(harness.session.model?.id).toBe("faux-roomy");
 		const before = harness.sessionManager.getBranch().length;
 
-		await harness.session.setModel(roomy);
+		await harness.session.setModel(spacious);
 
 		const appended = harness.sessionManager.getBranch().slice(before);
 		expect(appended.filter((entry) => entry.type === "model_change_rejected")).toEqual([]);
 		expect(harness.eventsOfType("model_change_rejected")).toEqual([]);
-		expect(harness.session.model?.id).toBe(roomy.id);
+		expect(appended.find((entry) => entry.type === "model_change")).toMatchObject({ modelId: "faux-spacious" });
+		expect(harness.session.model?.id).toBe("faux-spacious");
+		expect(harness.settingsManager.getDefaultModel()).toBe("faux-spacious");
+	});
+
+	it("#given a refusal from the guard after model_select #when setModel rethrows #then the refusal is recorded too", async () => {
+		const harness = await promptGrowingHarness();
+		const target = modelOf(harness, "target");
+
+		const error = await harness.session.setModel(target).then(
+			() => undefined,
+			(reason: unknown) => reason,
+		);
+
+		expect(error).toBeInstanceOf(ModelUsabilityBudgetError);
+		const branch = harness.sessionManager.getBranch();
+		expect(branch.filter((entry) => entry.type === "model_change")).toEqual([]);
+		const rejections = branch.filter((entry) => entry.type === "model_change_rejected");
+		expect(rejections).toHaveLength(1);
+		expect(rejections[0]).toMatchObject({ modelId: "target", reason: "context-budget" });
+		expect((rejections[0] as unknown as { detail: string }).detail).toContain("cannot switch");
+		expect(harness.eventsOfType("model_change_rejected")).toHaveLength(1);
+		expect(harness.session.model?.id).toBe("current");
+		expect(harness.settingsManager.getDefaultModel()).not.toBe("target");
+	});
+
+	it("#given a favorite cycle refused after model_select #when it rethrows #then no model_change and no default are written", async () => {
+		const harness = await promptGrowingHarness();
+		const current = modelOf(harness, "current");
+		const target = modelOf(harness, "target");
+		harness.session.setFavoriteModels([{ model: current }, { model: target }]);
+
+		await expect(harness.session.cycleModel()).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		const branch = harness.sessionManager.getBranch();
+		// The refused cycle used to append this entry BEFORE its post-`model_select`
+		// guard, so the session resumed on the refused model (`session-manager.ts`
+		// treats the last `model_change` as the authoritative explicit selection).
+		expect(branch.filter((entry) => entry.type === "model_change")).toEqual([]);
+		expect(harness.sessionManager.buildSessionContext().model?.modelId).not.toBe("target");
+		expect(harness.settingsManager.getDefaultModel()).not.toBe("target");
+		const rejections = branch.filter((entry) => entry.type === "model_change_rejected");
+		expect(rejections).toHaveLength(1);
+		expect(rejections[0]).toMatchObject({ modelId: "target", reason: "context-budget" });
+		expect(harness.session.model?.id).toBe("current");
+		expect(harness.eventsOfType("model_changed")).toEqual([]);
+	});
+
+	it("#given no configured auth #when the switch is refused #then the refusal is recorded with the auth reason", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-roomy", name: "Roomy", contextWindow: 200_000 },
+				{ id: "faux-spacious", name: "Spacious", contextWindow: 200_000 },
+			],
+			withConfiguredAuth: false,
+		});
+		harnesses.push(harness);
+		const target = modelOf(harness, "faux-spacious");
+
+		await expect(harness.session.setModel(target)).rejects.toThrow(`No API key for ${target.provider}/${target.id}`);
+
+		const rejections = harness.sessionManager.getBranch().filter((entry) => entry.type === "model_change_rejected");
+		expect(rejections).toHaveLength(1);
+		expect(rejections[0]).toMatchObject({ provider: target.provider, modelId: target.id, reason: "auth" });
+		expect((rejections[0] as unknown as { detail: string }).detail).toBe(
+			`No API key for ${target.provider}/${target.id}`,
+		);
+		const observed = harness.eventsOfType("model_change_rejected");
+		expect(observed).toHaveLength(1);
+		expect(observed[0]).toMatchObject({ reason: "auth" });
+		expect(observed[0]?.detail).toBe(`No API key for ${target.provider}/${target.id}`);
+		expect(harness.session.model?.id).toBe("faux-roomy");
+	});
+
+	it("#given a persisted session past its first assistant reply #when a switch is refused #then the refusal is on disk and reloads", async () => {
+		const harness = await oversizedHarness({ persistSession: true });
+		appendAssistant(harness, "already answered");
+		const sessionFile = harness.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("expected a persisted session file");
+
+		await expect(harness.session.setModel(tooSmall(harness))).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		expect(existsSync(sessionFile)).toBe(true);
+		const persistedTypes = readFileSync(sessionFile, "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => (JSON.parse(line) as { type: string }).type);
+		expect(persistedTypes).toContain("model_change_rejected");
+		const reloaded = SessionManager.open(sessionFile)
+			.getEntries()
+			.filter((entry) => entry.type === "model_change_rejected");
+		expect(reloaded).toHaveLength(1);
+		expect(reloaded[0]).toMatchObject({ modelId: "faux-small", reason: "context-budget" });
+		expect((reloaded[0] as unknown as { detail: string }).detail).toContain("Compact the session");
+	});
+
+	it("#given a session whose only content is a refused switch #when RPC state is built #then the entry list stays bookkeeping", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-roomy", name: "Roomy", contextWindow: 200_000 },
+				{ id: "faux-small", name: "Too Small", contextWindow: 5_120 },
+			],
+			persistSession: true,
+		});
+		harnesses.push(harness);
+
+		await expect(harness.session.setModel(tooSmall(harness))).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "model_change_rejected")).toBe(true);
+		// A refused switch is auto-appended bookkeeping like `model_change`: it must
+		// not turn every status snapshot of this session into a full entry dump.
+		expect(buildRpcSessionState(harness.session).entries).toBeUndefined();
+
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "real content" }],
+			timestamp: Date.now(),
+		});
+
+		expect(buildRpcSessionState(harness.session).entries).toBeDefined();
+	});
+
+	it("#given a persisted session with no assistant reply yet #when a switch is refused #then the record flushes with the first reply", async () => {
+		const harness = await oversizedHarness({ persistSession: true });
+		const sessionFile = harness.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("expected a persisted session file");
+
+		await expect(harness.session.setModel(tooSmall(harness))).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		// Documented limitation, not a special case: `_persist` buffers every entry
+		// until the branch holds an assistant message, so a pre-reply refusal is not
+		// yet on disk - but it is not lost either.
+		expect(existsSync(sessionFile)).toBe(false);
+
+		appendAssistant(harness, "first reply");
+
+		expect(existsSync(sessionFile)).toBe(true);
+		const persisted = readFileSync(sessionFile, "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as { type: string; modelId?: string });
+		expect(persisted.filter((entry) => entry.type === "model_change_rejected")).toMatchObject([
+			{ modelId: "faux-small" },
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-model-switch-rejection.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-switch-rejection.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ModelUsabilityBudgetError } from "../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+// https://github.com/code-yeongyu/senpi/issues/1526
+// A switch refused by the context-window guard threw before `_switchActiveModel`
+// ran, so nothing reached the session entries or the event stream: the attempt
+// was indistinguishable from never having been made.
+describe("rejected model switch", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) harness.cleanup();
+	});
+
+	async function oversizedHarness(): Promise<Harness> {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-roomy", name: "Roomy", contextWindow: 200_000 },
+				{ id: "faux-small", name: "Too Small", contextWindow: 5_120 },
+			],
+		});
+		harnesses.push(harness);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "context ".repeat(3_000) }],
+			timestamp: Date.now(),
+		});
+		return harness;
+	}
+
+	function tooSmall(harness: Harness) {
+		const model = harness.getModel("faux-small");
+		if (!model) throw new Error("expected the small-context faux model");
+		return model;
+	}
+
+	it("#given a target that cannot hold the live context #when the switch is refused #then a rejection entry is appended", async () => {
+		const harness = await oversizedHarness();
+		const target = tooSmall(harness);
+		const before = harness.sessionManager.getBranch().length;
+
+		await expect(harness.session.setModel(target)).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		const appended = harness.sessionManager.getBranch().slice(before);
+		const rejection = appended.find((entry) => entry.type === "model_change_rejected");
+		expect(rejection).toMatchObject({
+			type: "model_change_rejected",
+			provider: target.provider,
+			modelId: target.id,
+			reason: "context-budget",
+			contextWindow: target.contextWindow,
+		});
+		// The operator-actionable numbers must survive in the record, not only in
+		// the transient error message. `liveContextTokens` is deliberately not
+		// asserted non-zero: `_getDownswitchLiveContextTokens` reports 0 whenever
+		// the target's usable context is not smaller than the current model's, so a
+		// fixed expectation there would pin harness geometry rather than behavior.
+		const recorded = rejection as unknown as {
+			shortfallTokens: number;
+			requiredTokens: number;
+			liveContextTokens: number;
+			detail: string;
+		};
+		expect(recorded.shortfallTokens).toBeGreaterThan(0);
+		expect(recorded.requiredTokens).toBeGreaterThan(target.contextWindow);
+		expect(typeof recorded.liveContextTokens).toBe("number");
+		// The remedy the guard already names must reach the durable record.
+		expect(recorded.detail).toContain("Compact the session");
+	});
+
+	it("#given a refused switch #when subscribers observe the session #then a rejection event carries the same numbers", async () => {
+		const harness = await oversizedHarness();
+		const target = tooSmall(harness);
+
+		await expect(harness.session.setModel(target)).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		const observed = harness.eventsOfType("model_change_rejected");
+		expect(observed).toHaveLength(1);
+		expect(observed[0]).toMatchObject({ reason: "context-budget", contextWindow: target.contextWindow });
+		expect(observed[0]?.model.id).toBe(target.id);
+	});
+
+	it("#given the refusal #when the session continues #then the active model is unchanged", async () => {
+		const harness = await oversizedHarness();
+		const roomy = harness.getModel();
+
+		await expect(harness.session.setModel(tooSmall(harness))).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		expect(harness.session.model?.id).toBe(roomy.id);
+	});
+
+	it("#given an admissible target #when the switch succeeds #then no rejection is recorded", async () => {
+		const harness = await oversizedHarness();
+		const roomy = harness.getModel();
+		const before = harness.sessionManager.getBranch().length;
+
+		await harness.session.setModel(roomy);
+
+		const appended = harness.sessionManager.getBranch().slice(before);
+		expect(appended.filter((entry) => entry.type === "model_change_rejected")).toEqual([]);
+		expect(harness.eventsOfType("model_change_rejected")).toEqual([]);
+		expect(harness.session.model?.id).toBe(roomy.id);
+	});
+});

--- a/packages/coding-agent/test/suite/model-usability-budget.test.ts
+++ b/packages/coding-agent/test/suite/model-usability-budget.test.ts
@@ -87,8 +87,11 @@ describe("model usability budget", () => {
 		// then
 		expect(error).toBeInstanceOf(ModelUsabilityBudgetError);
 		if (!(error instanceof ModelUsabilityBudgetError)) throw new Error("expected model budget rejection");
+		// #1526: `setModel` now declares the switch admission, so the refusal keeps
+		// the switch wording (and its compaction remedy) even when the downswitch
+		// live-context probe reports 0, instead of degrading to cold-start wording.
 		expect(error.message).toBe(
-			'Model "faux/low-context" cannot start: context window 16000 tokens is 21464 tokens short of the 37464-token minimum (system prompt 1, active tool schemas 695, output reserve 4000, compaction reserve 16384, speculation lead 8192, safety margin 8192 [default]).',
+			'Model "faux/low-context" cannot switch: target context window 16000 tokens is 21464 tokens short of the 37464-token requirement (live context 0, system prompt 1, active tool schemas 695, output reserve 4000, compaction reserve 16384, speculation lead 8192, safety margin 8192 [default]). Compact the session, then revalidate and retry the model switch.',
 		);
 	});
 

--- a/packages/coding-agent/test/suite/model-usability-budget.test.ts
+++ b/packages/coding-agent/test/suite/model-usability-budget.test.ts
@@ -87,11 +87,12 @@ describe("model usability budget", () => {
 		// then
 		expect(error).toBeInstanceOf(ModelUsabilityBudgetError);
 		if (!(error instanceof ModelUsabilityBudgetError)) throw new Error("expected model budget rejection");
-		// #1526: `setModel` now declares the switch admission, so the refusal keeps
-		// the switch wording (and its compaction remedy) even when the downswitch
-		// live-context probe reports 0, instead of degrading to cold-start wording.
+		// #1526: `setModel` derives the admission from the session instead of
+		// declaring a switch, so an empty session keeps the cold-start contract - the
+		// switch wording would promise a compaction remedy with nothing to compact.
+		expect(error.projection.admission).toBe("start");
 		expect(error.message).toBe(
-			'Model "faux/low-context" cannot switch: target context window 16000 tokens is 21464 tokens short of the 37464-token requirement (live context 0, system prompt 1, active tool schemas 695, output reserve 4000, compaction reserve 16384, speculation lead 8192, safety margin 8192 [default]). Compact the session, then revalidate and retry the model switch.',
+			'Model "faux/low-context" cannot start: context window 16000 tokens is 21464 tokens short of the 37464-token minimum (system prompt 1, active tool schemas 695, output reserve 4000, compaction reserve 16384, speculation lead 8192, safety margin 8192 [default]).',
 		);
 	});
 

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
 import type {
 	ModelChangeEntry,
+	ModelChangeRejectedEntry,
 	SessionEntry,
 	SessionMessageEntry,
 	SessionTreeNode,
@@ -94,6 +95,20 @@ function modelChange(id: string, parentId: string | null): ModelChangeEntry {
 		timestamp: new Date().toISOString(),
 		provider: "anthropic",
 		modelId: "claude-sonnet-4",
+	};
+}
+
+function modelChangeRejected(id: string, parentId: string | null): ModelChangeRejectedEntry {
+	return {
+		type: "model_change_rejected",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		provider: "faux",
+		modelId: "too-small",
+		reason: "context-budget",
+		detail:
+			'Model "faux/too-small" cannot switch: ... Compact the session, then revalidate and retry the model switch.',
 	};
 }
 
@@ -771,6 +786,70 @@ describe("TreeSelectorComponent", () => {
 
 			selector.handleInput(DOWN); // user-3a → asst-3a (not user-3b)
 			expect(list.getSelectedNode()?.entry.id).toBe("asst-3a");
+		});
+	});
+
+	// https://github.com/code-yeongyu/senpi/issues/1526
+	describe("refused model switch entries", () => {
+		const DOWN = "\x1b[B";
+		const entries = [
+			userMessage("user-1", null, "hello"),
+			assistantMessage("asst-1", "user-1", "hi"),
+			modelChangeRejected("refused-1", "asst-1"),
+		];
+
+		test("renders the refusal with its model and reason instead of a blank row", () => {
+			const selector = new TreeSelectorComponent(
+				buildTree(entries),
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+				undefined,
+				undefined,
+				"all",
+			);
+
+			const rendered = stripVTControlCharacters(selector.getTreeList().render(200).join("\n"));
+
+			expect(rendered).toContain("[model rejected: too-small (context-budget)]");
+		});
+
+		test("keeps the refusal out of the default view like every other bookkeeping entry", () => {
+			const selector = new TreeSelectorComponent(
+				buildTree(entries),
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+			);
+			const list = selector.getTreeList();
+
+			const visible = new Set<string>();
+			for (let i = 0; i < entries.length + 2; i++) {
+				visible.add(list.getSelectedNode()?.entry.id ?? "");
+				selector.handleInput(DOWN);
+			}
+
+			expect([...visible].sort()).toEqual(["asst-1", "user-1"]);
+		});
+
+		test("finds the refusal by search text", () => {
+			const selector = new TreeSelectorComponent(
+				buildTree(entries),
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+				undefined,
+				undefined,
+				"all",
+			);
+			const list = selector.getTreeList();
+
+			selector.handleInput("rejected");
+
+			expect(list.getSelectedNode()?.entry.id).toBe("refused-1");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- A model switch refused by the context-window or auth guard now leaves a durable record instead of vanishing: `_setModel` appends a `model_change_rejected` session entry, emits a matching event, and rethrows the original error unchanged.
- The same refusal now uses the switch wording, so it carries the remedy it already knows ("Compact the session, then revalidate and retry the model switch") instead of claiming the model "cannot start".

Before this change an attempted-and-rejected switch was indistinguishable from a switch the user never made. That is not hypothetical: during an account-level `429` storm a user selected another provider, the guard refused it, the one-shot toast was buried under repeated provider errors, and the session kept running on the rate-limited model. Afterwards nothing on disk explained it — no `model_change`, no error entry, nothing in `logs/session.log` or `logs/fallback.log`. Reconstructing the incident was only possible by inferring from the *absence* of an entry.

Closes #1526.

## Changes

- `packages/coding-agent/src/core/agent-session.ts`: `_setModel` wraps its two guards; `_recordRejectedModelChange` appends the entry and emits `model_change_rejected` with the projection numbers (`contextWindow`, `liveContextTokens`, `requiredTokens`, `shortfallTokens`, `safetyMarginProfile`) plus the guard's own text. The `assertModelUsable` call declares `admission: "switch"`.
- `packages/coding-agent/src/core/session-manager.ts`: adds `ModelChangeRejectedEntry` (in the `SessionEntry` union) and `appendModelChangeRejected()`, mirroring the existing `appendModelChange()`.
- `packages/coding-agent/src/core/changes.md`: tracker entry.
- `packages/coding-agent/test/suite/agent-session-model-switch-rejection.test.ts`: new regression suite.
- `packages/coding-agent/test/suite/model-usability-budget.test.ts`: the one existing expectation that pinned the old cold-start sentence for this path, updated to the switch contract.

Two design notes worth reviewer attention:

**Why `detail` and not `message`.** The entry's text field is `detail` because `SessionMessageEntry.message` is an object; naming it `message` collapsed the `SessionEntry` discriminated union and broke unrelated call sites at the type level. Caught by `tsc`, not guessed.

**Why `admission: "switch"` is safe.** `admission` selects wording and one `resume`-only branch; `start` and `switch` compute the identical budget. The default infers `"switch"` only when `liveContextTokens > 0`, which is false on this path whenever the target's usable context is not smaller than the current model's — hence the wrong wording on exactly the switches a user makes to escape a rate limit.

No renderer was added to the TUI: `selectModelFromUi` already catches and shows this error, so an event handler there would double-report the same failure.

## QA & Evidence

- **What was tested:** `bun run --cwd packages/coding-agent test test/suite/agent-session-model-switch-rejection.test.ts`
  **Observed result:** RED before the fix — 2 failed / 2 passed, failing precisely on the missing session entry and the missing event. GREEN after — 4 passed.
  **Artifact:** `local-ignore/qa-evidence/20260909-model-switch-rejection/{red.txt,green.txt}`
  **Why sufficient:** the two failures are the exact contract this PR introduces; the two that passed before and after guard against a false positive (unchanged active model, and no rejection recorded on a successful switch).

- **What was tested:** six adjacent model/session suites (`agent-session-model-extension`, `gpt-model-switch-{characterization,lifecycle-characterization,rpc-set-model}`, `extension-session-model-api`, `model-fallback-command`).
  **Observed result:** 41 passed.
  **Artifact:** `local-ignore/qa-evidence/20260909-model-switch-rejection/adjacent.txt`
  **Why sufficient:** these cover the switch, cycle, fallback and RPC paths that share the modified `_setModel` and the extended `SessionEntry` union.

- **What was tested:** `bun run check`, then `npm run build` and the full `packages/coding-agent` suite.
  **Observed result:** check clean. Suite: 10,243 passed, 2 failed. Both were re-run in isolation and pass (`Test Files 3 passed | Tests 36 passed`): `rpc-socket-host` is pre-existing port contention under parallel files, and `model-usability-budget` is the expectation this PR updates.
  **Artifact:** `local-ignore/qa-evidence/20260909-model-switch-rejection/{check.txt,full-suite.txt,recheck.txt}`
  **Why sufficient:** it establishes the new entry type does not disturb the rest of the session/entry surface, and separates the one intended contract change from unrelated flake.

## Risks & Residuals

- **New persisted entry type.** `model_change_rejected` joins the `SessionEntry` union, so consumers switching exhaustively over entries see a new member. Mitigated: the union is type-checked repo-wide and `tsc --noEmit` is clean; readers that ignore unknown types are unaffected.
- **Changed refusal wording on the `setModel` path.** Intended, and the only test that pinned the old sentence is updated in this PR. Accepted.
- **`liveContextTokens` can legitimately be `0`** in the recorded entry, because `_getDownswitchLiveContextTokens` reports 0 when the target's usable context is not smaller. The test asserts the field's presence and type rather than a non-zero value, so it locks behavior instead of harness geometry.
- **Not addressed here:** the retry path's `tryFallback` wrapper swallows the same `ModelUsabilityBudgetError` and returns `false`, which is a second place a budget refusal disappears without a record. Called out in #1526; left out of this diff to keep it reviewable.

## Automated Checks

```bash
bun run check
bun run --cwd packages/coding-agent test
```

## Related Issues

Closes #1526

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records refused model switches as `model_change_rejected` entries instead of dropping them, preserving the original error while making context-budget and auth failures auditable. Favorite cycles now validate before committing a model, global default, or related change event, so a rejected target cannot become the active or future-session model. Addresses #1526.

**Changes**
- A shared guard path covers `setModel`, post-`model_select` revalidation, and favorite-cycle checks, recording the reason, detail, and budget projection values while emitting a matching event.
- The bookkeeping entry stays out of model context, survives Claude SDK OAuth resume, crosses RPC validation without inflating status snapshots, and renders and searches in `/tree`.
- Admission wording now includes the compaction remedy only when the session has context to compact.
- `SessionEntry` consumers must handle the new `model_change_rejected` member.

**Validation**
- Targeted suites passed 87 tests and `bun run check` is clean; the full suite reports 98 pre-existing failures from missing `dist/` artifacts and socket-port contention.

<sup>Written for commit a708cb3dfd5b272ab1b2be58652f37b603b75d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

