### PR TITLE
fix(rpc): cut stalled socket peers before they consume the session worker credit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Shared RPC hosts now cut a socket peer that stops reading (a write not accepted within 4 seconds) with an `overflow` record `stalled, resync required` instead of letting it hold the session worker's output credit until the 5-second `session_worker_credit_timeout` quarantined a healthy session mid-turn; a cut or overflowed peer no longer withholds session credit or fails the shared host writer ([#1529](https://github.com/code-yeongyu/senpi/pull/1529)).
+
 ### Removed
 
 ## [2026.9.9-2] - 2026-09-09

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -230,7 +230,12 @@ Display updates coalesce to one pending update and one latest value; UI cancella
 messages. IPC output and snapshots are limited to 16 MiB per record, with one acknowledged record at a time. Credit
 returns after the session's destinations consume their output, not merely on IPC receipt. A five-second credit
 failure closes that session visibly (`session_error` followed by `session_closed`), rather than retaining an
-unbounded queue. Socket queues retain their existing independent overflow/disconnect behavior. The default stdio
+unbounded queue. Socket queues retain their existing independent overflow/disconnect behavior, and a socket peer that
+stops reading is cut before it can consume that credit budget: a write the peer has not accepted within 4 seconds
+(`DEFAULT_STALL_MS`, below the 5-second worker deadline) is treated like a byte overflow — that connection receives one
+`overflow` record with `error: "stalled, resync required"`, is closed, and must reconnect and resynchronize — while the
+session keeps running and its other destinations keep receiving output. A failed or cut connection never withholds a
+session's credit and never fails the shared host writer; only the stdio lane can. The default stdio
 queue is bounded at 64 MiB or 4096 records, with reserved terminal-failure records and one control-overflow notice.
 Close admission counts both queued output and pending close replies (including their serialized bytes) before
 releasing an attachment or waiting for teardown. An admitted first closer reserves its lifecycle and terminal reply;

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Cut stalled socket peers before they consume the session worker credit (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/socket-event-fanout.ts`: `SocketEventSinkActor` bounds each write's drain wait with `stallMs` (`DEFAULT_STALL_MS` = 4000, pinned below `SESSION_WORKER_LIMITS.controlMs`). A peer that has not accepted the write in time fails the actor exactly like a byte overflow: one best-effort `{"type":"overflow","error":"stalled, resync required"}` notice, actor closed, `onFailure(SocketEventQueueStallError)` (the fanout removes the connection and closes its socket).
+- `packages/coding-agent/src/modes/rpc/session-event-writer.ts`: `waitForSessionBackpressure`, `flush` and `drainUntilEmpty` settle socket actors through `settleActors`, which treats a rejected actor flush as a cut peer. Previously any actor rejection (byte overflow, now also stall) propagated into `Promise.all`, rejected the writer-wide drain and called `fail()` on the shared host writer, or reached the session worker client which then killed the worker.
+- `registerConnection` accepts `stallMs` (tests use a short budget); `packages/coding-agent/docs/rpc.md` documents the stall cut and that a cut connection never withholds session credit.
+
+### Why
+
+- Live on mengmotaHost 2026-09-09 17:17 and 2026-09-10 11:07 (two runtimes): a desktop client stalled on its own downstream ack pacing, the kernel socket buffer filled during a large `eval` tool result, `waitForSessionBackpressure` never resolved, and the session worker failed itself with `session_worker_credit_timeout` after 5 s — the user's running turn was truncated (`session_closed` with no final assistant message) although the session and every other peer were healthy. One slow consumer must not kill the producer; the writer already had fail-closed overflow semantics for slow peers, they were just byte-only.
+- `test/suite/rpc-socket-stall.test.ts`: stall budget < worker deadline; a stalled actor is cut with the notice while a sibling drains; the writer returns session credit and closes only the stalled connection; the writer and its stdio lane survive a stalled peer (this last case failed the whole writer before the fix).
+
+### Why an extension could not handle it
+
+- Transport credit, socket drain and worker liveness are host infrastructure below the extension boundary.
+
+### Expected merge conflict zones
+
+- LOW: `SocketEventSinkActor.drain` and the three actor-flush aggregation sites in `session-event-writer.ts`. Upstream has no socket fanout.
+
 ## Bound quarantined and joined close reply admission (2026-09-08)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
@@ -68,7 +68,7 @@ export class SessionEventFanout {
 	registerConnection(
 		id: string,
 		connection: SessionEventWriterConnection,
-		options: { readonly maxQueueBytes?: number } = {},
+		options: { readonly maxQueueBytes?: number; readonly stallMs?: number } = {},
 	): void {
 		const actor = new SocketEventSinkActor(
 			connection,
@@ -85,6 +85,7 @@ export class SessionEventFanout {
 				connection.close?.();
 			},
 			options.maxQueueBytes,
+			options.stallMs,
 		);
 		this.connections.set(id, { connection, actor });
 		this.connectionCapabilities.set(id, new Set());

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -11,6 +11,10 @@ import type { SocketEventSinkActor } from "./socket-event-fanout.ts";
 
 export { RENDERED_COMPONENT_RECORD, type SessionEventWriterConnection } from "./session-event-fanout.ts";
 
+/** Await every actor's drain; a failed actor is a cut peer, not a writer failure. */
+const settleActors = (actors: readonly SocketEventSinkActor[]): Promise<void> =>
+	Promise.all(actors.map((actor) => actor.flush().catch(() => undefined))).then(() => undefined);
+
 type RawWriter = (chunk: string) => void;
 type BackpressureWaiter = () => Promise<void>;
 type FlushScheduler = (flush: () => Promise<void>) => void;
@@ -147,7 +151,7 @@ export class SessionEventWriter {
 	registerConnection(
 		id: string,
 		connection: SessionEventWriterConnection,
-		options: { readonly maxQueueBytes?: number } = {},
+		options: { readonly maxQueueBytes?: number; readonly stallMs?: number } = {},
 	): void {
 		this.fanout.registerConnection(id, connection, options);
 	}
@@ -250,16 +254,24 @@ export class SessionEventWriter {
 		return true;
 	}
 
-	/** Return worker credit only after this session's destinations consumed their queues. */
+	/**
+	 * Return worker credit only after this session's destinations consumed their
+	 * queues. A destination that failed (byte overflow or stall) was already cut
+	 * and closed by the fanout's onFailure; it must not withhold the session's
+	 * credit, or one bad peer kills the producing worker (session_worker_credit_timeout).
+	 */
 	waitForSessionBackpressure(sessionId: string): Promise<void> {
 		if (this.fanout.isEmpty()) return this.flush();
 		const targets = new Set([
 			...this.fanout.targets(sessionId, this.currentConnection(), false, false, undefined),
 			this.currentConnection(),
 		]);
-		return Promise.all(
-			[...targets].map((target) => (target === undefined ? undefined : this.fanout.get(target)?.actor.flush())),
-		).then(() => undefined);
+		return settleActors(
+			[...targets].flatMap((target) => {
+				const registered = target === undefined ? undefined : this.fanout.get(target);
+				return registered ? [registered.actor] : [];
+			}),
+		);
 	}
 
 	/** Queue one untagged host-control response for the current connection. */
@@ -397,8 +409,7 @@ export class SessionEventWriter {
 		if (this.failure !== undefined) return Promise.reject(this.failure);
 		this.flushScheduled = false;
 		if (this.drainPromise) return this.drainPromise;
-		if (this.readyQueues.length === 0)
-			return Promise.all([...this.fanout.values()].map(({ actor }) => actor.flush())).then(() => undefined);
+		if (this.readyQueues.length === 0) return settleActors([...this.fanout.values()].map(({ actor }) => actor));
 		let resolveDrain!: () => void;
 		let rejectDrain!: (cause: unknown) => void;
 		const drain = new Promise<void>((resolve, reject) => {
@@ -424,7 +435,9 @@ export class SessionEventWriter {
 		do {
 			await this.drainReadyQueues();
 		} while (this.readyQueues.length > 0);
-		await Promise.all([...this.fanout.values()].map(({ actor }) => actor.flush()));
+		// Per-connection failures are handled by the fanout (cut + close); only the
+		// shared stdio lane may fail this writer.
+		await settleActors([...this.fanout.values()].map(({ actor }) => actor));
 		this.controlOverflowReported = false;
 		if (this.reservedCloseRecords === 0) this.closeOverflowReported = false;
 	}

--- a/packages/coding-agent/src/modes/rpc/socket-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/socket-event-fanout.ts
@@ -22,6 +22,30 @@ type QueueEntry = {
 // above any single burst a normal session produces.
 const DEFAULT_QUEUE_BYTES = 64 * 1024 * 1024;
 
+// A session worker returns its output credit only after every destination of
+// that session has drained (session-event-writer.ts, waitForSessionBackpressure),
+// and it fails itself when the host has not answered within
+// SESSION_WORKER_LIMITS.controlMs (session-worker.ts, session_worker_credit_timeout).
+// A peer that stops reading its socket therefore used to kill the producing
+// session after 5 s (observed live 2026-09-09/10: a desktop client stalled on
+// its own ack pacing, the kernel buffer filled, and the worker was quarantined
+// mid-turn). Treat a write that cannot complete within this budget exactly like
+// a byte overflow: fail-closed disconnect of THAT peer, who must resync, while
+// the session keeps its credit. Must stay below controlMs; a test pins that.
+export const DEFAULT_STALL_MS = 4_000;
+
+export class SocketEventQueueStallError extends Error {
+	readonly pendingBytes: number;
+	readonly stallMs: number;
+
+	constructor(pendingBytes: number, stallMs: number) {
+		super(`socket event queue stalled: peer did not drain ${pendingBytes} queued bytes within ${stallMs}ms`);
+		this.name = "SocketEventQueueStallError";
+		this.pendingBytes = pendingBytes;
+		this.stallMs = stallMs;
+	}
+}
+
 export class SocketEventQueueOverflowError extends Error {
 	readonly queuedBytes: number;
 	readonly incomingBytes: number;
@@ -51,11 +75,18 @@ export class SocketEventSinkActor {
 	private readonly sink: SocketSink;
 	private readonly onFailure: (cause: unknown) => void;
 	private readonly maxQueueBytes: number;
+	private readonly stallMs: number;
 
-	constructor(sink: SocketSink, onFailure: (cause: unknown) => void, maxQueueBytes = DEFAULT_QUEUE_BYTES) {
+	constructor(
+		sink: SocketSink,
+		onFailure: (cause: unknown) => void,
+		maxQueueBytes = DEFAULT_QUEUE_BYTES,
+		stallMs = DEFAULT_STALL_MS,
+	) {
 		this.sink = sink;
 		this.onFailure = onFailure;
 		this.maxQueueBytes = maxQueueBytes;
+		this.stallMs = stallMs;
 	}
 
 	enqueue(line: string, key?: string, onWritten?: () => void, demotedLine?: string): void {
@@ -113,6 +144,35 @@ export class SocketEventSinkActor {
 		this.queuedBytes = 0;
 	}
 
+	/**
+	 * Resolve when the sink accepted the write, or throw SocketEventQueueStallError
+	 * once the peer has held the transport full for stallMs. The notice is best
+	 * effort: the socket is already not draining, so writeRaw may only buffer it.
+	 */
+	private waitForDrainOrStall(writtenBytes: number): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				const stall = new SocketEventQueueStallError(this.queuedBytes + writtenBytes, this.stallMs);
+				try {
+					this.sink.writeRaw(`${JSON.stringify({ type: "overflow", error: "stalled, resync required" })}\n`);
+				} catch {
+					// The peer is unreachable either way; the failure below closes it.
+				}
+				reject(stall);
+			}, this.stallMs);
+			this.sink.waitForBackpressure().then(
+				() => {
+					clearTimeout(timer);
+					resolve();
+				},
+				(cause) => {
+					clearTimeout(timer);
+					reject(cause);
+				},
+			);
+		});
+	}
+
 	private drain(): Promise<void> {
 		if (this.draining) return this.draining;
 		this.draining = (async () => {
@@ -121,7 +181,7 @@ export class SocketEventSinkActor {
 					const entry = this.queue.shift()!;
 					this.queuedBytes -= entry.bytes;
 					this.sink.writeRaw(entry.line);
-					await this.sink.waitForBackpressure();
+					await this.waitForDrainOrStall(entry.bytes);
 					entry.onWritten?.();
 				}
 			} catch (cause) {

--- a/packages/coding-agent/test/suite/rpc-socket-stall.test.ts
+++ b/packages/coding-agent/test/suite/rpc-socket-stall.test.ts
@@ -1,0 +1,124 @@
+import { expect, it, vi } from "vitest";
+import { SessionEventWriter } from "../../src/modes/rpc/session-event-writer.ts";
+import { SESSION_WORKER_LIMITS } from "../../src/modes/rpc/session-worker-protocol.ts";
+import {
+	DEFAULT_STALL_MS,
+	SocketEventQueueStallError,
+	SocketEventSinkActor,
+} from "../../src/modes/rpc/socket-event-fanout.ts";
+
+// A stalled peer must be cut before the producing worker's credit deadline, or
+// the host quarantines a healthy session (session_worker_credit_timeout).
+it("cuts a stalled socket peer before the worker credit deadline", () => {
+	expect(DEFAULT_STALL_MS).toBeLessThan(SESSION_WORKER_LIMITS.controlMs);
+});
+
+it("fails a sink whose peer never drains and keeps a draining sibling untouched", async () => {
+	vi.useFakeTimers();
+	try {
+		const written: string[] = [];
+		const failures: unknown[] = [];
+		const never = new Promise<void>(() => {});
+		const stalled = new SocketEventSinkActor(
+			{ writeRaw: (line) => void written.push(line), waitForBackpressure: () => never },
+			(cause) => failures.push(cause),
+			1024 * 1024,
+			50,
+		);
+		const healthyWritten: string[] = [];
+		const healthy = new SocketEventSinkActor(
+			{ writeRaw: (line) => void healthyWritten.push(line), waitForBackpressure: () => Promise.resolve() },
+			(cause) => failures.push(cause),
+		);
+		stalled.enqueue('{"a":1}\n');
+		healthy.enqueue('{"b":1}\n');
+		await vi.advanceTimersByTimeAsync(49);
+		expect(failures).toEqual([]);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toBeInstanceOf(SocketEventQueueStallError);
+		expect(written).toEqual(['{"a":1}\n', '{"type":"overflow","error":"stalled, resync required"}\n']);
+		await expect(stalled.flush()).rejects.toBeInstanceOf(SocketEventQueueStallError);
+		await healthy.flush();
+		expect(healthyWritten).toEqual(['{"b":1}\n']);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+it("returns session credit and disconnects only the stalled peer", async () => {
+	vi.useFakeTimers();
+	try {
+		const writer = new SessionEventWriter(() => {});
+		const closed: string[] = [];
+		const a: string[] = [];
+		const b: string[] = [];
+		writer.registerConnection(
+			"a",
+			{
+				writeRaw: (line) => void a.push(line),
+				waitForBackpressure: () => new Promise<void>(() => {}),
+				close: () => closed.push("a"),
+			},
+			{ stallMs: 50 },
+		);
+		writer.registerConnection("b", {
+			writeRaw: (line) => void b.push(line),
+			waitForBackpressure: () => Promise.resolve(),
+			close: () => closed.push("b"),
+		});
+		writer.attachConnectionToSession("a", "rpc-1");
+		writer.attachConnectionToSession("b", "rpc-1");
+		expect(writer.enqueue("rpc-1", { type: "message_update", text: "x" })).toBe(true);
+		// The worker's credit return waits on every destination of the session.
+		let credited = false;
+		const credit = writer.waitForSessionBackpressure("rpc-1").then(
+			() => (credited = true),
+			() => (credited = true),
+		);
+		await vi.advanceTimersByTimeAsync(49);
+		expect(credited).toBe(false);
+		await vi.advanceTimersByTimeAsync(1);
+		await credit;
+		expect(credited).toBe(true);
+		expect(closed).toEqual(["a"]);
+		expect(a.at(-1)).toBe('{"type":"overflow","error":"stalled, resync required"}\n');
+		expect(b).toHaveLength(1);
+		expect(JSON.parse(b[0]!)).toMatchObject({ type: "message_update", sessionId: "rpc-1" });
+		// A later record for the session no longer waits on the cut peer.
+		expect(writer.enqueue("rpc-1", { type: "message_update", text: "y" })).toBe(true);
+		await writer.waitForSessionBackpressure("rpc-1");
+		expect(b).toHaveLength(2);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+it("keeps the writer and its stdio lane alive when one socket peer stalls", async () => {
+	vi.useFakeTimers();
+	try {
+		const stdout: string[] = [];
+		const writer = new SessionEventWriter((line) => void stdout.push(line));
+		const closed: string[] = [];
+		writer.registerConnection(
+			"stalled",
+			{
+				writeRaw: () => {},
+				waitForBackpressure: () => new Promise<void>(() => {}),
+				close: () => closed.push("stalled"),
+			},
+			{ stallMs: 50 },
+		);
+		writer.attachConnectionToSession("stalled", "rpc-1");
+		expect(writer.enqueue("rpc-1", { type: "message_update", text: "x" })).toBe(true);
+		// The scheduled flush aggregates every actor; the stalled one rejects.
+		await vi.advanceTimersByTimeAsync(60);
+		expect(closed).toEqual(["stalled"]);
+		// Before the fix this rejected the writer-wide drain and failed the host writer;
+		// stdio control output must still flow afterwards.
+		await writer.enqueueControl({ type: "response", id: "after-stall", success: true });
+		await writer.flush();
+		expect(stdout.map((line) => JSON.parse(line))).toEqual([{ type: "response", id: "after-stall", success: true }]);
+	} finally {
+		vi.useRealTimers();
+	}
+});


### PR DESCRIPTION
## Problem

A session worker returns its output credit only after every destination of that session has drained (`waitForSessionBackpressure`), and fails itself with `session_worker_credit_timeout` when the host has not answered within `SESSION_WORKER_LIMITS.controlMs` (5 s). Socket actors bounded their queues by **bytes only**, so a peer that stopped reading (kernel buffer full) kept the credit wait open forever and the host quarantined a **healthy** session after 5 s.

Observed live twice on mengmotaHost (2026-09-09 17:17, 2026-09-10 11:07, two different runtime builds): the desktop client stalled on its own downstream ack pacing during a large `eval` tool result; the user's running turn was truncated (`session_closed`, no final assistant message). Daemon stderr: `senpi rpc session rpc-6 quarantined: session_worker_credit_timeout`.

A second latent defect surfaced while fixing it: any socket actor rejection (byte overflow, now also stall) propagated through `Promise.all` into the writer-wide drain and `fail()`, i.e. one bad peer could fail the shared host writer — or reached the session worker client, which killed the worker.

## Fix

- `socket-event-fanout.ts`: `SocketEventSinkActor` bounds each write's drain wait with `stallMs` (`DEFAULT_STALL_MS = 4000`, pinned below `controlMs` by a test). A peer that has not accepted the write in time is failed exactly like a byte overflow: one best-effort `{"type":"overflow","error":"stalled, resync required"}` notice, actor closed, `onFailure(SocketEventQueueStallError)` → the fanout removes and closes that connection. The session keeps its credit and its other peers.
- `session-event-writer.ts`: `waitForSessionBackpressure`, `flush`, `drainUntilEmpty` settle actors via `settleActors` — a rejected actor flush is a cut peer, never a writer failure. Only the stdio lane can fail the writer. `registerConnection` accepts `stallMs`.
- `docs/rpc.md` + `src/modes/rpc/changes.md` updated.

## Tests

`test/suite/rpc-socket-stall.test.ts` (fake timers, no subprocess):
1. `DEFAULT_STALL_MS < SESSION_WORKER_LIMITS.controlMs`
2. a stalled actor is cut with the notice while a sibling actor drains
3. the writer returns session credit and closes only the stalled connection; later records no longer wait on it
4. the writer and its stdio lane survive a stalled peer (previously failed the whole writer)

Mutation: with the three source files reverted to main, all 4 fail (credit wait times out at 30 s; no peer is cut).

## Verification (remote, mengmotaMac via bunshin — no tests run on the session host)

- `CI=1 bun run --cwd packages/coding-agent test` on: rpc-worker-capacity, rpc-worker-isolation, rpc-worker-output, rpc-worker-overflow, rpc-worker-rebind-commit, rpc-worker-requests, rpc-worker-reservations, rpc-worker-routing, rpc-close-backpressure, rpc-socket-stall → **10 files / 30 tests passed** (after `bun run build`; the FIFO-worker cases need the built `pi-ai` dist).
- Pre-commit `bun run check` (biome + tsc + lock checks) passed.

Written by OmO (Claude) in the senpi harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a stalled socket peer from holding the session worker output credit, which previously quarantined a healthy session after 5 seconds. The peer is now cut like a byte overflow, and a single failed actor can no longer fail the shared writer.

**Bug Fixes**
- A peer that doesn't accept a write within 4 seconds (`DEFAULT_STALL_MS`, below the worker's 5‑second deadline) gets one `overflow` notice with `stalled, resync required`, is closed, and must reconnect; the session keeps its credit and other peers.
- `waitForSessionBackpressure`, `flush`, and `drainUntilEmpty` now treat a socket actor's rejection as a cut peer, not a writer failure — only the stdio lane can fail the writer.
- `registerConnection` accepts `stallMs` so callers can tune the timeout; docs and changelog updated.

<sup>Written for commit 5bde8a770a74214033dd3e2d0c1716a6bd4088c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

