### PR TITLE
feat(coding-agent): edit assistant responses from /tree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- `/tree` can edit an assistant response: press `ctrl+e` (`app.tree.editMessage`) on an assistant entry to open it in the multi-line editor; submitting branches to that entry's parent and appends the edited copy as the new leaf, so the conversation continues from the corrected response while the original stays in the session file. Tool calls and thinking in the edited response are dropped, the branch-summary prompt appears only when messages are abandoned, and the key reopens user messages in the editor the same way `enter` does. `AgentSession.editAssistantMessage()` exposes the operation to hosts.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- `/tree` can edit an assistant response: press `ctrl+e` (`app.tree.editMessage`) on an assistant entry to open it in the multi-line editor; submitting branches to that entry's parent and appends the edited copy as the new leaf, so the conversation continues from the corrected response while the original stays in the session file. Tool calls and thinking in the edited response are dropped, the branch-summary prompt appears only when messages are abandoned, and the key reopens user messages in the editor the same way `enter` does. `AgentSession.editAssistantMessage()` exposes the operation to hosts.
+- `/tree` can edit an assistant response: press `ctrl+e` (`app.tree.editMessage`) on an assistant entry to open it in the multi-line editor; submitting branches to that entry's parent and appends the edited copy as the new leaf, so the conversation continues from the corrected response while the original stays in the session file. Tool calls and thinking in the edited response are dropped, the branch-summary prompt appears only when messages are abandoned, and the key reopens user messages in the editor the same way `enter` does. `AgentSession.editAssistantMessage()` exposes the operation to hosts ([#1532](https://github.com/code-yeongyu/senpi/pull/1532)).
 
 ### Changed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -271,6 +271,7 @@ Use `/session` in interactive mode to see the current session ID before reusing 
 - Search by typing, fold/unfold and jump between branches with Ctrl+←/Ctrl+→ or Alt+←/Alt+→, page with ←/→
 - Filter modes (Ctrl+O): default → no-tools → user-only → labeled-only → all
 - Press Ctrl+X to copy the selected message
+- Press Ctrl+E on an assistant response to edit it and continue from the edited copy
 - Press Shift+L to label entries as bookmarks and Shift+T to toggle label timestamps
 
 **`/fork`** - Create a new session file from a previous user message on the active branch. Opens a selector, copies the active path up to that point, and places the selected prompt in the editor for modification.

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -169,6 +169,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | `app.tree.foldOrUp` | `ctrl+left`, `alt+left` | Fold current branch segment, or jump to the previous segment start |
 | `app.tree.unfoldOrDown` | `ctrl+right`, `alt+right` | Unfold current branch segment, or jump to the next segment start or branch end |
 | `app.tree.editLabel` | `shift+l` | Edit the label on the selected tree node |
+| `app.tree.editMessage` | `ctrl+e` | Edit the selected assistant response in the editor and continue from the edited copy; on a user message it behaves like `enter` |
 | `app.tree.toggleLabelTimestamp` | `shift+t` | Toggle label timestamps in the tree |
 | `app.tree.filter.default` | `ctrl+d` | Set tree filter to default view |
 | `app.tree.filter.noTools` | `ctrl+t` | Toggle tree filter that hides tool results |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -23,6 +23,7 @@ The editor can be replaced temporarily by built-in UI such as `/settings` or by 
 | Path completion | Press Tab to complete paths |
 | Multi-line input | Shift+Enter, or Ctrl+Enter on Windows Terminal |
 | Copy response | Ctrl+X copies the selected message in `/tree`; otherwise it copies the last assistant message, or the active fullscreen text selection when `fullscreenCopyOnSelect` is disabled |
+| Edit response | Ctrl+E on an assistant message in `/tree` opens it in the editor; submitting continues the session from the edited copy |
 | Images | Paste with Ctrl+V, Alt+V on Windows, or drag into the terminal |
 | Shell command | `!command` runs and sends output to the model |
 | Hidden shell command | `!!command` runs without sending output to the model |
@@ -113,7 +114,7 @@ senpi --fork <path|id>    # Fork a session into a new session file
 Useful session commands:
 
 - `/session` shows the current session file and ID.
-- `/tree` navigates the in-file session tree and can summarize abandoned branches.
+- `/tree` navigates the in-file session tree and can summarize abandoned branches. Ctrl+E on an assistant entry edits that response in place of the original (the original stays in the file on an abandoned branch; tool calls in the edited response are dropped).
 - `/fork` creates a new session from an earlier user message.
 - `/clone` duplicates the current active branch into a new session file.
 - `/compact` summarizes older messages to free context.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -106,6 +106,7 @@ import { isTurnStuckOnContextOverflow } from "./compaction/stuck-overflow.ts";
 import { isWarmSummaryAnchorValid } from "./compaction/warm-anchor.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "./dynamic-prompt/index.ts";
+import { AssistantEditError, assistantTextEquals, buildEditedAssistantMessage } from "./edited-assistant-message.ts";
 import { areExperimentalFeaturesEnabled } from "./experimental.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
@@ -785,6 +786,24 @@ export interface ExtensionBindings {
 }
 
 /** Options for AgentSession.prompt() */
+export interface TreeNavigationOptions {
+	summarize?: boolean;
+	customInstructions?: string;
+	replaceInstructions?: boolean;
+	label?: string;
+}
+
+export interface AssistantEditResult {
+	editorText?: string;
+	cancelled: boolean;
+	aborted?: boolean;
+	summaryEntry?: BranchSummaryEntry;
+	/** The replacement text matched the original, so nothing was appended. */
+	unchanged?: boolean;
+	/** Id of the appended edited assistant entry. */
+	entryId?: string;
+}
+
 export type PromptDisposition = "handled" | "queued" | "started";
 
 export type QueuedInput = {
@@ -8543,26 +8562,53 @@ export class AgentSession {
 	 */
 	async navigateTree(
 		targetId: string,
-		options: {
-			summarize?: boolean;
-			customInstructions?: string;
-			replaceInstructions?: boolean;
-			label?: string;
-		} = {},
+		options: TreeNavigationOptions = {},
 	): Promise<{
 		editorText?: string;
 		cancelled: boolean;
 		aborted?: boolean;
 		summaryEntry?: BranchSummaryEntry;
 	}> {
+		return this._navigateTree(targetId, options);
+	}
+
+	/**
+	 * Replace an assistant response with an edited copy. The leaf moves to the target's parent and
+	 * the edited message is appended there as the new leaf, so the original and everything after it
+	 * are abandoned exactly like a tree navigation (branch summary optional, `session_before_tree`
+	 * and `session_tree` fire). Unchanged text appends nothing.
+	 */
+	async editAssistantMessage(
+		entryId: string,
+		text: string,
+		options: TreeNavigationOptions = {},
+	): Promise<AssistantEditResult> {
+		const targetEntry = this.sessionManager.getEntry(entryId);
+		if (!targetEntry) {
+			throw new AssistantEditError("not-found", `Entry ${entryId} not found`);
+		}
+		if (targetEntry.type !== "message" || targetEntry.message.role !== "assistant") {
+			throw new AssistantEditError("not-assistant", `Entry ${entryId} is not an assistant message`);
+		}
+		if (assistantTextEquals(targetEntry.message, text)) {
+			return { cancelled: false, unchanged: true };
+		}
+		return this._navigateTree(entryId, options, buildEditedAssistantMessage(targetEntry.message, text));
+	}
+
+	private async _navigateTree(
+		targetId: string,
+		options: TreeNavigationOptions,
+		replacement?: AssistantMessage,
+	): Promise<AssistantEditResult> {
 		if (this.isStreaming) {
 			throw new Error("Wait for the current response to finish before navigating the session tree.");
 		}
 
 		const oldLeafId = this.sessionManager.getLeafId();
 
-		// No-op if already at target
-		if (targetId === oldLeafId) {
+		// No-op if already at target (a replacement of the leaf itself still has work to do)
+		if (targetId === oldLeafId && !replacement) {
 			return { cancelled: false };
 		}
 
@@ -8687,7 +8733,10 @@ export class AgentSession {
 			let newLeafId: string | null;
 			let editorText: string | undefined;
 
-			if (targetEntry.type === "message" && targetEntry.message.role === "user") {
+			if (replacement) {
+				// Edited assistant message: leaf = parent, the edited copy is appended below
+				newLeafId = targetEntry.parentId;
+			} else if (targetEntry.type === "message" && targetEntry.message.role === "user") {
 				// User message: leaf = parent (null if root), text goes to editor
 				newLeafId = targetEntry.parentId;
 				editorText = contentText(targetEntry.message.content, "");
@@ -8726,9 +8775,11 @@ export class AgentSession {
 				this.sessionManager.branch(newLeafId);
 			}
 
+			const editedEntryId = replacement ? this.sessionManager.appendMessage(replacement) : undefined;
+
 			// Attach label to target entry when not summarizing (no summary entry to label)
 			if (label && !summaryText) {
-				this.sessionManager.appendLabelChange(targetId, label);
+				this.sessionManager.appendLabelChange(editedEntryId ?? targetId, label);
 			}
 
 			// Update agent state (preserving exact messages still awaiting persistence)
@@ -8747,7 +8798,7 @@ export class AgentSession {
 
 			// Emit to custom tools
 
-			return { editorText, cancelled: false, summaryEntry };
+			return { editorText, cancelled: false, summaryEntry, entryId: editedEntryId };
 		} finally {
 			this._branchSummaryAbortController = undefined;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -785,7 +785,6 @@ export interface ExtensionBindings {
 	onError?: ExtensionErrorListener;
 }
 
-/** Options for AgentSession.prompt() */
 export interface TreeNavigationOptions {
 	summarize?: boolean;
 	customInstructions?: string;
@@ -804,6 +803,7 @@ export interface AssistantEditResult {
 	entryId?: string;
 }
 
+/** Options for AgentSession.prompt() */
 export type PromptDisposition = "handled" | "queued" | "started";
 
 export type QueuedInput = {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,24 @@
+## Editable assistant responses from the session tree (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `navigateTree()` delegates to a private `_navigateTree()` that also accepts a replacement assistant message; new public `editAssistantMessage(entryId, text, options)` validates the target, treats unchanged text as a no-op (`unchanged: true`), and otherwise branches to the target's parent and appends the edited copy as the new leaf, reusing the branch-summary flow, labels, agent-state restore and `session_before_tree` / `session_tree` events. New exported `TreeNavigationOptions` and `AssistantEditResult` types.
+- `packages/coding-agent/src/core/edited-assistant-message.ts` (new): `buildEditedAssistantMessage()` keeps only the trimmed text (tool calls, thinking and provider-native blocks dropped, `stopReason: "stop"`, model/provider/api/usage preserved), `assistantTextEquals()`, and `AssistantEditError`.
+- `packages/coding-agent/src/core/keybindings.ts`: new `app.tree.editMessage` action (default `ctrl+e`, legacy alias `treeEditMessage`).
+
+### Why
+
+- `/tree` could re-open a user message for editing but offered no way to correct an assistant response; users had to fork or re-prompt to steer past a wrong answer.
+
+### Why an extension could not handle it
+
+- Extensions can replace a message only at `message_end` time; rewriting an already persisted entry needs the session leaf move plus append that only `AgentSession` owns, and the tree keybinding lives in the core keybinding registry.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` `navigateTree()` body (renamed to `_navigateTree`, three small hunks for the replacement branch).
+- LOW: `keybindings.ts` tree action tables; the new module is fork-only.
+
 ## Registration-time shared-host capability (2026-09-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/edited-assistant-message.ts
+++ b/packages/coding-agent/src/core/edited-assistant-message.ts
@@ -1,0 +1,39 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { contentText } from "@earendil-works/pi-ai";
+
+export class AssistantEditError extends Error {
+	readonly reason: "empty" | "not-assistant" | "not-found";
+
+	constructor(reason: AssistantEditError["reason"], message: string) {
+		super(message);
+		this.name = "AssistantEditError";
+		this.reason = reason;
+	}
+}
+
+export function assistantTextEquals(original: AssistantMessage, text: string): boolean {
+	return contentText(original.content, "").trim() === text.trim();
+}
+
+/**
+ * Text replaces every content block: thinking signatures and tool calls belong to the abandoned
+ * response, and a leaf ending in tool calls without results is rejected by providers.
+ * Model identity and usage stay so per-path cost and context estimates remain accurate.
+ */
+export function buildEditedAssistantMessage(original: AssistantMessage, text: string): AssistantMessage {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) {
+		throw new AssistantEditError("empty", "Edited assistant response cannot be empty");
+	}
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: trimmed }],
+		api: original.api,
+		provider: original.provider,
+		model: original.model,
+		...(original.responseModel !== undefined ? { responseModel: original.responseModel } : {}),
+		usage: original.usage,
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -36,6 +36,7 @@ export interface AppKeybindings {
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
+	"app.tree.editMessage": true;
 	"app.tree.toggleLabelTimestamp": true;
 	"app.session.togglePath": true;
 	"app.session.toggleSort": true;
@@ -156,6 +157,10 @@ export const KEYBINDINGS = {
 	"app.tree.editLabel": {
 		defaultKeys: "shift+l",
 		description: "Edit tree label",
+	},
+	"app.tree.editMessage": {
+		defaultKeys: "ctrl+e",
+		description: "Edit the selected assistant response, or reopen a user message in the editor",
 	},
 	"app.tree.toggleLabelTimestamp": {
 		defaultKeys: "shift+t",
@@ -293,6 +298,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	treeFoldOrUp: "app.tree.foldOrUp",
 	treeUnfoldOrDown: "app.tree.unfoldOrDown",
 	treeEditLabel: "app.tree.editLabel",
+	treeEditMessage: "app.tree.editMessage",
 	treeToggleLabelTimestamp: "app.tree.toggleLabelTimestamp",
 	toggleSessionPath: "app.session.togglePath",
 	toggleSessionSort: "app.session.toggleSort",

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,23 @@
+## 2026-09-10 - Edit assistant responses from /tree
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/tree-selector.ts`: `TreeList.editSelected()` routes `app.tree.editMessage` — assistant entries call the new `onEditMessage` callback, user/custom messages reuse `onSelect`, other entries are ignored; the help line gains an `edit` hint and `TreeSelectorComponent` exposes `onEditMessage`.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the tree selector's summary prompt, streaming abort, summary indicator and post-navigation refresh moved into `runTreeNavigation()` shared by selection and the new `editAssistantMessageFromTree()` flow (extension editor prefilled with the response, empty/unchanged guards, summary prompt only when `treeNavigationAbandonsConversation()` finds abandoned messages).
+
+### Why
+
+- The session tree is where users already revisit responses; editing an assistant answer there and continuing from the edited copy avoids forking or re-prompting.
+
+### Why an extension could not handle it
+
+- The tree selector's key handling and the branch-navigation UI flow are interactive-mode internals with no extension hook.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` `showTreeSelector()` — the inline navigation body was extracted into `runTreeNavigation()`.
+- LOW: `tree-selector.ts` `handleInput` chain and `TREE_HELP_ITEMS`.
+
 
 ## 2026-09-09 - Surface required compaction after oversized resume
 

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -123,6 +123,7 @@ class TreeList implements Component {
 	public onSelect?: (entryId: string) => void;
 	public onCancel?: () => void;
 	public onCopy?: (text: string | undefined) => void;
+	public onEditMessage?: (entryId: string) => void;
 	public onLabelEdit?: (entryId: string, currentLabel: string | undefined) => void;
 
 	constructor(
@@ -629,6 +630,17 @@ class TreeList implements Component {
 		this.onCopy?.(node ? this.getEntryCopyText(node) : undefined);
 	}
 
+	/** Assistant responses open the edit flow; user-authored messages reuse the select flow, which already edits them. */
+	editSelected(): void {
+		const entry = this.getSelectedNode()?.entry;
+		if (!entry) return;
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			this.onEditMessage?.(entry.id);
+		} else if ((entry.type === "message" && entry.message.role === "user") || entry.type === "custom_message") {
+			this.onSelect?.(entry.id);
+		}
+	}
+
 	updateNodeLabel(entryId: string, label: string | undefined, labelTimestamp?: string): void {
 		for (const flatNode of this.flatNodes) {
 			if (flatNode.node.entry.id === entryId) {
@@ -1035,6 +1047,8 @@ class TreeList implements Component {
 			}
 		} else if (kb.matches(keyData, "app.message.copy")) {
 			this.copySelected();
+		} else if (kb.matches(keyData, "app.tree.editMessage")) {
+			this.editSelected();
 		} else if (kb.matches(keyData, "tui.select.cancel")) {
 			if (this.searchQuery) {
 				this.searchQuery = "";
@@ -1226,6 +1240,7 @@ const TREE_HELP_ITEMS: Array<{ keys: Keybinding[]; label: string; labelFirst?: b
 	{ keys: ["tui.editor.cursorLeft", "tui.editor.cursorRight"], label: "page" },
 	{ keys: ["app.tree.foldOrUp", "app.tree.unfoldOrDown"], label: "branch" },
 	{ keys: ["app.message.copy"], label: "copy" },
+	{ keys: ["app.tree.editMessage"], label: "edit" },
 	{ keys: ["app.tree.editLabel"], label: "label" },
 	{ keys: ["app.tree.toggleLabelTimestamp"], label: "label time" },
 	{
@@ -1339,6 +1354,7 @@ export class TreeSelectorComponent extends Container implements Focusable {
 	private treeContainer: Container;
 	private onLabelChangeCallback?: (entryId: string, label: string | undefined) => void;
 	public onCopy?: (text: string | undefined) => void;
+	public onEditMessage?: (entryId: string) => void;
 
 	// Focusable implementation - propagate to labelInput when active for IME cursor positioning
 	private _focused = false;
@@ -1372,6 +1388,7 @@ export class TreeSelectorComponent extends Container implements Focusable {
 		this.treeList.onSelect = onSelect;
 		this.treeList.onCancel = onCancel;
 		this.treeList.onCopy = (text) => this.onCopy?.(text);
+		this.treeList.onEditMessage = (entryId) => this.onEditMessage?.(entryId);
 		this.treeList.onLabelEdit = (entryId, currentLabel) => this.showLabelInput(entryId, currentLabel);
 
 		this.treeContainer = new Container();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { type AuthEvent, type AuthPrompt, modelsAreEqual } from "@earendil-works/pi-ai";
+import { type AuthEvent, type AuthPrompt, contentText, modelsAreEqual } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent, Usage } from "@earendil-works/pi-ai/compat";
 import type {
 	AutocompleteItem,
@@ -63,7 +63,12 @@ import {
 	getShareViewerUrl,
 	VERSION,
 } from "../../config.ts";
-import { type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
+import {
+	type AgentSessionEvent,
+	type AssistantEditResult,
+	parseSkillBlock,
+	type TreeNavigationOptions,
+} from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import { envValue } from "../../core/brand.ts";
@@ -74,6 +79,8 @@ import {
 	computeCacheWaste,
 	detectCacheMiss,
 } from "../../core/cache-stats.ts";
+import { collectEntriesForBranchSummary } from "../../core/compaction/branch-summarization.ts";
+import { assistantTextEquals } from "../../core/edited-assistant-message.ts";
 import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
@@ -7392,96 +7399,12 @@ export class InteractiveMode {
 						return;
 					}
 
-					// Ask about summarization
 					done(); // Close selector first
-
-					// Loop until user makes a complete choice or cancels to tree
-					let wantsSummary = false;
-					let customInstructions: string | undefined;
-
-					// Check if we should skip the prompt (user preference to always default to no summary)
-					if (!this.settingsManager.getBranchSummarySkipPrompt()) {
-						while (true) {
-							const summaryChoice = await this.showExtensionSelector("Summarize branch?", [
-								"No summary",
-								"Summarize",
-								"Summarize with custom prompt",
-							]);
-
-							if (summaryChoice === undefined) {
-								// User pressed escape - re-show tree selector with same selection
-								this.showTreeSelector(entryId);
-								return;
-							}
-
-							wantsSummary = summaryChoice !== "No summary";
-
-							if (summaryChoice === "Summarize with custom prompt") {
-								customInstructions = await this.showExtensionEditor("Custom summarization instructions");
-								if (customInstructions === undefined) {
-									// User cancelled - loop back to summary selector
-									continue;
-								}
-							}
-
-							// User made a complete choice
-							break;
-						}
-					}
-
-					// The user committed to navigating: stop the active response first.
-					if (this.session.isStreaming) {
-						this.restoreQueuedMessagesToEditor();
-						await this.session.abort();
-					}
-
-					// Set up escape handler and status indicator if summarizing
-					let showingSummaryIndicator = false;
-					const originalOnEscape = this.defaultEditor.onEscape;
-
-					if (wantsSummary) {
-						this.defaultEditor.onEscape = () => {
-							this.session.abortBranchSummary();
-						};
-						this.chatContainer.addChild(new Spacer(1));
-						this.showStatusIndicator(new BranchSummaryStatusIndicator(this.ui));
-						showingSummaryIndicator = true;
-						this.ui.requestRender();
-					}
-
-					try {
-						const result = await this.session.navigateTree(entryId, {
-							summarize: wantsSummary,
-							customInstructions,
-						});
-
-						if (result.aborted) {
-							// Summarization aborted - re-show tree selector with same selection
-							this.showStatus("Branch summarization cancelled");
-							this.showTreeSelector(entryId);
-							return;
-						}
-						if (result.cancelled) {
-							this.showStatus("Navigation cancelled");
-							return;
-						}
-
-						// Update UI
-						this.chatContainer.clear();
-						this.renderInitialMessages();
-						if (result.editorText && !this.editor.getText().trim()) {
-							this.editor.setText(result.editorText);
-						}
-						this.showStatus("Navigated to selected point");
-						void this.flushCompactionQueue({ willRetry: false });
-					} catch (error) {
-						this.showError(error instanceof Error ? error.message : String(error));
-					} finally {
-						if (showingSummaryIndicator) {
-							this.clearStatusIndicator("branchSummary");
-						}
-						this.defaultEditor.onEscape = originalOnEscape;
-					}
+					await this.runTreeNavigation(entryId, {
+						promptForSummary: true,
+						navigate: (options) => this.session.navigateTree(entryId, options),
+						successStatus: "Navigated to selected point",
+					});
 				},
 				() => {
 					done();
@@ -7506,8 +7429,153 @@ export class InteractiveMode {
 					this.showError(error instanceof Error ? error.message : String(error));
 				}
 			};
+			selector.onEditMessage = (entryId) => {
+				done();
+				void this.editAssistantMessageFromTree(entryId);
+			};
 			return { component: selector, focus: selector };
 		});
+	}
+
+	private async editAssistantMessageFromTree(entryId: string): Promise<void> {
+		const entry = this.sessionManager.getEntry(entryId);
+		if (entry?.type !== "message" || entry.message.role !== "assistant") {
+			this.showError("Only assistant responses can be edited here");
+			return;
+		}
+		const message = entry.message;
+		const dropsToolCalls = message.content.some((block) => block.type === "toolCall");
+		const title = dropsToolCalls
+			? "Edit assistant response (its tool calls will be dropped)"
+			: "Edit assistant response";
+		const edited = await this.showExtensionEditor(title, contentText(message.content, ""));
+		if (edited === undefined) {
+			this.showTreeSelector(entryId);
+			return;
+		}
+		if (!edited.trim()) {
+			this.showError("Assistant response cannot be empty");
+			this.showTreeSelector(entryId);
+			return;
+		}
+		if (assistantTextEquals(message, edited)) {
+			this.showStatus("Assistant response unchanged");
+			return;
+		}
+		await this.runTreeNavigation(entryId, {
+			promptForSummary: this.treeNavigationAbandonsConversation(entryId),
+			navigate: (options) => this.session.editAssistantMessage(entryId, edited, options),
+			successStatus: "Replaced assistant response with your edit",
+		});
+	}
+
+	/** Bookkeeping entries after the target (thinking level, labels, custom state) leave nothing to summarize. */
+	private treeNavigationAbandonsConversation(targetId: string): boolean {
+		const { entries } = collectEntriesForBranchSummary(
+			this.sessionManager,
+			this.sessionManager.getLeafId(),
+			targetId,
+		);
+		return entries.some(
+			(entry) =>
+				entry.type === "message" ||
+				entry.type === "custom_message" ||
+				entry.type === "compaction" ||
+				entry.type === "branch_summary",
+		);
+	}
+
+	private async promptBranchSummaryChoice(): Promise<{ summarize: boolean; customInstructions?: string } | undefined> {
+		while (true) {
+			const summaryChoice = await this.showExtensionSelector("Summarize branch?", [
+				"No summary",
+				"Summarize",
+				"Summarize with custom prompt",
+			]);
+			if (summaryChoice === undefined) {
+				return undefined;
+			}
+			if (summaryChoice !== "Summarize with custom prompt") {
+				return { summarize: summaryChoice !== "No summary" };
+			}
+			const customInstructions = await this.showExtensionEditor("Custom summarization instructions");
+			if (customInstructions !== undefined) {
+				return { summarize: true, customInstructions };
+			}
+		}
+	}
+
+	private async runTreeNavigation(
+		entryId: string,
+		flow: {
+			promptForSummary: boolean;
+			navigate: (options: TreeNavigationOptions) => Promise<AssistantEditResult>;
+			successStatus: string;
+		},
+	): Promise<void> {
+		let wantsSummary = false;
+		let customInstructions: string | undefined;
+		if (flow.promptForSummary && !this.settingsManager.getBranchSummarySkipPrompt()) {
+			const choice = await this.promptBranchSummaryChoice();
+			if (choice === undefined) {
+				// User pressed escape - re-show tree selector with same selection
+				this.showTreeSelector(entryId);
+				return;
+			}
+			wantsSummary = choice.summarize;
+			customInstructions = choice.customInstructions;
+		}
+
+		// The user committed to navigating: stop the active response first.
+		if (this.session.isStreaming) {
+			this.restoreQueuedMessagesToEditor();
+			await this.session.abort();
+		}
+
+		// Set up escape handler and status indicator if summarizing
+		let showingSummaryIndicator = false;
+		const originalOnEscape = this.defaultEditor.onEscape;
+
+		if (wantsSummary) {
+			this.defaultEditor.onEscape = () => {
+				this.session.abortBranchSummary();
+			};
+			this.chatContainer.addChild(new Spacer(1));
+			this.showStatusIndicator(new BranchSummaryStatusIndicator(this.ui));
+			showingSummaryIndicator = true;
+			this.ui.requestRender();
+		}
+
+		try {
+			const result = await flow.navigate({ summarize: wantsSummary, customInstructions });
+
+			if (result.aborted) {
+				// Summarization aborted - re-show tree selector with same selection
+				this.showStatus("Branch summarization cancelled");
+				this.showTreeSelector(entryId);
+				return;
+			}
+			if (result.cancelled) {
+				this.showStatus("Navigation cancelled");
+				return;
+			}
+
+			// Update UI
+			this.chatContainer.clear();
+			this.renderInitialMessages();
+			if (result.editorText && !this.editor.getText().trim()) {
+				this.editor.setText(result.editorText);
+			}
+			this.showStatus(flow.successStatus);
+			void this.flushCompactionQueue({ willRetry: false });
+		} catch (error) {
+			this.showError(error instanceof Error ? error.message : String(error));
+		} finally {
+			if (showingSummaryIndicator) {
+				this.clearStatusIndicator("branchSummary");
+			}
+			this.defaultEditor.onEscape = originalOnEscape;
+		}
 	}
 
 	private showSessionSelector(): void {

--- a/packages/coding-agent/test/suite/tree-edit-assistant-message.test.ts
+++ b/packages/coding-agent/test/suite/tree-edit-assistant-message.test.ts
@@ -1,0 +1,183 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxText, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SessionTreeEvent } from "../../src/core/extensions/types.ts";
+import type { SessionMessageEntry } from "../../src/core/session-manager.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+function isAssistantEntry(entry: { type: string; message?: { role: string } }): entry is SessionMessageEntry {
+	return entry.type === "message" && entry.message?.role === "assistant";
+}
+
+function assistantEntries(harness: Harness): SessionMessageEntry[] {
+	return harness.sessionManager.getEntries().filter(isAssistantEntry);
+}
+
+function assistantMessageOf(entry: SessionMessageEntry): AssistantMessage {
+	if (entry.message.role !== "assistant") throw new Error(`entry ${entry.id} is not an assistant message`);
+	return entry.message;
+}
+
+describe("AgentSession.editAssistantMessage", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	const treeEvents: SessionTreeEvent[] = [];
+
+	async function createConversation(): Promise<Harness> {
+		const harness = await createHarness({
+			persistSession: true,
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_tree", (event) => {
+						treeEvents.push(event);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		treeEvents.length = 0;
+		harness.setResponses([fauxAssistantMessage("The answer is 41."), fauxAssistantMessage("Anything else?")]);
+		await harness.session.prompt("What is the answer?");
+		await harness.session.prompt("Thanks");
+		return harness;
+	}
+
+	it("appends an edited copy under the original parent and makes it the leaf", async () => {
+		const harness = await createConversation();
+		const [a1] = assistantEntries(harness);
+		if (!a1) throw new Error("expected an assistant entry");
+		const original = assistantMessageOf(a1);
+		const entryCountBefore = harness.sessionManager.getEntries().length;
+		const leafBefore = harness.sessionManager.getLeafId();
+
+		const result = await harness.session.editAssistantMessage(a1.id, "The answer is 42.", { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.unchanged).toBeUndefined();
+		if (!result.entryId) throw new Error("expected the edited entry id");
+		const edited = harness.sessionManager.getEntry(result.entryId);
+		if (!edited || !isAssistantEntry(edited)) throw new Error("expected the edited assistant entry");
+		const editedMessage = assistantMessageOf(edited);
+		expect(edited.parentId).toBe(a1.parentId);
+		expect(harness.sessionManager.getLeafId()).toBe(edited.id);
+		expect(editedMessage.content).toEqual([{ type: "text", text: "The answer is 42." }]);
+		expect(editedMessage.stopReason).toBe("stop");
+		expect(editedMessage.model).toBe(original.model);
+		expect(editedMessage.provider).toBe(original.provider);
+		expect(editedMessage.api).toBe(original.api);
+		expect(editedMessage.usage).toEqual(original.usage);
+		expect(getMessageText(assistantMessageOf(a1))).toBe("The answer is 41.");
+		expect(harness.sessionManager.getEntries().length).toBe(entryCountBefore + 1);
+		const contextMessages = harness.sessionManager.buildSessionContext().messages;
+		const lastMessage = contextMessages[contextMessages.length - 1];
+		expect(lastMessage?.role).toBe("assistant");
+		expect(lastMessage && getMessageText(lastMessage)).toBe("The answer is 42.");
+		expect(contextMessages.some((message) => message.role === "user" && getMessageText(message) === "Thanks")).toBe(
+			false,
+		);
+		expect(harness.agent.state.messages).toHaveLength(contextMessages.length);
+		expect(treeEvents).toHaveLength(1);
+		expect(treeEvents[0]?.newLeafId).toBe(edited.id);
+		expect(treeEvents[0]?.oldLeafId).toBe(leafBefore);
+	});
+
+	it("keeps only the edited text when the original carried thinking and tool calls", async () => {
+		const harness = await createConversation();
+		const [a1] = assistantEntries(harness);
+		if (!a1) throw new Error("expected an assistant entry");
+		harness.sessionManager.branch(a1.id);
+		const withTools = fauxAssistantMessage(
+			[
+				fauxThinking("Let me look."),
+				fauxText("Checking the file."),
+				fauxToolCall("read", { path: "x" }, { id: "call-1" }),
+			],
+			{ stopReason: "toolUse" },
+		);
+		const toolCallEntryId = harness.sessionManager.appendMessage(withTools);
+		harness.sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: "file contents" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+
+		const result = await harness.session.editAssistantMessage(toolCallEntryId, "Here is the answer.", {
+			summarize: false,
+		});
+
+		if (!result.entryId) throw new Error("expected the edited entry id");
+		const edited = harness.sessionManager.getEntry(result.entryId);
+		if (!edited || !isAssistantEntry(edited)) throw new Error("expected the edited assistant entry");
+		const editedMessage = assistantMessageOf(edited);
+		expect(edited.parentId).toBe(a1.id);
+		expect(editedMessage.content).toEqual([{ type: "text", text: "Here is the answer." }]);
+		expect(editedMessage.stopReason).toBe("stop");
+		const contextMessages = harness.sessionManager.buildSessionContext().messages;
+		expect(contextMessages.some((message) => message.role === "toolResult")).toBe(false);
+		expect(contextMessages[contextMessages.length - 1]?.role).toBe("assistant");
+	});
+
+	it("leaves the session untouched when the text did not change", async () => {
+		const harness = await createConversation();
+		const [a1] = assistantEntries(harness);
+		if (!a1) throw new Error("expected an assistant entry");
+		const leafBefore = harness.sessionManager.getLeafId();
+		const entryCountBefore = harness.sessionManager.getEntries().length;
+
+		const result = await harness.session.editAssistantMessage(a1.id, "  The answer is 41.\n", { summarize: false });
+
+		expect(result.unchanged).toBe(true);
+		expect(result.entryId).toBeUndefined();
+		expect(harness.sessionManager.getLeafId()).toBe(leafBefore);
+		expect(harness.sessionManager.getEntries().length).toBe(entryCountBefore);
+	});
+
+	it("rejects targets that are not assistant messages and empty replacements", async () => {
+		const harness = await createConversation();
+		const [a1] = assistantEntries(harness);
+		if (!a1?.parentId) throw new Error("expected a parented assistant entry");
+		const leafBefore = harness.sessionManager.getLeafId();
+
+		await expect(harness.session.editAssistantMessage(a1.parentId, "x", { summarize: false })).rejects.toThrow(
+			/not an assistant message/,
+		);
+		await expect(harness.session.editAssistantMessage("missing-entry", "x", { summarize: false })).rejects.toThrow(
+			/not found/,
+		);
+		await expect(harness.session.editAssistantMessage(a1.id, "   \n", { summarize: false })).rejects.toThrow(/empty/);
+		expect(harness.sessionManager.getLeafId()).toBe(leafBefore);
+	});
+
+	it("refuses to edit while a response is streaming and keeps the leaf", async () => {
+		const harness = await createConversation();
+		const [a1] = assistantEntries(harness);
+		if (!a1) throw new Error("expected an assistant entry");
+		let editResult: unknown;
+		let leafDuringEdit: string | null | undefined;
+		harness.setResponses([
+			async () => {
+				editResult = await harness.session
+					.editAssistantMessage(a1.id, "edited mid-stream", { summarize: false })
+					.catch((error: unknown) => error);
+				leafDuringEdit = harness.sessionManager.getLeafId();
+				return fauxAssistantMessage("streamed");
+			},
+		]);
+
+		await harness.session.prompt("third");
+
+		expect(editResult).toBeInstanceOf(Error);
+		expect(String(editResult)).toMatch(/current response to finish/);
+		expect(leafDuringEdit).not.toBe(a1.parentId);
+		expect(
+			assistantEntries(harness).some((entry) => getMessageText(assistantMessageOf(entry)) === "edited mid-stream"),
+		).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -265,6 +265,7 @@ describe("TreeSelectorComponent", () => {
 			const plain = plainLines.join("\n");
 			expect(plain).toContain("branch");
 			expect(plain).toContain("copy");
+			expect(plain).toContain("edit");
 			expect(plain).toContain("filters");
 			expect(plain).toContain("cycle");
 			expect(plain).toContain("label time");
@@ -292,6 +293,79 @@ describe("TreeSelectorComponent", () => {
 			selector.handleInput("\x18");
 
 			expect(copied).toBe(message);
+		});
+	});
+
+	describe("edit message", () => {
+		function createEditSelector(entries: SessionEntry[], currentLeafId: string) {
+			const selected: string[] = [];
+			const edited: string[] = [];
+			const selector = new TreeSelectorComponent(
+				buildTree(entries),
+				currentLeafId,
+				24,
+				(entryId) => selected.push(entryId),
+				() => {},
+			);
+			selector.onEditMessage = (entryId) => edited.push(entryId);
+			return { selector, selected, edited };
+		}
+
+		test("requests an assistant edit with ctrl+e instead of navigating", () => {
+			const { selector, selected, edited } = createEditSelector(
+				[userMessage("user-1", null, "hello"), assistantMessage("asst-1", "user-1", "The answer is 41.")],
+				"asst-1",
+			);
+
+			selector.handleInput("\x05");
+
+			expect(edited).toEqual(["asst-1"]);
+			expect(selected).toEqual([]);
+		});
+
+		test("falls back to the select flow when ctrl+e targets a user message", () => {
+			const { selector, selected, edited } = createEditSelector(
+				[userMessage("user-1", null, "hello"), assistantMessage("asst-1", "user-1", "hi")],
+				"asst-1",
+			);
+			selector.handleInput("\x1b[A"); // up: select user-1
+			expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe("user-1");
+
+			selector.handleInput("\x05");
+
+			expect(selected).toEqual(["user-1"]);
+			expect(edited).toEqual([]);
+		});
+
+		test("ignores ctrl+e on entries that are not messages", () => {
+			const { selector, selected, edited } = createEditSelector(
+				[
+					userMessage("user-1", null, "hello"),
+					modelChange("model-1", "user-1"),
+					assistantMessage("asst-1", "model-1", "hi"),
+				],
+				"asst-1",
+			);
+			selector.handleInput("\x01"); // ctrl+a: show all entries
+			selector.handleInput("\x1b[A"); // up: select model-1
+			expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe("model-1");
+
+			selector.handleInput("\x05");
+
+			expect(selected).toEqual([]);
+			expect(edited).toEqual([]);
+		});
+
+		test("keeps enter on an assistant message as plain navigation", () => {
+			const { selector, selected, edited } = createEditSelector(
+				[userMessage("user-1", null, "hello"), assistantMessage("asst-1", "user-1", "hi")],
+				"asst-1",
+			);
+
+			selector.handleInput("\r");
+
+			expect(selected).toEqual(["asst-1"]);
+			expect(edited).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
## Summary
`/tree` can now edit an assistant response. Pressing `ctrl+e` (`app.tree.editMessage`) on an assistant entry opens it in the multi-line editor; submitting branches to that entry's parent and appends the edited copy as the new leaf, so the conversation continues from the corrected response while the original stays in the session file on an abandoned branch. On a user message the same key reopens it in the editor exactly like `enter` already does.

Upstream pi offers no way to edit an already persisted assistant message (extensions can only replace a message at `message_end`), so this adds the operation to `AgentSession` and wires the tree selector to it.

## Changes
- **Core (`AgentSession`)**: `navigateTree()` now delegates to a private `_navigateTree()` that optionally appends a replacement assistant message after moving the leaf; new public `editAssistantMessage(entryId, text, options)` validates the target (assistant message only, non-empty text), treats unchanged text as a no-op (`unchanged: true`), and otherwise reuses the whole navigation flow (branch summary, labels, agent-state restore, `session_before_tree`/`session_tree`). New `edited-assistant-message.ts` builds the copy: only the trimmed text survives (tool calls, thinking and provider-native blocks are dropped so the new leaf never ends in tool calls without results), `stopReason: "stop"`, model/provider/api/usage preserved so per-path cost and context estimates stay accurate.
- **Keybindings**: `app.tree.editMessage` (default `ctrl+e`, legacy alias `treeEditMessage`); the tree selector routes it via `TreeList.editSelected()` (assistant -> `onEditMessage`, user/custom message -> `onSelect`, other entries ignored) and shows an `edit` hint in the help line.
- **Interactive mode**: the selection flow's summary prompt / streaming abort / indicator / refresh moved into `runTreeNavigation()`, shared by the existing select path and the new `editAssistantMessageFromTree()` (editor prefilled with the response; empty and unchanged guards; the "Summarize branch?" prompt is only shown when the abandoned path contains messages, not just bookkeeping entries).
- **Docs**: CHANGELOG `[Unreleased]` entry, README tree bullets, `docs/keybindings.md`, `docs/usage.md`, and the `core/` + `modes/interactive/` `changes.md` trackers.

## QA & Evidence
- **Unit/integration (vitest, run on gorky via bunshin)**: `test/suite/tree-edit-assistant-message.test.ts` (edited copy under original parent + leaf + `session_tree`; tool calls/thinking dropped and tool results off-path; unchanged no-op; non-assistant/missing/empty rejected with leaf unchanged; refused while streaming) and `test/tree-selector.test.ts` edit-message cases were RED before the implementation (8 failed / 18 passed: `editAssistantMessage is not a function`, ctrl+e did nothing, no `edit` hint) and GREEN after (26/26). Final tree: tree-selector, tree-edit-assistant-message, branch-summary-extensions, tree-during-streaming, 2860-replaced-session-context, keybindings -> 36 passed, 0 failed (agent-session-tree-navigation.test.ts skipped by its pre-existing API-key gate).
- **Real TUI (xterm.js web terminal, seeded session u1 -> a1 "The answer is 41.")**: released senpi 2026.9.9-2: `/tree`, ctrl+e -> tree stays open, no editor (RED). This branch's build: ctrl+e -> "Edit assistant response" editor prefilled; End, type " Actually 42.", Enter -> chat re-renders "The answer is 41. Actually 42." with status "Replaced assistant response with your edit"; the JSONL gained an assistant entry with `parentId` = u1 and the original a1 untouched, leaf moved to the new entry. No summary prompt appeared because only bookkeeping entries followed a1.
- **Static**: root `tsc --noEmit` clean, biome clean on changed files, `bun scripts/build-all.mjs --pm bun` exit 0, changelog gate PASS (4 production paths covered by trackers).

## Risks & Residuals
- Editing a response that carried tool calls drops them (title warns "its tool calls will be dropped"); descendants of the original are abandoned like any other tree navigation. Mitigated by the tool-call regression test and the summary prompt when messages are abandoned.
- Anthropic signed thinking blocks are intentionally not carried into the edited copy.
- RPC / extension API do not yet expose `editAssistantMessage`; hosts can call the `AgentSession` method directly. Follow-up if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`/tree` can now edit an assistant response. Pressing `ctrl+e` on an assistant entry opens it in the editor; submitting branches to that entry's parent and appends the edited copy as the new leaf, so the conversation continues from the corrected response while the original stays in the session file. On a user message the same key reopens it in the editor like `enter`.

- Adds `AgentSession.editAssistantMessage(entryId, text, options)` so hosts can do the same programmatically; it rejects non-assistant targets and empty text, and treats unchanged text as a no-op.
- The edited copy keeps only the text: tool calls and thinking blocks are dropped, and model/provider/api usage are preserved so per-path cost estimates stay accurate.
- The branch-summary prompt now only appears when the abandoned path contains real messages, not just bookkeeping entries.
- Editing is refused while a response is streaming; the new `app.tree.editMessage` keybinding has a legacy alias `treeEditMessage`.

<sup>Written for commit 66ee17d19ed798900fde8076c4e69682f713bf86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

