### PR TITLE
docs(agents): refresh AGENTS.md knowledge base for 2026-09-10 HEAD

### DIFF
--- a/.agents/skills/senpi-qa/AGENTS.md
+++ b/.agents/skills/senpi-qa/AGENTS.md
@@ -1,16 +1,16 @@
 # .agents/skills/senpi-qa
 
-Manual QA harness for the senpi coding agent, driven from source in isolated sandboxes. `SKILL.md` is the operating manual (channels, golden rules, evidence contract); root `AGENTS.md` owns when QA is mandatory. This file maps the ~107-script codebase behind them.
+Manual QA harness for the senpi coding agent, driven from source in isolated sandboxes. `SKILL.md` is the operating manual (channels, golden rules, evidence contract); root `AGENTS.md` owns when QA is mandatory. This file maps 121 script files behind them. Retained at score 13: a distinct QA domain with its own dependency configuration.
 
 ## STRUCTURE
 
 ```text
 SKILL.md                                 Channel manual; start here to run QA
-scripts/*.mjs (32)                       Top-level drivers (rpc-drive, tui-smoke,
+scripts/*.mjs (38)                       Top-level drivers (rpc-drive, tui-smoke,
                                          mock-loop, cli-smoke, pty-drive) + focused QA
-scripts/lib/ (42)                        Shared harness; common.mjs is the foundation
+scripts/lib/ (43, including tests)       Shared harness; common.mjs is the foundation
 scripts/lib/*.test.mjs (4)               node:test units for lib helpers
-scripts/scenarios/ (30 + helpers)        One-off runners; -qa checks, -repro bugs
+scripts/scenarios/ (31 + 6 helpers)      One-off runners; -qa checks, -repro bugs
 scripts/scenarios/cursor-exec-lifecycle/ HTTP/2 + protobuf Cursor wire helpers
 scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts  Only TypeScript here; runs via tsx
 scripts/probes/cursor-cli/ (3)           Cursor CLI canaries/probes
@@ -25,36 +25,36 @@ package.json + package-lock.json         Private dep island (node-pty only); sta
 
 | Task | Path |
 |---|---|
-| Run a channel / self-test suite | `SKILL.md` scripts index |
+| Run a channel / self-test suite | `SKILL.md`; driver-specific map in `scripts/AGENTS.md` |
 | Sandbox, CLI spawn, auth guard, evidence | `scripts/lib/common.mjs` |
 | Provider presets, mock `models.json`, MCP fixtures | `scripts/lib/mock-loop-support.mjs` |
 | Fake model server (three wire formats) | `scripts/lib/fake-model-server.mjs` |
-| RPC clients for QA | `scripts/lib/rpc-client.mjs`, `rpc-qa-client.mjs`, `target-rpc-client.mjs` |
-| New regression scenario | `scripts/scenarios/<name>-qa.mjs` + `--evidence <slug>` |
+| RPC clients for QA | `scripts/lib/rpc-client.mjs`, `scripts/lib/rpc-qa-client.mjs`, `scripts/lib/target-rpc-client.mjs` |
+| New regression scenario | `scripts/scenarios/AGENTS.md`; runners have individual argument/evidence contracts |
 | Cursor CLI behavior | `scripts/probes/cursor-cli/`, `scripts/scenarios/cursor-*` |
 | Env/credential rules | `references/env-vars.md`, `references/credential-injection.md` |
 
 ## CONVENTIONS
 
 - ESM `.mjs` with explicit `node:` imports; relative imports carry extensions.
-- Every executable ships `--self-test`/`--self-check`; a script is both tool and regression check.
-- Isolation via `lib/common.mjs`: `makeSandbox`, `scrubSandboxEnv`, `PI_OFFLINE=1`, `PI_TELEMETRY=0`, `guardRealAuth`.
-- Drive the CLI from source through `tsxEntry()`; never assume built `dist`.
-- Suffix taxonomy: `-qa` check, `-repro` bug reproduction, `-spike`/`-probe` gated exploration.
+- Channel drivers expose `--self-test`/`--self-check`; many focused scenarios execute their assertions directly instead.
+- Isolation via `scripts/lib/common.mjs`: `makeSandbox`, `scrubSandboxEnv`, `PI_OFFLINE=1`, `PI_TELEMETRY=0`, `guardRealAuth`; provider-key scrubbing is separate (`scripts/lib/AGENTS.md`).
+- Drive the CLI from source, normally through `tsxEntry()`; never assume built `dist`. The GPT-6 Astra driver uses Bun directly.
+- Suffix taxonomy: `-qa` check, `-repro` bug reproduction, `-spike`/`-probe` exploration; suffixes do not establish whether a run is hermetic.
 - Evidence to `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/` via `--evidence`/`evidenceDir()`.
 - Lib units use `node:test` + `node:assert/strict`, not Vitest.
 
 ## ANTI-PATTERNS
 
-- Never read or write the real `~/.senpi`; snapshot `auth.json` sha256 and assert unchanged.
-- Never inherit or log provider env/auth headers: scrub before spawn, `sanitizeRequests` before evidence.
+- Never mutate real `~/.senpi` or use its credentials for default QA. `guardRealAuth()` reads the original auth file only to hash it; call `assertUnchanged()` after the run.
+- Never inherit provider keys into mock runs or log auth headers: scrub before spawn and redact request evidence; sanitizers are local helpers, not a shared exported API.
 - No `src/` edits from this skill — it verifies and reports; fixes are follow-up changes.
-- No unbounded sleeps as synchronization; bounded observable waits and watchdogs only.
-- Live external paths are opt-in gates (`SENPI_CURSOR_CLI_LIVE=1`, `SENPI_LIVE_CLAUDE_SDK_OAUTH=1`), never defaults.
+- Subscribe to the exact completion signal before triggering it, with a bounded watchdog; do not copy fixed-delay polling from legacy scenarios.
+- Live external runs require explicit intent. Gates such as `SENPI_CURSOR_CLI_LIVE=1` and `SENPI_LIVE_CLAUDE_SDK_OAUTH=1` cover specific runners, not every probe; inspect its argument/auth path first.
 - Never treat generated Cursor protobuf TypeScript as hand-authored wire logic.
 
 ## VALIDATION
 
 - Setup once: `bun scripts/devenv-setup.mjs`; harness check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`.
-- Lib units: `node --test .agents/skills/senpi-qa/scripts/lib/` (runs the four `*.test.mjs`).
-- A new script is not done until its own `--self-test` passes with evidence captured.
+- Lib units: `node --test .agents/skills/senpi-qa/scripts/lib/*.test.mjs` (four files; independent of root workspace tests).
+- A new script is not done until its actual regression entry point passes with evidence captured; do not append an unsupported `--self-test` flag.

--- a/.agents/skills/senpi-qa/scripts/AGENTS.md
+++ b/.agents/skills/senpi-qa/scripts/AGENTS.md
@@ -1,0 +1,45 @@
+# QA Drivers
+
+## OVERVIEW
+
+Channel entry points and focused probes; score 12, a distinct executable-driver domain above the shared library and regression scenarios.
+
+## WHERE TO LOOK
+
+| Task | Driver | Contract |
+|---|---|---|
+| Headless liveness / prompt events | `rpc-drive.mjs` | `--state`, `--prompt`, `--self-test` |
+| Deterministic provider/tool loop | `mock-loop.mjs` | Three API presets; tool, MCP, retry and reasoning cases |
+| Interactive boot and composer input | `tui-smoke.mjs` | node-pty; `--driver tmux` selects the POSIX alternative |
+| Offline flags and model listing | `cli-smoke.mjs` | No model turn needed |
+| Persistent terminal runtime | `pty-drive.mjs` | Native PTY or `--force-pipe` |
+| First-byte steering and transport recovery | `mock-loop-stream-start-timeout-steering.mjs`, `mock-loop-transport-timeout-recovery.mjs` | RPC scenarios with `--evidence-dir` |
+| SDK query/session continuity | `claude-sdk-oauth-fullstack-probe.mjs` | Real SDK subprocess against loopback; `--matrix` selects continuity phases |
+| New prompt presets on the wire | `gpt-6-astra-preset-mock-loop.mjs`, `glm-5.3-preset-mock-loop.mjs` | Capture the real CLI's model request, not just a rendered prompt fixture |
+| Cursor CLI transport limits | `probes/cursor-cli/prompt-ceiling-probe.mjs` | `--out` report; `--self-test` exercises its local classifier logic |
+| Cursor permissions / resume model swaps | `probes/cursor-cli/permissions-config-probe.mjs`, `probes/cursor-cli/resume-model-swap-canary.mjs` | Separate external-CLI investigations, not channel smoke tests |
+
+## CONVENTIONS
+
+- Run channel commands from the repository root; `../SKILL.md` owns the complete channel recipe.
+- Most drivers use Node plus the shared tsx launcher; the Astra preset driver intentionally spawns source with its current Bun runtime.
+- Full-stack OAuth continuity is hermetic despite its name; live OAuth spikes are separate entry points.
+- Full-stack gate mode returns 1 on behavioral failure and 2 on infrastructure rejection; `--baseline` is observational, not a passing gate.
+- Evidence options differ: `--evidence` is usually a slug, the two timeout drivers use `--evidence-dir`, and Cursor probes use `--out`.
+- Prompt-ceiling probe's normal `--out` path prepares a temporary Cursor HOME from Keychain credentials. Its `--self-test` returns before that setup.
+
+## COMMANDS
+
+```bash
+node .agents/skills/senpi-qa/scripts/rpc-drive.mjs --self-test
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
+node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs --matrix
+bun .agents/skills/senpi-qa/scripts/gpt-6-astra-preset-mock-loop.mjs
+```
+
+## ANTI-PATTERNS
+
+- Do not sweep every `.mjs` as an offline suite: executable bodies, runtime requirements, live credentials and exit contracts differ.
+- Do not import `rpc-drive.mjs` for a client; its module body dispatches on argv. Import `lib/rpc-client.mjs` instead.
+- Do not count TUI boot/render/input as proof of provider or loop correctness; those assertions belong in RPC/mock-loop runs.
+- Do not interpret a baseline exit code of 0 as continuity success; inspect the verdict or use gate mode.

--- a/.agents/skills/senpi-qa/scripts/lib/AGENTS.md
+++ b/.agents/skills/senpi-qa/scripts/lib/AGENTS.md
@@ -1,0 +1,46 @@
+# QA Harness Library
+
+## OVERVIEW
+
+Shared process, transport and scenario machinery; score 12, with high export density and more than 20 import-backed references to the core harness symbols.
+
+## WHERE TO LOOK
+
+| Concern | Module | Local detail |
+|---|---|---|
+| Brand/session isolation | `common.mjs` | `scrubSandboxEnv` removes inherited brand-prefix and session steering variables |
+| Provider-key isolation | `mock-loop-support.mjs` | `hermeticEnv` removes `PROVIDER_ENV_KEYS`; it is separate from sandbox creation |
+| Generic buffered RPC | `rpc-client.mjs` | `RpcClient` retains event history and correlates responses by id |
+| Turn-scoped RPC waits | `rpc-qa-client.mjs` | `RpcQaClient.waitForEvent` accepts an `afterIndex` cursor |
+| Alternate-worktree RPC | `target-rpc-client.mjs` | `TargetRpcClient` accepts `targetRoot`; events are `{ at, message }` |
+| Additional mock models / retry settings | `mock-loop-support.mjs` | `writeMockModelsJson` writes sandbox models and optional settings |
+| Full-stack SDK setup | `claude-sdk-oauth-fullstack-harness.mjs`, `claude-sdk-oauth-hermetic-env.mjs` | Real session stack with SDK interception and loopback-only traffic |
+| Continuity expectations | `claude-sdk-oauth-matrix.mjs`, `claude-sdk-oauth-matrix-phases.mjs`, `claude-sdk-oauth-matrix-assert.mjs` | Runner, phase definitions and lineage/query assertions |
+| Cache-warm RPC plus terminal proof | `cache-warm-ready-scenario.mjs`, `cache-warm-ready-rpc.mjs` | Shared scenario orchestration and RPC evidence extraction |
+| TUI resume mechanics | `tui-resume-args.mjs`, `tui-resume-pty.mjs`, `tui-resume-signal.mjs`, `tui-resume-teardown.mjs` | Argument, terminal, signal and teardown boundaries |
+| Sanitized diagnostic details | `output-safety.mjs` | `safeDetail` for probe verdict/error output |
+
+## CONVENTIONS
+
+- `makeSandbox()` pins HOME and USERPROFILE to the temporary directory and disables `SENPI_OMO_LOCAL_UPDATE`; preserve these alongside agent/session directory pins.
+- For ordinary mock traffic, pass `hermeticEnv(box.env)` to the child. SDK probes use their stronger `applyHermeticEnvironment` / `assertHermeticEnvironment` pair.
+- `spawnCli()` tracks the child but does not create a sandbox; callers supply the isolated env and cwd. `runCli()` also closes stdin for one-shot modes.
+- RPC commands use `{ type, id?, ... }`; responses use `{ type: "response", command, success, data? | error }`, not JSON-RPC `method`/`params`.
+- `RpcClient.waitForEvent` searches all buffered events; use a per-turn cursor with `RpcQaClient` when an old completion could satisfy the predicate.
+- `TargetRpcClient.waitFor` is future-only and predicates receive its timestamped wrapper, unlike the other clients' raw events.
+- Continuity phase skips carry reasons in `MATRIX_PHASES`; the matrix reports them separately from executed phases.
+- Close resident SDK sessions before disposing the agent and removing its sandbox; the subprocess can otherwise recreate files during teardown.
+
+## VALIDATION
+
+- Unit coverage is `common.test.mjs` plus `tui-resume-{args,pty,signal}.test.mjs`; these are helper tests, not the channel QA suite.
+- `common.mjs --self-check` and `fake-model-server.mjs --self-test` have explicit executable branches; ordinary library imports do not imply a self-test entry point.
+- Check a shared-helper change through its consuming driver as well as its focused unit coverage; the library is not a workspace package.
+
+## ANTI-PATTERNS
+
+- Do not treat `PI_OFFLINE=1` or brand/session scrubbing as provider-credential removal.
+- Do not let `spawnCli` fall back to its host env/cwd defaults in an isolated QA run.
+- Do not reuse a prior turn's `agent_end` as proof that a newly submitted prompt completed.
+- Do not register duplicate mock model ids; `writeMockModelsJson` rejects them before writing the fixture.
+- Do not replace the SDK query boundary with a fake session: continuity assertions depend on observing the real resident and flattened paths.

--- a/.agents/skills/senpi-qa/scripts/scenarios/AGENTS.md
+++ b/.agents/skills/senpi-qa/scripts/scenarios/AGENTS.md
@@ -1,0 +1,48 @@
+# QA Regression Scenarios
+
+## OVERVIEW
+
+Issue-focused real-CLI runners and their wire/setup fixtures; score 9, a distinct regression domain with 31 direct runners and six nested helper files.
+
+## WHERE TO LOOK
+
+| Regression surface | Starting point |
+|---|---|
+| Anthropic fallback after partial output | `anthropic-mid-output-fallback-qa.mjs` |
+| Compaction budgets, retry sharing and aborts | `compaction-absolute-cap-qa.mjs`, `compaction-shared-retry-qa.mjs`, `compaction-abort-standdown-qa.mjs` |
+| Cached goals across RPC and terminal | `cache-warm-ready-rpc-tui.mjs` -> `../lib/cache-warm-ready-scenario.mjs` |
+| Reload/warmup lifecycle | `goal-reload-reengagement-qa.mjs`, `reload-stale-warmup-crash-qa.mjs` |
+| RPC malformed input / fast-mode state | `rpc-input-hardening-qa.mjs`, `rpc-fast-mode-surface-qa.mjs` |
+| Eval execution signals / throughput UI | `eval-execution-event-qa.mjs`, `eval-throughput-badge-qa.mjs` |
+| Dollar skill/extension invocation | `dollar-skill-invocation-qa.mjs`, `dollar-invocation-qa.mjs` |
+| Per-model thinking state | `per-model-thinking-memory-qa.mjs` |
+| Cursor exec bridge lifecycle | `cursor-exec-lifecycle-qa.mjs` and `cursor-exec-lifecycle/` |
+| Cursor import and post-login model catalog | `cursor-oauth-catalog-refresh-qa.mjs` and `cursor-oauth-catalog-refresh/setup.ts` |
+| Credentialed Cursor CLI lane | `cursor-cli-oauth-qa.mjs` (`SENPI_CURSOR_CLI_LIVE=1`) |
+
+## CONVENTIONS
+
+- These are directly invoked programs, not tests discovered by a workspace runner; many have top-level execution and no `--self-test` parser.
+- Fixtures may register temporary extensions, HTTP/SSE servers or sandbox settings to reach a specific real session path.
+- `anthropic-mid-output-fallback-qa.mjs` runs both abort-server-fallback settings, checks primary/fallback request order and proves abandoned tools never execute.
+- That scenario also resumes the saved session, rejects fallback markers in replayed model input and records cleanup assertions.
+- Its evidence slug is fixed to `anthropic-mid-output-wire`; no `--evidence` argument is consumed.
+- Cursor lifecycle `wire.mjs` loads the real generated protobuf schemas via `tsx/esm/api`; sibling modules separate frames, server playback and CLI turns.
+- Catalog-refresh `setup.ts` is a source-loaded helper, not a standalone Node script; it observes import refresh and the interactive post-login catalog/render path.
+- `cursor-cli-oauth-qa.mjs` is credentialed opt-in QA, not proof that all `-qa` files are hermetic.
+
+## COMMANDS
+
+Run from the repository root; the focused regression owns its argument and evidence contract.
+
+```bash
+node .agents/skills/senpi-qa/scripts/scenarios/anthropic-mid-output-fallback-qa.mjs
+node .agents/skills/senpi-qa/scripts/scenarios/rpc-input-hardening-qa.mjs --evidence rpc-input-hardening
+```
+
+## ANTI-PATTERNS
+
+- Do not import a top-level scenario merely to reuse a fixture; shared behavior belongs in `../lib/` or its existing scenario helper directory.
+- Do not collapse the mid-output fallback scenario into a fake successful response: abandoned tool execution and replay sanitization are part of its proof.
+- Do not use a successful reproduction run as an assertion suite; `-repro` runners have their own observational contract.
+- Do not replace the catalog helper's real `ModelRuntime` login/refresh path with a static model-list assertion.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,15 +1,12 @@
 # .github/
 
-CI, release, and issue automation for the senpi fork, plus the committed agent guidance
-the merge/release workflows execute. Score 12: 25 files, distinct automation domain —
-prescriptive rules here are load-bearing for agents running in Actions.
+CI, release, and issue automation for the senpi fork, plus committed merge/release agent guidance. Score 8: 28 files, seven descendant directories, own workflow configuration, and dense embedded JavaScript; distinct automation domain.
 
 ## STRUCTURE
 
 ```text
-workflows/     13 workflows (CI, build-binaries, native-prebuilds, publish-npm,
-               publish-model-catalog, changelog-gate, releasability, npm-audit,
-               perf-trend, issue-analysis, issue-triage-labels, remove-inprogress-on-close)
+workflows/     14 workflows: CI, publishing, native builds, issue/review gates,
+               model catalog, audit, performance, and compiled-worker proof
 agent/         Merge/release agent drivers, /cl command, committed skills
 ISSUE_TEMPLATE/ bug.yml, contribution.yml, package-report.yml
 upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
@@ -22,6 +19,8 @@ upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
 | CI parity for local checks | `workflows/ci.yml` (Node 24, `npm ci --ignore-scripts`, bun 1.4.2 pinned through `oven-sh/setup-bun` in the jobs that run bun, fan-in job named exactly `Check and test`) |
 | npm publish path | `workflows/publish-npm.yml` (the ONLY publisher; triggered after release tag) |
 | Binary/native builds | `workflows/build-binaries.yml`, `workflows/native-prebuilds.yml` |
+| Compiled worker relocation | `workflows/session-worker-compile.yml` runs `bun test scripts/session-worker-compile.test.ts` on Linux/macOS/Windows |
+| Review-claim automation | `workflows/review-claims.yml`: `Review claim gate`, reviewer requests, hourly stale-claim sweep; label policy lives in root guidance |
 | PR changelog gate | `workflows/changelog-gate.yml` (drives `scripts/check-pr-changelog.mjs`) |
 | Merge agent procedure | `agent/README.md`, `agent/merge-driver.md`, `agent/skills/merge-upstream/` |
 | Release audit agent | `agent/release-driver.md`, `agent/skills/release-publish/` |
@@ -29,8 +28,11 @@ upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
 
 ## CONVENTIONS
 
-- GitHub Actions are pinned by full commit SHA (e.g. `actions/checkout@df4cb1c0...`); never reference floating tags.
-- Workflows install with `npm ci --ignore-scripts` and run the root scripts through npm (`npm run check`, `npm run build`, `npm run test:scripts`); `test-workspaces` also runs `bun run test:scripts` under pinned bun 1.4.2 to prove the bun path of the root scripts and runs the workspace suites through `scripts/run-workspaces.mjs`; `rpc-windows` runs its suites through `bunx vitest`.
+- Pin GitHub Actions by full commit SHA. Current exception: `session-worker-compile.yml` still uses `checkout@v7`, `setup-node@v7`, and `setup-bun@v2`; do not copy those floating refs.
+- CI installs with `npm ci --ignore-scripts` and runs root checks/build/script tests through npm; `test-workspaces` also runs `bun run test:scripts` under Bun 1.4.2. The standalone compiled-worker workflow pins Bun 1.4.0.
+- `test-coding-agent` uses three Vitest shards. `test-workspaces` has an explicit package list, not automatic workspace discovery; client tests are not on that list. `rpc-windows` runs suites in separate `bunx vitest` processes.
+- Preserve the exact `Check and test` fan-in name and its `needs` list. Terminal cross-OS and inspector-handoff jobs run separately from that fan-in.
+- Native prebuilds declare six targets; lifecycle tests and load probes run only for non-cross-compile targets. Windows arm64 is best-effort.
 - The release driver emits a final stdout status line: `RELEASE_DECISION: RELEASE | SKIP | FAILED`.
   The merge agent emits `MERGE_RESULT: CLEAN_PR_READY | NO_RELEASE_NEEDED | CONFLICTS | QA_FAILED | AGENT_FAILED`.
 - Release runs only after the upstream PR is merge-committed into `main`, a fresh `/cl`
@@ -47,4 +49,4 @@ upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
 - Credentials stay local to the runner; never copy them into reports, PRs, or committed files.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Updated: 2026-09-10 | Commit `2d0fa41c5`

--- a/.omo/init-deep.json
+++ b/.omo/init-deep.json
@@ -1,1 +1,1 @@
-{"commitSha":"baf15a54d4aac39e4c25012b54ff0a537eb890ab","fileCount":5287,"loc":734565,"timestamp":1787568830091,"mode":"committed"}
+{"commitSha":"2d0fa41c529aedd103c8883f58d05ef9ff12ab63","fileCount":5788,"loc":821284,"timestamp":1789013019536,"mode":"committed"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Senpi Repository Guide
 
-Generated: 2026-08-24
-Commit: `baf15a54d`
-Branch: `initdeep-refresh-20260824`
+**Generated:** 2026-08-24 · refreshed 2026-09-10 (init-deep update)
+**Commit:** 2d0fa41c5
+**Branch:** main
 
 Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve upstream mergeability, and read the nearest `AGENTS.md` plus every applicable `changes.md` before editing.
 
@@ -35,15 +35,15 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | Area | Purpose |
 |---|---|
 | `packages/ai/` | Provider-neutral streaming, models, auth, API implementations |
-| `packages/agent/` | Browser-safe agent loop plus optional Node harness |
-| `packages/coding-agent/` | `senpi` CLI, sessions, extensions, RPC, interactive mode |
-| `packages/tui/` | Differential terminal renderer and editor primitives |
-| `packages/protocol/`, `packages/server/`, `packages/client/` | Framed-CBOR wire protocol plus its server and client for remote sessions |
+| `packages/agent/` | Browser-safe loop and harness libraries; optional Node execution adapter |
+| `packages/coding-agent/` | `senpi` CLI, sessions, extensions, RPC workers, interactive/remote hosting |
+| `packages/tui/` | Differential renderer, editors, transcript search, optional platform addons |
+| `packages/protocol/`, `packages/server/`, `packages/client/` | Framed-CBOR remote-session leases; runtime-neutral cores, separate Unix transports |
 | `packages/telemetry/` | Vendor-neutral telemetry contracts and typed schema utilities |
 | `packages/session-backends/` | Session backend adapters; `sqlite-node/` Node sqlite session store |
 | `packages/evals/` | Model-backed eval suites over real `AgentSession`; spends tokens by design |
-| `packages/pty/` | TypeScript PTY loader, sessions, registry, vendored prebuilds, pipe fallback |
-| `packages/senpi-codemode/` | Source-only persistent-kernel `eval` extension (js/py/rb/jl kernels) |
+| `packages/pty/` | Native loader/registry, opt-in Bun terminal, non-PTY pipe fallback |
+| `packages/senpi-codemode/` | Source-only persistent `eval` kernels (js/py/rb/jl), authenticated bridge, detached cells |
 | `crates/senpi-pty/` | Rust/N-API native PTY implementation and ABI owner |
 | `scripts/` | Build, validation, release, lock and environment tooling |
 | `bench/` | Benchmark baselines and improvement ledger (data only; run via `scripts/run-pr530-benchmarks.mjs`) |
@@ -55,48 +55,48 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 
 | Task | Start here |
 |---|---|
-| Add a feature to the CLI | `packages/coding-agent/src/core/extensions/builtin/` |
-| Change provider/API behavior | `packages/ai/src/api/` then `packages/ai/src/providers/` |
-| Change Cursor transport or exec bridging | `packages/ai/src/api/cursor-agent/`, `packages/coding-agent/src/core/cursor-exec-bridge.ts` |
+| Change CLI extensions or local models | `packages/coding-agent/src/core/extensions/builtin/` (`tool-search/` owns deferred tools); hidden llama manager in `packages/coding-agent/src/extensions/llama/` |
+| Change provider APIs or retry policy | `packages/ai/src/{api,providers,utils/retry-profile}/`; injected turn strategy in `packages/coding-agent/src/core/retry-fallback/` |
+| Change Cursor selection, transport or exec bridging | `packages/ai/src/cursor/`, `packages/ai/src/api/cursor-agent/`, `packages/coding-agent/src/core/cursor-exec-bridge.ts` |
 | Change agent-loop semantics or the harness | `packages/agent/src/agent-loop.ts`, `packages/agent/src/harness/` |
-| Change interactive rendering | `packages/coding-agent/src/modes/interactive/` and `packages/tui/src/` |
-| Change app-server/RPC | `packages/coding-agent/src/modes/app-server/` or `.../modes/rpc/` |
+| Change interactive rendering or reconnect | `packages/coding-agent/src/modes/interactive/` (including `interactive-host-runtime.ts`), `packages/tui/src/{components,alt-screen-search.ts}` |
+| Change Codex app-server or JSONL/socket RPC | `packages/coding-agent/src/modes/app-server/` or `.../modes/rpc/`; these are separate transports |
 | Add or change coding-agent tests or examples | `packages/coding-agent/test/`, `packages/coding-agent/examples/` |
-| Change PTY behavior | `packages/pty/` and, for native behavior, `crates/senpi-pty/` |
-| Change model/provider runtime or docs | `packages/ai/src/{models.ts,auth,providers}`, `packages/coding-agent/docs/providers.md` |
-| Change compaction | mechanics in `packages/coding-agent/src/core/compaction/`; policy in `.../extensions/builtin/compaction/` |
-| Change wire protocol or remote sessions | `packages/protocol/`, then consumers `packages/server/` and `packages/client/` |
-| Change eval prompt/rendering | `packages/senpi-codemode/src/{prompt,tool,kernels}/` |
+| Change PTY behavior | `packages/pty/src/{loader.ts,session-bun.ts}`; native threads/ABI in `crates/senpi-pty/` |
+| Change models, auth or account rotation | `packages/ai/src/{models.ts,auth,providers}`, `packages/coding-agent/src/core/credential-pool/`, `packages/coding-agent/docs/providers.md` |
+| Change compaction or oversized-resume admission | mechanics in `packages/coding-agent/src/core/compaction/`; policy in `.../extensions/builtin/compaction/` |
+| Change wire protocol or remote sessions | `packages/{protocol,server,client}/`; CLI facade is `packages/coding-agent/src/client/remote-session.ts`, not a pi-client re-export |
+| Change eval prompt, bridge or detached execution | `packages/senpi-codemode/src/{prompt,bridge,tool,kernels}/`; goal wake-state snapshots cross the package boundary |
 | Audit changelogs or prepare a release | `.github/agent/commands/cl.md`, `scripts/release.mjs`, `scripts/release-packages.mjs` |
 
 ## CODE MAP
 
-Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop.ts`, driven by `coding-agent/src/core` into interactive | print | RPC | app-server; `tui` renders, `pty` -> `crates/senpi-pty` runs terminals, `protocol` (framed CBOR) links `server` and `client`.
+Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop.ts`, driven by `coding-agent/src/core` into interactive | print | JSONL RPC | Codex app-server. `tui` renders; `pty` selects native/Bun/pipe execution. The separate framed-CBOR `protocol` links `PiServer` and `PiClient`; transports/applications own authentication.
 
 | Symbol / file | Role | Notes |
 |---|---|---|
-| `coding-agent/src/core/agent-session.ts` | Session runtime core | 8k LOC; highest-risk file in the repo |
-| `coding-agent/src/modes/interactive/interactive-mode.ts` | Interactive loop | 8.5k LOC; components under `interactive/components/` |
-| `agent/src/agent-loop.ts` | Browser-safe agent loop | Reached via `coding-agent/src/core/sdk.ts` |
-| `coding-agent/src/core/extensions/builtin/index.ts` | `builtinExtensions` order | 39 entries, `mcp` last; the only authority on numbering |
-| `ai/src/api/cursor-agent/gen/agent_pb.ts` | Generated protobuf-es | 19.6k LOC; regenerate, never hand-edit |
-| `tui/src/index.ts` | Renderer barrel | Consumer coupling point for coding-agent and senpi-codemode |
+| `coding-agent/src/core/agent-session.ts` | Session runtime core | 9,031 lines; shared credential rotation/health lives in `core/credential-pool/` |
+| `coding-agent/src/modes/interactive/interactive-mode.ts` | Interactive loop | Components/theme are separate; `interactive-host-runtime.ts` owns reconnect/rebind |
+| `agent/src/agent-loop.ts` | Browser-safe agent loop | Separate `AgentHarness` remains an incomplete scaffold, not a durable execution coordinator |
+| `coding-agent/src/core/extensions/builtin/index.ts` | `builtinExtensions` order | 41 entries, including `account` and `gpt-account`; `mcp` last; source owns order |
+| `client/src/index.ts` | `PiClient` / `SessionLease` API | Runtime-neutral core; Node-only Unix transport is the `./unix` export |
+| `tui/src/index.ts` | Renderer barrel | Exports `TUI`, `TuiMainScreen`, `TuiAltScreen`; not `TuiBase` or low-level layout helpers |
 
 ## COMMANDS
 
-- Install dependencies: `bun install --ignore-scripts`. After an approved dependency change, `bun run refresh-lock` (lockfile + registry metadata + shrinkwrap + install-lock).
-- Full static validation after code changes: `bun run check` (biome, pinned-deps/ts-imports/shrinkwrap/install-lock checks, `check:claude-sdk-platform-lock`, `tsc --noEmit`, browser-smoke). It runs no tests; CI runs the same commands, so keep them in sync. Broad validation: `bun run test` runs `test:scripts`, then `scripts/run-workspaces.mjs` runs every workspace `test` script sequentially in path order with the package manager you invoked, so `bun run test`, `npm run test`, and `pnpm run test` run the same suites the same way.
-- Narrow tests run from the package root using that package's test command (`bun run --cwd packages/<pkg> test -- <args>`), or from the repository root through the runner (`bun run test --workspace packages/<pkg> -- <args>`, which runs the scripts tests first). Runners differ: Vitest for `ai`, `coding-agent`, `senpi-codemode`, `server`, `session-backends`, `telemetry`; `node --test --import tsx` for `tui`; `node --test` for `scripts/` (`bun run test:scripts`) and `.agents/skills/senpi-qa/scripts/lib/`.
-- App-server transport QA is its own channel: `bun run qa:app-server` (`packages/coding-agent/scripts/qa-app-server/`), not part of `bun run test`. Model catalog data: `bun run hydrate:model-data`, verified by `check:model-data`, from the repository root.
+- Install: `bun install --ignore-scripts`. Approved dependency changes: `bun run refresh-lock` refreshes npm/Bun locks, registry metadata and coding-agent publish/install locks; Claude SDK platform-lock generation/materialization is separate.
+- Static validation: `bun run check` runs Biome, pinned-deps/TS-import/publish/install/Claude SDK lock checks, tsc and browser smoke — not tests, changelog/upstream audits or catalog/thinking generation. `bun run test` runs `test:scripts`, then `scripts/run-workspaces.mjs` runs workspace tests sequentially in path order using the invoking package manager; npm/pnpm use the same runner.
+- Narrow tests: `bun run --cwd packages/<pkg> test -- <args>`; root runner: `bun run test --workspace packages/<pkg> -- <args>` (scripts tests first). Vitest: `ai`, `agent`, `client`, `coding-agent`, `senpi-codemode`, `server`, `session-backends/sqlite-node`, `telemetry`; TUI: `node --test --import tsx` via its package script. `test:scripts` covers only `scripts/*.test.mjs`; QA helper units need `node --test .agents/skills/senpi-qa/scripts/lib/*.test.mjs`. CI's explicit workspace list omits client: run `bun run --cwd packages/client test` directly.
+- App-server QA: `bun run qa:app-server` (`packages/coding-agent/scripts/qa-app-server/`, source-driven, includes real-client-sweep), outside workspace tests; socket probes live separately in `packages/coding-agent/scripts/qa-rpc-socket/`. Model data: root `bun run hydrate:model-data`, then `bun run check:model-data`; ordinary AI builds copy committed catalogs offline.
 - Never run `bun run dev` in this repository.
 
 ## CONVENTIONS
 
 - Read files in full before broad edits; prefer existing patterns and public extension APIs over new core behavior.
 - TypeScript under `packages/*/src`, `packages/*/test`, and `packages/coding-agent/examples` must use erasable syntax. Avoid `any` and verify external types in `node_modules`.
-- Imports are top-level by default. Inline or dynamic imports are forbidden except existing documented lazy/browser-safe boundaries such as `packages/ai/src/api/*.lazy.ts` and credential probes.
+- Imports are top-level by default. Inline/dynamic imports are forbidden except documented lazy/browser-safe boundaries such as `packages/ai/src/api/*.lazy.ts` and credential probes. AI's browser-safe root exports factories/utilities but must not load builtin catalogs or compat registration.
 - Do not hardcode TUI keys; add defaults to `packages/tui/src/keybindings.ts` or `packages/coding-agent/src/core/keybindings.ts`.
-- Never hand-edit generated sources: `packages/ai/src/{models,image-models}.generated.ts` and `src/providers/data/*.json` (regenerate via `packages/ai/scripts/generate-models.ts`), `packages/ai/src/api/cursor-agent/gen/agent_pb.ts` (`buf generate` + `scripts/transform-cursor-agent-proto.mjs`), `crates/senpi-pty/index.{js,d.ts}` (napi-rs), `packages/coding-agent/install-lock/*`, and `packages/coding-agent/src/modes/app-server/protocol/generated/`. Builtin extension registration order is authoritative only in `builtin/index.ts` — never quote a registration number from prose.
+- Never hand-edit generated sources: AI model/image catalogs and `packages/ai/src/providers/data/*.json` (`packages/ai/scripts/generate-models.ts`; 41 provider shards, not 41 runtime factories), `packages/ai/src/api/cursor-agent/gen/agent_pb.ts` (`buf generate` + `scripts/transform-cursor-agent-proto.mjs`), `crates/senpi-pty/index.{js,d.ts}` (napi-rs), `packages/coding-agent/install-lock/*`, and `packages/coding-agent/src/modes/app-server/protocol/generated/`. Only `builtin/index.ts` defines extension order — never take registration numbers from prose.
 - Root `package.json` scripts reach workspaces only through `node scripts/run-workspaces.mjs`; never `npm run --workspaces`, `npm --workspace=<name> run`, `npm --prefix <dir> run`, or `cd <dir> && npm run` (`scripts/root-workspace-scripts.test.mjs` fails the manifest). Those shapes hardcode npm, and under bun the flag-after-name form re-entered the root script forever.
 - Ask before removing intentional functionality; backward compatibility is opt-in, not automatic.
 - Changing fork-specific source behavior means reading the nearest `changes.md` first and updating it in the same verified increment, not in a follow-up. Merges resolve tracker files to `ours`, so a stale entry misleads the next upstream sync.
@@ -113,13 +113,13 @@ Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop
 
 ## QUALITY GATES
 
-- Any runtime change under `packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}` (the release-managed set) plus `crates/senpi-pty` requires scoped tests, `bun run check`, and real CLI QA through `.agents/skills/senpi-qa/`.
+- Any runtime change under `packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}` (the real-CLI QA set) plus `crates/senpi-pty` requires scoped tests, `bun run check`, and real CLI QA through `.agents/skills/senpi-qa/`.
 - Save QA receipts under `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/`; no evidence means no commit or push. Evidence, logs, comments, and PR bodies must never contain tokens, credentials, auth headers, cookies, or raw environment dumps.
 - Default/unit tests must not spend tokens or require real credentials; coding-agent tests use the faux provider and `packages/coding-agent/test/suite/harness.ts` (the legacy `test/test-harness.ts` must not be extended).
 - Tests added or changed run directly until green. New coding-agent lifecycle tests go in `test/suite/`; when a regression test fixes a GitHub issue, add a comment with the issue number next to the test; the flat `test/*.test.ts` root cluster is legacy placement and must not grow.
-- Test quarantine is a safety boundary: `test/setup.ts` forces `SENPI_CODING_AGENT_DIR` into a temp dir and always wins over an inherited value. Never reintroduce an `if (!process.env.SENPI_CODING_AGENT_DIR)` short-circuit — that once deleted a real user agent dir.
+- Test quarantine is a safety boundary: `test/setup.ts` scrubs `SENPI_BRAND`, every `*_CODING_AGENT_DIR` and `*_PACKAGE_DIR`, then forces a temp agent dir. Never restore `if (!process.env.SENPI_CODING_AGENT_DIR)` — that once deleted a real user dir. Provider-key blanking is separate; QA `makeSandbox` alone is not credential isolation.
 - Live/credentialed surfaces are opt-in only: `packages/ai/test/live-api-gates.ts` (`PI_ENABLE_*`), `packages/coding-agent/test/integration/` (`PI_RUN_INTEGRATION=1`), `packages/evals` (`bun run eval --provider X --model Y`). `packages/evals/.eval/` artifacts hold prompts and responses — treat as sensitive.
-- Async tests subscribe before triggering, with bounded deadlines or fake timers; fixed sleeps survive only at genuine OS boundaries and must not be copied from legacy tests.
+- Async tests subscribe before triggering, with bounded deadlines or fake timers; legacy sleeps/polling are reliability debt, not patterns to copy. TUI `VirtualTerminal.waitForRender()` contains a fixed sleep; `flush()` only acknowledges queued xterm writes.
 - Documentation-only changes use focused validators and `git diff --check`, not runtime QA — but `packages/coding-agent/docs/` ships in the tarball and is test-asserted, so doc edits there can fail CI.
 
 ## DEPENDENCIES AND INFRA
@@ -128,7 +128,7 @@ Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop
 - Keep shared environment surfaces synchronized: dependency, Node, provider/env, QA-channel, build-command, and forwarded-port changes must update `scripts/devenv-setup.mjs`, `.devcontainer/devcontainer.json`, and related references together, keeping root `package.json` workspaces and `pnpm-workspace.yaml` aligned with any workspace-package move or rename.
 - Regenerate `packages/coding-agent/publish-deps.lock.json` with `bun scripts/generate-coding-agent-shrinkwrap.mjs`; never replace it with `npm-shrinkwrap.json`. Regenerate `packages/coding-agent/install-lock/` with `bun run install-lock:coding-agent`.
 - External registry entries in root, publish, and installer locks must preserve both npm tarball `resolved` URLs and `integrity` hashes; incomplete merge results are invalid even when dependency topology still resolves.
-- `@earendil-works/pi-telemetry` is a runtime dependency and must stay in Senpi's owned CalVer alias, publish, and bundle sets. `@earendil-works/pi-storage-sqlite-node` remains private and independently versioned because it is not reachable from the shipped coding-agent runtime.
+- `@earendil-works/pi-telemetry` remains in owned CalVer/publish/bundle sets; `@earendil-works/pi-storage-sqlite-node` stays private and independently versioned, outside the shipped CLI runtime. Client/protocol stay workspace/release-versioned but ship under `packages/coding-agent/vendor/pi-{client,protocol}` with relative imports, never as resolver-visible published `node_modules` packages.
 - Dependencies with lifecycle scripts require package/version review and an explicit justified generator allowlist entry; never add one silently to pass the gate.
 
 ## GIT AND DELIVERY
@@ -140,15 +140,15 @@ Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop
 
 ## RELEASE NOTES
 
-- Releases use CalVer and lockstep-version the packages in `scripts/release-packages.mjs`; the pipeline runs `.github/agent/` drivers -> `scripts/release.mjs` -> `publish-npm.yml` -> `build-binaries.yml` / `native-prebuilds.yml`.
+- CalVer covers ten workspaces in `scripts/release-packages.mjs`; seven registry packages are defined by `scripts/registry-packages.mjs`. Pipeline: `.github/agent/` drivers -> `scripts/release.mjs` -> `publish-npm.yml` -> `build-binaries.yml` / `native-prebuilds.yml`.
 - Release only from clean `main` after changelog audit and release smoke tests; `scripts/release.mjs` owns versioning, generated artifacts, checks, commits, tag, and push.
-- Never rerun the release script after its tag is pushed; failed publishing is retried from the existing tag workflow. Publishing is fork-scoped: `scripts/publish.mjs` rewrites private `@earendil-works/pi-*` packages into public `@code-yeongyu/senpi-*` manifests, and upstream names never appear on npm.
+- Never rerun release after its tag is pushed; retry publishing from the existing tag workflow. `scripts/publish.mjs` publishes fork-scoped `@code-yeongyu/senpi-*` manifests, never upstream names. Staging rewrites emitted imports too: restoring only package.json is insufficient; rebuild coding-agent or use disposable release checkouts.
 
 ## NOTES
 
-- Deep guidance lives in ~60 nested `AGENTS.md` files holding the file-level maps this root omits; read the nearest one before editing. `packages/coding-agent` is by far the largest package (~105k LOC with tests).
-- `packages/ai` tests alias `@earendil-works/pi-telemetry` to telemetry source, so telemetry breakage fails AI tests. Node floors differ: packages require >=22.19.0, root and CI use Node 24.
-- `packages/tui` uses tabs in source and its own `node --test` runner — do not apply coding-agent test habits there. `packages/coding-agent/bin/senpi` is only a symlink to built output; launcher logic lives in `src/cli.ts` / `src/bun-runtime.ts`.
+- Nested `AGENTS.md` files own file-level maps, including new retry-profile, tool-search, remote-client, QA-helper and codemode-bridge domains; read the nearest guide. Child Node/tsx tests need fresh dist despite Vitest source aliases: repair prerequisites with root `npm run build`; protocol must build before client.
+- Use Node 24 for repository work; agent, PTY, TUI and the QA island require it. AI tests alias telemetry source, so telemetry breakage fails AI tests. `SENPI_BUN_TERMINAL=1` opts into Bun PTY only under Bun; codemode's Bun 1.4 skill follows the JS kernel runtime, not PATH.
+- TUI uses tabs and its own Node test bootstrap, which clears multiplexer env. `packages/coding-agent/bin/senpi` is a built-output symlink; launcher logic is in `src/cli.ts` / `src/bun-runtime.ts`. QA drivers differ in runtime/live gating; never assume every executable has `--self-test`.
 
 ## Review claim labels (merge-gating)
 

--- a/crates/senpi-pty/AGENTS.md
+++ b/crates/senpi-pty/AGENTS.md
@@ -1,13 +1,13 @@
 # crates/senpi-pty
 
-`senpi-pty` is the Rust/N-API native PTY implementation consumed by `packages/pty` and bundled into Senpi binaries.
+`senpi-pty` is the Rust/N-API native PTY implementation consumed by `packages/pty` and bundled into Senpi binaries. Score 9: code-heavy native ABI boundary, Cargo/NAPI configuration, dense symbols and public methods.
 
 ## STRUCTURE
 
 ```text
-src/lib.rs              N-API exports and ABI marker
-src/session.rs          PTY process/session lifecycle
-src/session_threads.rs  Reader/waiter thread coordination
+src/lib.rs              N-API exports, ABI marker, JS callback delivery, waitExit reaper
+src/session.rs          PTY lifecycle, background waiting, output drain, ConPTY handshake
+src/session_threads.rs  Reader and timeout threads
 src/signals.rs          Platform signal/process-tree handling
 src/session_tests.rs    In-crate lifecycle tests
 tests/manual_qa.rs      Manual native QA harness
@@ -17,18 +17,25 @@ index.js, index.d.ts     Node package loader/types
 
 ## ABI CONTRACT
 
-- `NATIVE_PTY_ABI_VERSION = "1"` in the TypeScript loader (`packages/pty/src/native-loader.ts`) and the exported `__senpiPtyAbi1` marker must agree; the Rust constant lives in `src/lib.rs`.
+- `NATIVE_PTY_ABI_VERSION = "1"` in `packages/pty/src/loader.ts` and the exported `__senpiPtyAbi1` marker must agree; the Rust constant lives in `src/lib.rs`. `native-loader.ts` is only a compatibility re-export.
 - ABI versioning is intentionally separate from CalVer. Change it only for an incompatible native contract and update both crate and loader tests.
-- `index.js` and `index.d.ts` are NAPI-RS-generated loader output; never hand-edit them. Regenerate with `bun run build --workspace=@earendil-works/senpi-pty-native` (`napi build --platform`).
-- Keep the six targets declared in `package.json` aligned when changing exports or build paths. A checked-in `senpi_pty.darwin-arm64.node` prebuild covers the local darwin-arm64 fast path only; other targets come from prebuilt packaging, and missing native bindings intentionally use the TypeScript pipe fallback.
+- `index.js` and `index.d.ts` are NAPI-RS-generated loader output; never hand-edit them. With the crate's NAPI CLI installed, regenerate from the repo root with `bun run --cwd crates/senpi-pty build` (`napi build --platform`). This crate is a Cargo member, not a root JavaScript workspace.
+- Keep the six targets declared in `package.json` aligned with `.github/workflows/native-prebuilds.yml`. The crate-root checked-in `.node` is darwin-arm64 only; runtime candidates live under `native/prebuilds/<host>/`, staged through `packages/pty/native/`.
+- A crate rebuild alone does not refresh vendored prebuilds. Missing or quarantined bindings permit the TypeScript pipe fallback; ABI sentinel mismatches throw instead of silently falling back.
 
 ## LIFECYCLE INVARIANTS
 
 - Session exit is reported exactly once despite reader EOF, waiter completion, kill, drop, or startup-error races.
 - Kill and cleanup terminate the process tree, not only the immediate shell child.
-- Reader/waiter threads cannot outlive released session ownership or call into freed N-API state.
+- Keep N-API callback state alive until output delivery finishes; `start_pty_session` waits for each JS callback before reading onward.
+- Close the PTY writer/master before joining the reader in `drain_output`; ConPTY does not produce EOF merely because its child exits.
+- Answer the first ConPTY startup cursor-position query even if the consumer already wrote; later queries pass through after the first consumer write.
 - Signal behavior remains platform-aware; preserve paired Unix/Windows semantics when changing process control.
+
+## ANTI-PATTERNS
+
 - Do not expose secret-bearing environment data through diagnostics or errors.
+- Do not route native compilation through root JavaScript workspace flags or assume a local `.node` is the shipped prebuild.
 
 ## WHERE TO LOOK
 
@@ -36,13 +43,14 @@ index.js, index.d.ts     Node package loader/types
 |---|---|
 | N-API/ABI export | `src/lib.rs` |
 | Spawn, resize, write, kill | `src/session.rs` |
-| Thread coordination | `src/session_threads.rs` |
+| Reader/timeout threads | `src/session_threads.rs`; waiting/draining in `src/session.rs` |
 | Signals/process tree | `src/signals.rs` |
-| TypeScript loader contract | `packages/pty/src/native-loader.ts` |
+| TypeScript loader contract | `packages/pty/src/loader.ts` |
 | Prebuilt packaging | `packages/pty/native/` and root copy scripts |
 
 ## VALIDATION
 
 - Run `cargo test -p senpi-pty` from the repository root.
-- Run package loader/ABI tests in `packages/pty` and `bun run check:prebuild` after native changes.
+- From the repo root: `bun run --cwd packages/pty test` and `bun run --cwd packages/pty check:prebuild` after native changes. The latter rebuilds and compares the host's vendored binary.
+- Native lifecycle QA: `cargo test -p senpi-pty --test manual_qa -- --nocapture`; `.github/workflows/native-prebuilds.yml` also runs `scripts/probe-native-pty-lifecycle.mjs` against built artifacts on native runner targets.
 - Native lifecycle changes require manual PTY QA on affected platforms plus root `bun run check`.

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/agent
 
-`@earendil-works/pi-agent-core` provides the stateful agent loop and a publicly exported optional harness for compaction, sessions, skills, prompts, and execution environments.
+`@earendil-works/pi-agent-core` provides the stateful agent loop and optional harness libraries for compaction, sessions, skills, prompts, and execution environments. Package boundary earns this file (score 10: file count, code ratio, own configs, symbol/export density).
 
 ## STRUCTURE
 
@@ -13,9 +13,9 @@ src/stream-fn.ts             Injectable stream function abstraction
 src/types.ts                 App messages, events, state, conversion boundary
 src/proxy.ts                 Remote stream proxy
 src/index.ts                 Browser-safe public exports
-src/node.ts                  Node harness public exports
+src/node.ts                  NodeExecutionEnv plus the main public exports
 src/search/                  Scanning session search over readable storage
-src/harness/                 AgentHarness: lanes, sessions (own AGENTS.md),
+src/harness/                 Public AgentHarness scaffold; sessions (own AGENTS.md),
                              tools (own AGENTS.md), compaction, skills, prompt
                              templates, env adapters
 src/harness/reducer.ts       Record-log validation and lane state reduction
@@ -35,7 +35,7 @@ scripts/generate-telemetry-docs.ts  Regenerates docs/telemetry-schema.md
 | Tool scheduling or terminal states | `src/agent-loop.ts` |
 | Agent lifecycle or abort | `src/agent.ts` |
 | Public message/event contract | `src/types.ts` |
-| Harness orchestration | `src/harness/agent-harness.ts` |
+| Harness scaffold and configuration | `src/harness/agent-harness.ts`; see its AGENTS.md for unimplemented lifecycle operations |
 | Node process and filesystem behavior | `src/harness/env/nodejs.ts` |
 | Session persistence | `src/harness/session/` (`session.ts`, `state.ts`, `context.ts`, `types.ts`, `jsonl/`, `memory.ts`; own AGENTS.md) |
 | Session search | `src/search/scanning.ts`, contracts in `src/search/index.ts`; see `docs/search.md` |
@@ -61,7 +61,7 @@ scripts/generate-telemetry-docs.ts  Regenerates docs/telemetry-schema.md
 
 ## VALIDATION
 
-- Run `bun run test` from this package for agent-loop coverage.
+- Run `bun run test` from this package for the full Vitest suite, including core-loop and harness tests.
 - Run `bun run test:harness` for harness/session/env changes.
 - Telemetry schema changes: `bun run generate-telemetry-docs` to rewrite `docs/telemetry-schema.md`, then `bun run check:telemetry-docs`; the generated file must never be edited by hand.
 - Runtime changes also require root `bun run check` and the root QA evidence gate.
@@ -69,8 +69,8 @@ scripts/generate-telemetry-docs.ts  Regenerates docs/telemetry-schema.md
 
 ## NOTES
 
-- Session storage: `SessionStorage` implementations (`jsonl/` `JsonlSessionStorage`/`JsonlSessionRepo`, `memory.ts` `InMemorySessionStorage`/`InMemorySessionRepo`) behind `Session` tree semantics in `session.ts`; SQLite backend in `packages/session-backends/sqlite-node`. New backends must pass `createSessionBackendConformance`, published as the `@earendil-works/pi-agent-core/session/testing` subpath.
+- Public storage surface: `SessionStorage`, `Session`, `JsonlSessionRepo`, `InMemorySessionStorage`, and `InMemorySessionRepo`; `JsonlSessionStorage` stays internal to `jsonl/storage.ts`. Backend conformance is published separately as `@earendil-works/pi-agent-core/session/testing`.
 - Cursor exec bridging: `execHandlers`/`onToolResult` are installed only when `config.cursorExecHandlers` is set. Assistant `toolCall` blocks stamped `kCursorExecResolved` (`packages/ai/src/utils/block-symbols.ts`) were executed server-side and are never re-run locally; their buffered `toolResult`s are appended right after the assistant message, including on error/abort paths. Local exec work re-arms the idle watchdog via `AssistantMessageEventStream.trackLocalWork`.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Generated: 2026-09-10 | Commit `2d0fa41c5`

--- a/packages/agent/src/harness/AGENTS.md
+++ b/packages/agent/src/harness/AGENTS.md
@@ -1,14 +1,14 @@
 # src/harness
 
-Optional Node-side harness over the core agent loop: durable sessions, lane state machine, compaction, skills/prompt templates, built-in tools, and schema-first telemetry. Public entry `AgentHarness` (`agent-harness.ts`), exported via `src/node.ts`.
+Optional harness libraries and an `AgentHarness` scaffold over the core loop, exported through `src/index.ts`; only the Node execution adapter requires `src/node.ts`.
 
-Earned its own file: 41 files / ~10k LOC, distinct domain from the browser-safe core (score 12: file count, export surface, 23+ `AgentHarness` references in coding-agent).
+Earned its own file: 42 TypeScript files, distinct durable-runtime domain (score 9: file count, code ratio, symbol/export density; cross-workspace centrality not credited).
 
 ## WHERE TO LOOK
 
 | Task | File |
 |---|---|
-| Run/compaction/navigation/queue lifecycle | `agent-harness.ts` (`AgentHarness`, `AgentLane`) |
+| Public scaffold, configuration, explicit unsupported operations | `agent-harness.ts` (`AgentHarness`, `AgentLane`, `HarnessNotImplemented`) |
 | Record-log validation, lane state reduction | `reducer.ts` (`validateRecordLog`, `reduceLaneState`, `RecordLogCorruption`) |
 | Telemetry span schemas | `telemetry.ts` (`AI_TELEMETRY_SCHEMA`, `HARNESS_TELEMETRY_SCHEMA`, `startAiSpan`/`startHarnessSpan`) |
 | Node process/filesystem environment | `env/nodejs.ts` (`NodeExecutionEnv`, Windows process-tree teardown) |
@@ -18,18 +18,22 @@ Earned its own file: 41 files / ~10k LOC, distinct domain from the browser-safe 
 | Skills, prompt templates, system prompt | `skills.ts`, `prompt-templates.ts`, `system-prompt.ts` |
 | Result/error vocabulary | `result.ts`, `types.ts` (`Result`, `TaggedError`, `matchError`) |
 | Output truncation, shell capture | `utils/truncate.ts`, `utils/shell-output.ts` |
+| Internal event subscriptions and snapshot buffering | `events.ts` (`HarnessEventBus`); not yet wired into the public scaffold |
 
 ## CONVENTIONS
 
-- `docs/harness.md` is the normative implementation spec (entries + registers + usage ledger, transactional writes, op-state recovery). When code and spec contradict, stop for review; do not improvise a new durable contract.
-- Operational failures are tagged errors inside `Result` values, never untyped exceptions.
-- Telemetry is schema-first: edit the const schemas in `telemetry.ts`, then regenerate `docs/telemetry-schema.md` (`bun run generate-telemetry-docs`; `bun run check:telemetry-docs` verifies CI-exact output).
-- Harness tools are `AgentTool & { replay?: "never" | "safe" }` (`HarnessTool`); only tools marked replay-safe re-run after recovery.
+- `packages/agent/docs/harness.md` is the intended implementation spec, ahead of the current scaffold. Preserve its durable-contract decisions, but do not describe planned execution/recovery as shipped behavior.
+- `AgentHarness.create()` accepts sessions without lane records; recorded sessions reject with `HarnessNotImplemented("create.restore")`. Prompt, compaction, navigation, queues, recovery, watches, hooks, and events remain explicit unsupported operations; see `test/harness/agent-harness-scaffold.test.ts`.
+- Configuration accessors and session reads work. `setThinkingLevel()` persists `configuration_update` for `gpt-6-astra` on `openai`/`openai-codex`; the durable writer regression lives in `test/harness/configuration-update-writer.test.ts`.
+- Result-returning APIs use tagged errors; scaffold operations reject with `HarnessNotImplemented`/`HarnessClosed`, storage rejects with `SessionError`, and tool execution throws. Do not conflate these contracts.
+- `HarnessTool = AgentTool & { replay?: "never" | "safe" }` declares intended recovery policy; the scaffold does not yet execute or replay tools.
+- `messages.ts:convertToLlm` drops failed assistant turns and orphaned tool results using pi-ai's `dropFailedAssistantTurns`. Compaction estimates count the same retained messages, but `lastUsageIndex` remains relative to the caller's original array.
 - Harness tests run under `vitest.harness.config.ts` (`test/harness/**`; coverage limited to `src/harness/**` plus `src/agent.ts` and `src/agent-loop.ts`).
 
 ## ANTI-PATTERNS
 
 - Weakening `never`-typed fields that keep invalid entry/record/operation unions unrepresentable.
 - Defining telemetry spans or attributes outside the schemas in `telemetry.ts`.
+- Treating `events.ts:HarnessEventBus` as the implementation of `AgentHarness.events`; the latter still uses `UnavailableRegistry`.
 - Treating non-zero command exits as thrown execution failures; they are values in the execution result (spawn/timeout/abort are the distinct error cases).
 - Truncation that returns partial lines; `utils/truncate.ts` must never split a line (documented bash-tail edge case aside).

--- a/packages/agent/src/harness/session/AGENTS.md
+++ b/packages/agent/src/harness/session/AGENTS.md
@@ -1,8 +1,8 @@
 # src/harness/session
 
-Durable session storage: append-only entries (message, model/thinking/tools changes, compaction, branch-summary, custom), lane operation records, and the `Session` tree that projects them. Ships JSONL and in-memory backends; the SQLite backend lives in `packages/session-backends/sqlite-node`.
+Durable session storage: append-only entries (message, model/thinking/tools changes, configuration updates, compaction, branch-summary, custom), lane operation records, and the `Session` tree that projects them. Ships JSONL and in-memory backends; the SQLite backend lives in `packages/session-backends/sqlite-node`.
 
-Earned its own file: distinct domain from harness orchestration (score 11: `index.ts` boundary, wide type surface, `SessionRepo`/`SessionError`/`Entry` consumed across sqlite-node).
+Earned its own file: distinct storage domain (score 8: `index.ts` boundary, code ratio, symbol/export density; cross-workspace centrality not credited).
 
 ## WHERE TO LOOK
 
@@ -13,20 +13,22 @@ Earned its own file: distinct domain from harness orchestration (score 11: `inde
 | Mutation log feeding state reduction | `state.ts` (`SessionState`) |
 | JSONL backend: codec, atomic storage, repo, torn-tail repair | `jsonl/` (`codec.ts`, `storage.ts`, `repo.ts`, `errors.ts`) |
 | In-memory backend | `memory.ts` (`InMemorySessionStorage`, `InMemorySessionRepo`) |
-| Session context projection to model messages | `context.ts` |
+| Context transforms, custom projectors, durable configuration projection | `context.ts` (`buildSessionContext`, `buildContextEntries`) |
 | Backend conformance suite | `testing/conformance.ts` (`createSessionBackendConformance`, published as `@earendil-works/pi-agent-core/session/testing`) |
 
 ## CONVENTIONS
 
 - IDs come from an injectable `IdGenerator`, defaulting to `uuidv7` from pi-ai.
 - Entries, records, and usage rows are append-only with strictly increasing sequence numbers; `SessionState` is the derived projection, never the source of truth.
-- JSONL publication stages a complete sibling `.tmp` file and atomically renames it over the destination; callers must serialize publications per destination (shared deterministic temp path). Torn tails are repaired from the valid prefix on load.
+- JSONL fork publication and torn-tail repair stage a complete sibling `.tmp` file and atomically rename it over the destination; callers serialize publications per destination. Ordinary mutations append before updating in-memory state. Only a syntax-invalid final line is discarded as a torn tail; schema errors and interior corruption fail.
 - Query misuse throws `SessionError` (`invalid_query`, `invalid_payload`); `session.ts` validates limits and cursors up front.
 - New backends must pass `createSessionBackendConformance`; memory, JSONL, and SQLite all run the same cases.
+- `findOpenOperations(lane, { limit: 2 })` distinguishes idle, one suspended operation, and corrupt multiple-open state; preserve bounded recovery queries.
+- `buildSessionContext` derives configuration from the full branch before compaction trimming and custom transforms. `configurationUpdate` is separate from `thinkingLevel`; custom entries require an explicit projector to become model messages.
 
 ## ANTI-PATTERNS
 
 - Mutating entries, records, or usage rows in place instead of appending.
-- Weakening `never`-typed union members in `types.ts`.
+- Treating labels or the session name as branch-local: they are session-wide, latest-write-wins facts.
 - Claiming writer leases from scanning code; use read-only helpers (`scanningEntries` in `src/search/`) or already-open storage.
-- Swallowing decode failures; malformed JSONL surfaces as `JsonlDecodeError` with the item index.
+- Swallowing decode failures; the codec returns `JsonlDecodeError`, while storage load wraps it in `SessionError("invalid_entry")` with the path and physical line number.

--- a/packages/agent/src/harness/tools/AGENTS.md
+++ b/packages/agent/src/harness/tools/AGENTS.md
@@ -1,8 +1,8 @@
 # src/harness/tools
 
-Built-in tool library (bash, edit, edit-diff, write, read, image) for the harness, re-exported by coding-agent as `create*Tool` and `create*ToolDefinition`. All factories are generic over `ExecutionToolContext`.
+Context-injected bash/edit/read/write factories plus diff and image helpers, exported through the agent-core barrel. These are separate from coding-agent's cwd-bound `create*Tool`/`create*ToolDefinition` implementations.
 
-Earned its own file: distinct domain plus external centrality (score 11: `index.ts` barrel, 57 tool-factory references in coding-agent).
+Earned its own file: distinct execution-tool domain (score 8: `index.ts` boundary, code ratio, symbol/export density; similarly named coding-agent factories are not reference evidence).
 
 ## WHERE TO LOOK
 
@@ -13,18 +13,19 @@ Earned its own file: distinct domain plus external centrality (score 11: `index.
 | File write/read | `write.ts`, `read.ts` |
 | Serialized filesystem mutations | `file-mutation-queue.ts` (`withFileMutationQueue`) |
 | Path resolution helpers | `path-utils.ts` |
-| Tool context contract | `tool-context.ts` (`ExecutionToolContext`, `PostMutateHook`) |
+| Tool context contract | `tool-context.ts` (`ExecutionToolContext`, `PostMutateContext`, `PostMutateHook`) |
 | Post-write hook execution | `post-mutate.ts` (`runPostMutate`, `appendPostMutateNote`) |
 | Image attachment encoding | `image.ts` |
 | Public surface | `index.ts` (factories + types) |
 
 ## CONVENTIONS
 
-- All filesystem mutation goes through `withFileMutationQueue(env, path, fn)`; tools never write via env APIs directly.
+- Factories return `AgentHarnessTool<TContext>`; `execute` receives `{ env, postMutate }` in its fifth argument rather than capturing a cwd at construction.
+- Edit/write mutations call env APIs inside `withFileMutationQueue(env, path, fn)`. Slots are keyed by environment identity and canonical path, so aliases serialize while different files can proceed independently.
 - Paths resolve through `path-utils.ts` helpers against the context root.
 - Tools throw on failure so the agent reports the error; failure text is never returned as successful result content. The one deliberate exception is `postMutate`: the write it follows has already landed, so a rejecting hook becomes an appended warning note instead of discarding a committed mutation.
 - The optional `context.postMutate` hook runs inside the same `withFileMutationQueue` slot as the write it follows; `edit` recomputes its diff metadata from disk whenever the hook may have touched the file (reported `changed`, or rejected after a partial rewrite).
-- Replay semantics are declared where consumed as `HarnessTool` (`replay?: "never" | "safe"`, defined in `agent-harness.ts`), not inferred from the tool.
+- `edit` matches the entire `edits[]` batch against the original normalized content, rejects overlaps, and preserves BOM/line endings. `prepareArguments` accepts legacy or stringified input, but the public schema remains `{ path, edits }`.
 - A new tool ships as a factory plus exported input/details types in `index.ts`.
 
 ## ANTI-PATTERNS
@@ -32,3 +33,4 @@ Earned its own file: distinct domain plus external centrality (score 11: `index.
 - Bypassing the mutation queue for writes.
 - Returning failure text as tool result content instead of throwing.
 - Adding a tool without its matching exported types in `index.ts`.
+- Copying coding-agent factory signatures here or treating same-named tool implementations as interchangeable.

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/ai
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 13: package boundary, generated-data contract, cross-package API.
 
 `@earendil-works/pi-ai` is the provider-neutral streaming, model, auth, tool-call, and image API used across the monorepo. Its root surface must remain browser-safe. ESM, Node `>=24`, built with `tsc -p tsconfig.build.json` (`src/**/*.ts` -> `dist`).
 
@@ -16,11 +16,11 @@ src/models-store.ts             Persisted dynamic-model store
 src/api/                        Wire/API implementations and lazy wrappers
 src/api/cursor-agent/           Cursor Connect-RPC client (Node-only, reached via api/cursor-agent.lazy.ts);
                                 gen/agent_pb.ts is generated protobuf-es output — never hand-edit
-src/cursor-agent-provider.ts    Static cursor-agent module bundle for the Bun binary override
-src/cursor/                     Cursor catalog grouping, model capabilities, selection descriptors,
-                                variant aliases (cursor-variant-aliases.json), store migration
+src/cursor-agent-provider.ts    Static Cursor transport bundle for the Bun binary override; browser-safe history measurement lives in api/cursor-agent/measure.ts
+src/cursor/                     Cursor catalog grouping, shared transport selection, Composer prompt,
+                                variant aliases and store migration (own AGENTS.md)
 proto/cursor/agent.proto        Vendored Cursor agent protocol schema (source for gen/)
-src/providers/                  Provider factories, catalogs, shared transforms
+src/providers/                  Provider factories, catalogs, shared provider configuration
 src/providers/data/             COMMITTED generated per-provider model JSON (see below)
 src/auth/                       Credential stores, contexts, auth helpers/types
 src/node/provider-scope.ts      Node-only subpath (provider scoping); not root-reachable
@@ -38,10 +38,10 @@ src/images.ts                   Image generation API (+ images-api-registry.ts, 
 src/env-api-keys.ts             Browser-safe credential detection boundary
 src/wire-identity.ts            Product token/originator carried on outbound requests
 src/tool-call-middleware/       Text-encoded tool protocols
-src/utils/                      ~33 files; key: retry.ts, provider-retry.ts, retry-hint.ts, prompt-cache-ttl.ts, stop-details.ts, tool-call-id.ts, tool-schema-compat.ts
+src/utils/                      42 TS files including retry-profile/; retry, cache, schema, stream utilities
 scripts/generate-models.ts      Model catalog source of truth
 scripts/generate-image-models.ts Image catalog source of truth
-test/                           Faux-first + opt-in live tests, ~53k LOC flat (own AGENTS.md; ditto test/tool-call-middleware/)
+test/                           268 top-level TS files, ~60k LOC; faux-first + opt-in live tests (own AGENTS.md; ditto tool-call-middleware/)
 bench/                          event-stream + model-registry micro-benchmarks
 ```
 
@@ -57,7 +57,7 @@ bench/                          event-stream + model-registry micro-benchmarks
 - Provider factories and model catalogs live in `src/providers/`; wire protocol implementations live in `src/api/`.
 - `src/api/lazy.ts` exposes `lazyApi()`. API-specific `*.lazy.ts` wrappers are the documented dynamic-import boundary.
 - `src/providers/register-builtins.ts` registers compatibility behavior and currently imports only `src/compat.ts`; do not restore the old provider-loader architecture there.
-- Public subpaths in `package.json`: `.`, `./compat`, `./oauth`, wildcard `./providers/*`, `./api/*`, `./utils/*`, plus `./node/provider-scope`, `./bedrock-provider` (root shim re-exporting `dist/`), `./bun-oauth`. Keep root exports browser-safe.
+- Public subpaths in `package.json`: `.`, `./compat`, `./oauth`, wildcard `./providers/*`, `./api/*`, `./utils/*`, plus `./auth/pool/*`, `./node/provider-scope`, `./bedrock-provider`, `./bun-oauth`. Keep root exports browser-safe.
 - `sideEffects` is non-empty by design: `dist/compat.js`, `dist/images.js`, `dist/providers/images/register-builtins.js` register on import.
 - Message transforms return new structures; never mutate shared input messages.
 
@@ -79,8 +79,8 @@ bench/                          event-stream + model-registry micro-benchmarks
 
 ## INVARIANTS
 
-- Dynamic imports are limited to lazy API and browser-safe credential/OAuth boundaries; ordinary source uses top-level imports.
-- Generated model files are never hand-edited. Regenerate and commit intentional catalog changes. `src/api/cursor-agent/gen/agent_pb.ts` is likewise generated: run `buf generate` against `proto/cursor/agent.proto`, then `bun scripts/transform-cursor-agent-proto.mjs <in> <out>` to rewrite enums for `erasableSyntaxOnly`.
+- Lazy API wrappers, image registration, and credential/OAuth loading are deliberate dynamic-import boundaries; ordinary source uses top-level imports.
+- Generated model files are never hand-edited. Regenerate and commit intentional catalog changes. `src/api/cursor-agent/gen/agent_pb.ts` is likewise generated: run `buf generate` against `proto/cursor/agent.proto`, then the enum transform in `scripts/transform-cursor-agent-proto.mjs` for `erasableSyntaxOnly` (exact commands in that script's header).
 - Unit tests use `src/providers/faux.ts`; live APIs require explicit key/feature gating and must not be part of default success.
 - Keep `extraBody`, tool definitions, reasoning options, usage, stop reasons, errors, and abort behavior consistent across APIs.
 - Inspect installed SDK types before changing external request/response shapes.

--- a/packages/ai/scripts/AGENTS.md
+++ b/packages/ai/scripts/AGENTS.md
@@ -1,15 +1,16 @@
 # packages/ai/scripts
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`.
 
-Networked generators that produce the committed model catalogs (`src/providers/data/*.json`, `src/models.generated.ts`, `src/image-models.generated.ts`) plus their validators. Scored 7 but kept: this is the only place the generation contract (flags, staging/rename, manifest hashing) is written down, and the parent file states only the outcome.
+Networked generators that produce the committed model catalogs (`src/providers/data/*.json`, `src/models.generated.ts`, `src/image-models.generated.ts`) plus their validators. Score 6; retained in update mode: this is the only place the generation contract (flags, staging/rename, manifest hashing) is written down, and the parent file states only the outcome.
 
 ## FILE MAP
 
 ```text
-generate-models.ts             3.4k LOC orchestrator; all four model scripts are flag variants of it
+generate-models.ts             3.6k LOC orchestrator; full, hydration, and JSON-catalog modes
 generate-models-opengateway.ts fetchOpenGatewayModels + OpenGatewayReasoningRecorder (enrichment source)
 models-dev-reasoning-options.ts getEffortThinkingLevelMap — models.dev effort -> thinkingLevelMap
+openrouter-reasoning-options.ts getOpenRouterThinkingLevelMap — OpenRouter reasoning metadata
 model-data.ts                  Shared manifest/schema layer: MODEL_DATA_SCHEMA_VERSION=3,
                                createModelDataManifest, validateGeneratedModelData, assertExactModelIds
 check-model-data.ts            Thin CLI over validateGeneratedModelData
@@ -22,27 +23,27 @@ transform-cursor-agent-proto.mjs Rewrites protoc-gen-es enums to const objects f
 
 | Invocation | Flags | Effect |
 |---|---|---|
-| `bun run generate-models` | `--strict` | Full: `data/` JSON + `models.generated.ts` |
+| `bun run generate-models` | `--strict` | Full: `data/` JSON + provider `*.models.ts` shards + `models.generated.ts` |
 | `bun run hydrate-model-data` | `--strict --data-only` | `data/` JSON only; rejects any JSON-catalog flag |
 | `bun run generate-model-catalog` | `--strict --json-only --json-output <dir>` | Publishable catalog to `.artifacts/model-catalog`; `--json-only` requires `--json-output` |
 | `bun run check:model-data` | — | Validates manifest hashes; fails with "run `bun run hydrate:model-data` from the repository root" |
 
-`--strict` turns per-provider fetch failures into a thrown error instead of a skip. Without it a network hiccup silently ships a shrunken catalog — always keep it on for committed regeneration.
+`--strict` turns per-provider fetch failures into a thrown error instead of a skip. Without it a failed source can be skipped — keep it on for committed regeneration; `prepublishOnly` currently invokes both generators without the flag.
 
 ## CONVENTIONS
 
 - `data/` writes are staged, not in-place: a `.model-generation-*` temp dir under `src/providers/`, then rename-swap with the previous dir kept for rollback. Never write `data/` file-by-file.
-- Every provider fetch skips records with `status === "deprecated"` (five separate call sites) — deprecated upstream models must not enter the catalog.
+- Deprecated-status filtering appears in five fetch paths in `generate-models.ts`; preserve it when changing the corresponding upstream loader.
 - `model-data.ts` is the single schema authority: the manifest carries a sha256 per file plus a `structureHash`, so a hand-edit of any JSON fails `check:model-data`.
 - Scripts run under `tsx` (see package scripts), use explicit `.ts` import suffixes, and import repo types from `../src/types.ts` — they are type-checked against runtime contracts, not standalone.
-- These are the only files in the package that legitimately use bare `fs`/`path` imports rather than `node:`-prefixed ones; leave the style alone unless converting the whole file.
+- The main generator uses bare `fs`/`path` imports; the protobuf transform uses `node:fs`. Do not infer a package-wide import convention from these scripts.
 
 ## ANTI-PATTERNS
 
 - Hand-editing `src/providers/data/*.json`, `src/models.generated.ts`, or `src/image-models.generated.ts` instead of rerunning the generator — the manifest will catch it, but only at `check:model-data` time.
 - Running generation without `--strict` and committing the diff.
 - Adding a provider fetcher that does not honor the deprecated-status skip or the staging/rename path.
-- Editing `src/api/cursor-agent/gen/agent_pb.ts` by hand: regenerate via `buf generate` on `proto/cursor/agent.proto`, then `bun scripts/transform-cursor-agent-proto.mjs <in> <out>` (the exact `buf` invocation is in that file's header comment).
+- Editing `src/api/cursor-agent/gen/agent_pb.ts` by hand: regenerate via `buf generate` on `proto/cursor/agent.proto`, then `bun scripts/transform-cursor-agent-proto.mjs <in> <out>` (the exact `buf` invocation is in the transform script's header comment).
 
 ## VALIDATION
 

--- a/packages/ai/src/AGENTS.md
+++ b/packages/ai/src/AGENTS.md
@@ -1,26 +1,26 @@
 # packages/ai/src
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 16: public entry surfaces and scoped runtime.
 
-Entry-surface discipline and the API-provider scope model. Directory structure is mapped in the parent `packages/ai/AGENTS.md`; children own the deep guidance (`api/`, `auth/`, `providers/`, `tool-call-middleware/`, `utils/`).
+Entry-surface discipline and the API-provider scope model. Directory structure is mapped in the parent `packages/ai/AGENTS.md`; children own the deep guidance (`api/`, `auth/`, `cursor/`, `providers/`, `tool-call-middleware/`, `utils/`).
 
 ## ENTRY SURFACES
 
 | Entry | Loads | Use for |
 |---|---|---|
-| `index.ts` | Side-effect-free core only: types, option types, lazy API factories, cursor arg helpers, provenance, wire-identity. No catalogs, no provider factories, no registry, no OAuth, no compat (its header comment is the contract) | Browser-safe imports |
+| `index.ts` | Browser-safe types/helpers, `getApiProvider`, Models/ImagesModels constructors, stores, faux provider, Cursor measurement/selection, recovery. No builtin catalogs, concrete provider bundle, OAuth implementations, or compat registration; the older header overstates exclusions | Browser-safe imports |
 | `compat.ts` | `index` + legacy dispatch + builtin API registration + env keys + image surface + legacy aliases | Legacy/global API, registration side effects |
 | `stream.ts` | Re-exports `complete`, `completeSimple`, `stream`, `streamSimple` from compat | One-line stream imports |
 | `images.ts` | Image generation; resolves `model.api` through `getImagesApiProvider`, triggers image registration via side-effect import | Image generation |
 | `cli.ts` | Node CLI (`#!/usr/bin/env node`) | Auth flows from the shell |
 | `oauth.ts` / `bun-oauth.ts` | OAuth re-exports / Bun registration | OAuth surfaces |
-| `node/provider-scope.ts` | Node-only subpath (`@earendil-works/pi-ai/node/*`); NOT root-reachable | Installing a provider scope |
+| `node/provider-scope.ts` | Node-only subpath (`@earendil-works/pi-ai/node/provider-scope`); NOT root-reachable | Installing a provider scope |
 
 ## PROVIDER SCOPE (api-registry.ts)
 
 - `ProviderScope` has `active|closed` state plus a per-scope overlay `Map`. In an active scope, lookup = `session overlay → immutable builtin set` — **NEVER the mutable legacy global** (recorded invariant in `changes.md`).
 - A closed scope throws on any lookup/mutation; no silent fallback.
-- Builtin entries register once and retain immutable identity for active scopes; `getBuiltinProvider*` must keep working while a scope holds unrelated overlay entries.
+- Builtin entries register once and retain immutable identity for active scopes; `getBuiltinApiProvider` must keep working while a scope holds unrelated overlay entries.
 - The images registry (`images-api-registry.ts`) is scoped identically.
 - `providerScopeStrictMode` makes scope-less lookup throw instead of using the global registry.
 
@@ -28,12 +28,11 @@ Entry-surface discipline and the API-provider scope model. Directory structure i
 
 - `KnownApi`/`Provider` ids are open string unions (`KnownApi | (string & {})`), not enums; `legacy-api-aliases.ts` carries the old ids — extend it when renaming an api.
 - `model-catalog.ts` `flattenModelCatalog` turns grouped JSON into the flat typed catalog every `*.models.ts` reuses; `models.generated.ts` / `image-models.generated.ts` are generated (never hand-edit — see `../scripts/AGENTS.md`).
-- `xml` is retained only as a deprecated alias of `morph-xml` in tool-call format strings.
-- `changes.md` (2.7k lines) is the design history for registry, catalog, OAuth, and Cursor invariants — read the relevant dated section before touching any of those.
+- `changes.md` is the design history for registry, catalog, OAuth, and Cursor invariants — read the relevant dated section before touching any of those.
 
 ## ANTI-PATTERNS
 
-- Adding generated catalogs, provider factories, OAuth, or compat side effects to `index.ts`.
+- Treating `index.ts` as types-only, or introducing builtin catalog loading, concrete wire clients, OAuth implementations, or compat registration through its transitive exports.
 - Falling back from an active scope overlay to the mutable legacy provider set.
 - Letting external image providers extend the generated `IMAGE_MODELS` catalog or builtin list instead of the images registry.
 - Bypassing provider-managed request fields via `StreamOptions.extraBody` — builders reserve and protect those keys.

--- a/packages/ai/src/api/AGENTS.md
+++ b/packages/ai/src/api/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai/src/api
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 9: wire adapters and streaming state machines.
 
-Provider wire protocol implementations and stream adapters. Each provider ships as a concrete module plus a `.lazy.ts` wrapper that uses `lazyApi()` from `lazy.ts`. 44 files at this level, ~19.5k LOC; the three largest (`cursor-agent.ts` 4.5k, `openai-completions.ts` 1.8k, `openai-codex-responses.ts` 1.7k) hold the streaming state machines.
+Provider wire protocol implementations and stream adapters. Chat and image adapters pair concrete modules with `.lazy.ts` wrappers using `lazyApi()`/`lazyStream()`. 45 TS files at this level, ~20.7k LOC; `cursor-agent.ts`, `anthropic-messages.ts`, `openai-completions.ts`, and `openai-codex-responses.ts` are the largest stateful adapters.
 
 ## MODULE PAIRS
 
@@ -22,15 +22,15 @@ Provider wire protocol implementations and stream adapters. Each provider ships 
 | `openrouter-images.ts` | `openrouter-images.lazy.ts` |
 | `openai-images.ts` | `openai-images.lazy.ts` |
 
-Utility modules with no lazy wrapper: `cloudflare.ts`, `cloudflare-gateway-binding.ts` (`createGatewayBindingFetch` — routes gateway HTTPS URLs to the Workers AI binding; pre-authenticated in-account via a sentinel header that must be stripped before send), `github-copilot-headers.ts`, `openai-prompt-cache.ts`, `warm-prompt-cache.ts` (`warmPromptCache` pre-flight), `anthropic-tool-pairs.ts` (browser-safe Anthropic tool_use/tool_result pair sanitizer; final pre-submit pass), `openai-client-auth.ts` (shared client-auth resolution from credential headers), `constrained-sampling.ts` (JSON-schema-driven constrained sampling helpers), `cursor-conversation-rotation.ts` (Node-only; rotates a poisoned Cursor conversation up to `MAX_CURSOR_CONVERSATION_ROTATIONS`), `cursor-task-args.ts` (usable-task-arg predicates).
+Utility modules with no lazy wrapper: `cloudflare.ts`, `cloudflare-gateway-binding.ts` (`createGatewayBindingFetch` — routes gateway HTTPS URLs to the Workers AI binding; pre-authenticated in-account via a sentinel header that must be stripped before send), `github-copilot-headers.ts`, `openai-prompt-cache.ts`, `warm-prompt-cache.ts` (`warmPromptCache` pre-flight), `anthropic-tool-pairs.ts` (browser-safe Anthropic tool_use/tool_result pair sanitizer; final pre-submit pass), `openai-client-auth.ts` (shared client-auth resolution from credential headers), `constrained-sampling.ts` (JSON-schema-driven constrained sampling helpers), `cursor-conversation-rotation.ts` (Node-only; rotates a poisoned Cursor conversation up to `MAX_CURSOR_CONVERSATION_ROTATIONS`), `cursor-task-args.ts` (usable-task-arg predicates), `context-room.ts` (context-budget helpers).
 
-`cursor-agent/` subdir: `types.ts` (exec-handler contracts), `pi-args.ts` (arg translators shared with `cursor-exec-bridge.ts` in coding-agent — display blocks and executed args must stay identical), `exec-modern.ts` (wire result builders for modern exec frames), `exec-lifecycle.ts` (one exec-scoped heartbeat armed at a time; next timer starts only after the current write callback succeeds), `stream-retry.ts` (`CursorRetryableStreamError` with `stall` | `transport` | `clean-end` causes), `reasoning-params.ts` (renders the resolved `src/cursor/` selection descriptor into protobuf `RequestedModel` fields), `deterministic-id.ts` (stable UUID-shape ids), and `gen/agent_pb.ts` (19.6k LOC generated protobuf-es schema; regenerate with `buf generate` from `packages/ai/proto/cursor/agent.proto`, then `bun scripts/transform-cursor-agent-proto.mjs <in> <out>`; never hand-edit, and never reuse a field number that would decode into unknown fields). `cursor-agent.ts` is Node-only: it is reached exclusively through `cursor-agent.lazy.ts`, and the Bun binary overrides it statically via `packages/ai/src/cursor-agent-provider.ts` plus `packages/coding-agent/src/bun/register-cursor-agent.ts` (imported before any Cursor provider use).
+`cursor-agent/` subdir: `types.ts` (exec-handler contracts), `pi-args.ts` (arg translators shared with `cursor-exec-bridge.ts` in coding-agent — display blocks and executed args must stay identical), `exec-modern.ts` (wire result builders for modern exec frames), `exec-lifecycle.ts` (one exec-scoped heartbeat armed at a time; next timer starts only after the current write callback succeeds), `stream-retry.ts` (`CursorRetryableStreamError` with `stall` | `transport` | `clean-end` causes), `reasoning-params.ts` (renders the resolved `src/cursor/` selection descriptor into protobuf `RequestedModel` fields), `deterministic-id.ts` (stable UUID-shape ids), `measure.ts` (browser-safe serialized-history sizing, exported from the package root), and `gen/agent_pb.ts` (19.6k LOC generated protobuf-es schema; regenerate with `buf generate` from `packages/ai/proto/cursor/agent.proto`, then `bun scripts/transform-cursor-agent-proto.mjs <in> <out>`; never hand-edit, and never reuse a field number that would decode into unknown fields). `cursor-agent.ts` is Node-only; normal lazy dispatch uses `cursor-agent.lazy.ts`, while the Bun binary overrides it statically via `packages/ai/src/cursor-agent-provider.ts` plus `packages/coding-agent/src/bun/register-cursor-agent.ts` (imported before any Cursor provider use).
 
 `openai-codex-responses/` subdir: `fallback-state.ts` (WebSocket fallback state + cooldown), `reasoning.ts` (Codex reasoning summary normalizer).
 
 ## LAZY BOUNDARY
 
-`lazy.ts` exports `lazyApi()` and `lazyStream()`. A `.lazy.ts` wrapper is the **only** sanctioned dynamic-import boundary in this package. Concrete modules use top-level imports only. `src/compat.ts` (one level up) re-exports all lazy wrappers and registers them via the api-registry.
+`lazy.ts` exports `lazyApi()` and `lazyStream()`. A `.lazy.ts` wrapper is the API implementation loading boundary; image registration and OAuth have separate documented loaders. Concrete adapters use top-level imports for ordinary dependencies. `src/compat.ts` (one level up) re-exports all lazy wrappers and registers them via the api-registry.
 
 `openai-codex-responses.ts` cannot use top-level `node:os` or `node:zlib` imports because the module loads in browser/Vite builds. It uses `process.getBuiltinModule?.("node:os")` behind a runtime check. The file carries an explicit `// NEVER convert to top-level runtime imports` comment. Keep it.
 
@@ -47,7 +47,7 @@ Utility modules with no lazy wrapper: `cloudflare.ts`, `cloudflare-gateway-bindi
 
 ## PROVIDERSTREAMS CONTRACT
 
-Every concrete module exports an object implementing `ProviderStreams` (`types.ts`): `stream()` and `streamSimple()`. Both must preserve usage counters, stop reasons, error events, abort behavior, and partial-JSON tool call chunks across the full response lifetime. Lazy wrappers forward these invariants transparently via `lazyStream`.
+Chat adapters implement `ProviderStreams` (`types.ts`): `stream()` and `streamSimple()`. Both preserve usage counters, stop reasons, error events, abort behavior, and partial-JSON tool call chunks across the response lifetime; lazy wrappers forward them transparently. Image adapters instead expose `generateImages` and return `AssistantImages`.
 
 ## EXPORTS
 
@@ -57,6 +57,5 @@ All files in this directory are wildcarded in `package.json` under the `./api/*`
 
 - No ordinary dynamic imports in concrete modules; all dynamic loading goes through `.lazy.ts` wrappers.
 - Don't duplicate shared conversion logic in a single adapter; put it in `simple-options.ts`, `transform-messages.ts`, `openai-responses-shared.ts`, or `google-shared.ts`.
-- Don't hand-edit `src/models.generated.ts`; regenerate with `scripts/generate-models.ts` (see `scripts/AGENTS.md`).
 - Don't add top-level Node built-in imports to any module consumed in browser builds.
 - Don't sanitize by sending: unsupported native tools, thinking modes, and Cursor schema keys are stripped before the request, and reserved headers (`authorization`/`host` for Bedrock; `content-length`/`host`/the gateway auth sentinel for Cloudflare) are removed rather than forwarded.

--- a/packages/ai/src/auth/AGENTS.md
+++ b/packages/ai/src/auth/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai/src/auth
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 12: shared credential resolution and OAuth boundary.
 
-Credential storage, auth contexts, provider auth resolution, and bundled OAuth flows. Everything here must stay browser-safe; Node access goes through injected/lazy boundaries only.
+Credential storage, auth contexts, provider auth resolution, and bundled OAuth flows. Core auth stays browser-safe; Node-only OAuth flow dependencies remain behind loader boundaries.
 
 ## FILES
 
@@ -13,17 +13,21 @@ credential-store.ts  Default in-memory CredentialStore; apps inject persistent s
 headers.ts           Credential-header contract; case-insensitive (all names lowercased on set and get)
 helpers.ts           Standard api-key auth helper: stored credential wins, else first set env var; includes prompt-based login
 resolve.ts           Provider auth resolution (credential vs env, OAuth refresh paths)
-oauth/               Bundled OAuth flow implementations + loader registry
+oauth/               OAuth flows + variable-specifier loader / Bun static-loader injection
+pool/                Credential slot projection, HRW selection, failure classification, stream failover
 ```
 
 ## oauth/
 
 ```text
-load.ts              registerBundledOAuthFlowLoaders(loaders) — registry of per-provider flow loaders
+load.ts              load*OAuth helpers; registerBundledOAuthFlowLoaders injects Bun's static bundle
 pkce.ts              Shared PKCE machinery
 device-code.ts       Shared device-code flow
 oauth-page.ts        Local callback/result page rendering
 anthropic.ts         Anthropic OAuth flow
+anthropic-callback-listener.ts Local callback listener
+authorization-input.ts       Shared pasted callback/code parsing
+error-details.ts     OAuth error-detail formatting
 cursor.ts            Cursor OAuth flow
 github-copilot.ts    Copilot device flow
 kimi-coding.ts       Kimi coding-plan flow
@@ -37,17 +41,21 @@ xai.ts               xAI flow
 
 - Header names are case-insensitive everywhere; never compare raw header keys, go through `headers.ts`.
 - One entry per provider id in the store; an entry may pool sibling credential slots under `accounts` while its flat top-level fields stay a valid credential (the downgrade projection older binaries read). Persistent stores are injected by the app, never assumed.
-- OAuth flows register through `registerBundledOAuthFlowLoaders`; don't import flow modules eagerly from browser-reachable code.
+- `oauth/load.ts` normally loads variable specifiers, rewriting `.ts` to `.js` in built output; Bun supplies static flows through `registerBundledOAuthFlowLoaders`. Do not eagerly import flows from browser-reachable code.
 - Auth resolution order in `helpers.ts` (stored credential, then env) is load-bearing; don't reorder.
 - `oauth/openai-codex.ts` and `oauth/radius.ts` carry `// NEVER convert to top-level imports - breaks browser/Vite builds` on their dynamic imports. Keep both the imports and the comments.
-- `resolveProviderAuth` / `resolveProviderAuthWithSignal` in `resolve.ts` is the cross-provider choke point (credential, env, OAuth refresh, error paths); it raises `ModelsError` with a `ModelsErrorCode`, not bare `Error`.
+- Public `resolveProviderAuth` delegates to private `resolveProviderAuthWithSignal`; stored credentials own the provider. Failed refresh or an unsupported stored credential type must not fall through to ambient/env auth; explicit request-key overrides are handled separately.
+- OAuth refresh double-checks expiry inside `CredentialStore.modify`, persists the rotated credential under that lock, and preserves slot siblings. Auth failures use `ModelsError` codes; cancellation remains signal-driven.
+- `slotName` pins resolution to that stored slot: missing slots return undefined, never another account or ambient credentials.
+- `pool/failover.ts` rotates only before committed output; after output, `senpi:no-turn-retry:` prevents replay. `pool/select.ts` hashes `key\0slot.name` with the caller's injected hasher and keeps auth blocks until re-login.
 
 ## WHERE TO LOOK
 
 | Task | File |
 |---|---|
-| New OAuth provider flow | `oauth/<provider>.ts` + register in `oauth/load.ts` |
+| New OAuth provider flow | `oauth/<provider>.ts`, `oauth/load.ts`, and `../bun-oauth.ts` static bundle |
 | Header semantics | `headers.ts` |
-| Credential persistence | `credential-store.ts` + app-side injected store |
+| Credential persistence / slot mutations | `credential-store.ts`, `pool/slots.ts` + app-side injected store |
+| Account affinity / failover | `pool/select.ts`, `pool/classify.ts`, `pool/failover.ts`; `../../test/credential-pool-*.test.ts` |
 | Env-vs-credential precedence | `helpers.ts`, `resolve.ts` |
 | Codex auth token helpers shared with `../api/` | `../utils/openai-codex-auth.ts` |

--- a/packages/ai/src/cursor/AGENTS.md
+++ b/packages/ai/src/cursor/AGENTS.md
@@ -1,0 +1,41 @@
+# packages/ai/src/cursor
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+Cursor catalog identity and reasoning selection shared by the native and CLI transports. Score 9: distinct domain, dense exports, 23 measured selection-resolver call sites.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Resolve model + thinking selection to wire identity | `selection-descriptor.ts` |
+| Render the CLI `--model` argument | `renderCursorCliModelString` in `selection-descriptor.ts` |
+| Capability evidence, parameter order, supported levels | `model-capabilities.ts` |
+| Known variant spellings | `cursor-variant-aliases.json` |
+| Collapse raw catalog variants into selectable entries | `catalog-grouping.ts` |
+| Persisted catalog compatibility | `store-migration.ts` |
+| Composer-family prompt selection | `composer-prompt.ts`, also consumed by history measurement |
+| Native protobuf rendering of the descriptor | `../api/cursor-agent/reasoning-params.ts` |
+
+## CONVENTIONS
+
+- Both transports consume `resolveCursorSelectionDescriptor`; native protobuf and CLI strings must not invent separate reasoning-selection rules.
+- With no reasoning compat, selection falls back to `upstreamModelId ?? id` and no parameters.
+- With compat but no explicit selection, use the representative variant, not a guessed bare capability id.
+- Explicit legacy variants are accepted only when present in the alias catalog; unsupported selections fall back to the representative.
+- Supported levels prefer catalog-guaranteed suffix aliases. Bare capability ids can be rejected by Cursor Run; do not synthesize suffixes without alias evidence.
+- Parameterized selections follow the capability's `parameterOrder`, including context, thinking, effort/reasoning, and fast flags.
+- Catalog level maps reflect observed variants as well as capability support; a capability alone does not prove the server offers a selectable level.
+
+## ANTI-PATTERNS
+
+- Encoding every Cursor id as a generic `<base>-<level>-<mode>` string; alias spellings and thinking placement vary.
+- Fixing native transport selection without checking the CLI renderer that consumes the same descriptor.
+- Dropping legacy aliases during catalog grouping or stored-model migration.
+
+## VALIDATION
+
+- Focused suites live in `packages/ai/test/cursor-model-grouping.test.ts`, `cursor-model-capabilities.test.ts`, and `cursor-reasoning-params.test.ts`.
+- Exercise representative, unsupported, legacy-variant, suffix-alias, and parameterized selections when changing identity rules.

--- a/packages/ai/src/providers/AGENTS.md
+++ b/packages/ai/src/providers/AGENTS.md
@@ -1,18 +1,18 @@
 # packages/ai/src/providers
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 9: provider assembly and generated catalog boundary.
 
-This directory owns provider factories, catalogs, provider metadata, and the faux test provider. API wire implementations, option translation, and message transforms live in sibling `../api/`. 41 provider factories, 41 matching `*.models.ts` catalogs, 41 `data/` JSONs — the three counts move together or generation is broken.
+This directory owns provider factories, catalogs, provider metadata, and the faux test provider. API wire implementations, option translation, and message transforms live in sibling `../api/`. 41 generated `*.models.ts` catalogs match 41 provider JSONs plus `data/.manifest.json`. Runtime factories also include dynamic Cursor/Radius/Ollama and image/test surfaces; factory counts are not a generation invariant.
 
 ## FILE MAP
 
 ```text
 register-builtins.ts     One line: `import "../compat.ts"` — that is the whole contract
 all.ts                   Builtin provider/model aggregation: builtinProviders, builtinModels,
-                         builtinImagesProviders, builtinImagesModels, getBuiltinProvider(s)/Model(s);
+                         builtinImagesProviders, builtinImagesModels, getBuiltinProviders/Model(s);
                          also re-exports the data/.manifest.json generation timestamp
 faux.ts                  Deterministic public test provider
-*-models.ts              Provider model/catalog helpers where present
+*.models.ts              Generated catalog shards over matching data/ JSON
 images/register-builtins.ts  Image API registration; holds its own lazy module promises per images
                          provider and returns a lazy-load-error AssistantImages instead of throwing
 radius.ts                Dynamic Radius provider with persisted model refresh
@@ -47,9 +47,9 @@ Newer providers on disk (each `<name>.ts` + `<name>.models.ts`): ant-ling, kimi-
 - Keep provider-specific quirks local; shared behavior belongs in clearly named shared modules.
 - Every API stream must preserve tool calls, thinking blocks, usage accounting, stop reasons, setup errors, and abort semantics.
 - Default tests run with zero credentials. Use the faux provider for deterministic event sequences.
-- Keep image providers structurally separate under `images/`.
+- Image factories are `openai-images.ts` / `openrouter-images.ts`; shared lazy API registration lives in `images/register-builtins.ts`.
 - `data/` is committed generated source; never hand-edit. Regenerate with `bun run hydrate-model-data`, validate with `bun run check:model-data` (contract in `packages/ai/scripts/AGENTS.md`).
-- Every `*.models.ts` opens with "Do not edit manually - run `bun run generate-models` to update" and flattens its JSON through `../model-catalog.ts`.
+- Every `*.models.ts` has an auto-generation header and flattens its JSON through `../model-catalog.ts`; the emitted header currently names `npm run generate-models`.
 
 ## ANTI-PATTERNS
 

--- a/packages/ai/src/tool-call-middleware/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/AGENTS.md
@@ -2,9 +2,9 @@
 
 Text-format tool-call protocols for providers that don't support native function calling. Wraps `openai-completions` streams and parses `<tool_call>` / XML / delimiter formats back into pi's canonical `toolCall` events. Fork-modified — see `changes.md`.
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`.
 
-Size: 21 files here + 9 under `protocols/` (~5.4k LOC). Complexity sits in `morph-xml.ts` (1.2k), `json-mix.ts` (854), `gemma4.ts` (809).
+Score 14: 54 TS files across wrapper/recovery and protocol domains (~8.4k LOC). `protocols/AGENTS.md` covers parser internals; this file owns activation and stream integration.
 
 ## FILES
 
@@ -42,38 +42,37 @@ tool-call-middleware/
 
 | Task | File |
 |------|------|
-| Add a new text-tool protocol | `protocols/<name>.ts` + register in `index.ts` + extend the `ToolCallFormat` union/whitelist (see ADD A PROTOCOL step 4) |
+| Add a new text-tool protocol | `protocols/`, `context-transformer.ts` registry, `types.ts` union, `index.ts` whitelist |
 | Fix a parser bug | `protocols/<name>.ts` (parse step) |
 | Fix streaming partial-arg bug | `protocols/<name>.ts` (stream step) + `stream-wrapper.ts` |
 | System-prompt format for tools | `context-transformer.ts` (per-protocol prompt injector) |
 | Cross-provider stream error fallback | `stream-wrapper.ts` — preserves reconstructed outer text+toolCalls on transport error |
+| Leaked text-tool recovery activation | `index.ts`: Claude/Kimi defaults, explicit `recoverTextToolCalls`, Cursor excluded by default |
 
 ## ADD A PROTOCOL (5 steps)
 
-1. Implement `Protocol` interface in `protocols/<name>.ts` or `protocols/<name>/index.ts` plus focused helpers (parse, format, stream).
-2. Add system-prompt rendering for tools to `context-transformer.ts`.
-3. Export from `index.ts` and register in the protocol registry.
-4. Add "<name>" to the ToolCallFormat union in types.ts (this dir) and to the literal whitelist in getToolCallFormat() in index.ts. models.json accepts toolCallFormat as a free string (packages/coding-agent/src/core/model-config.ts:104, Type.String() by design), so the getToolCallFormat() whitelist is the ONLY enforcement point — a format missing there silently deactivates the middleware.
+1. Implement `ToolCallProtocol` in `protocols/<name>.ts` or `protocols/<name>/index.ts` plus focused helpers (parse, format, stream).
+2. Supply tool-system-prompt, call, and result formatters alongside batch and stream parsers.
+3. Wire the implementation into `protocolRegistry` in `context-transformer.ts`; `index.ts` re-exports that dispatcher, not the protocol implementations.
+4. Add the format to `ToolCallFormat` in `types.ts` and the `getToolCallFormat()` whitelist in `index.ts`. The whitelist applies only to `openai-completions`; a missing format silently deactivates explicit middleware.
 5. Add manual test command to `TESTING.md` and an automated test under `packages/ai/test/tool-call-middleware/<name>*.test.ts`.
 
 ## CONVENTIONS
 
 - **Stream-error preservation** (2026-04-11): when a provider stream errors AFTER complete tool-call blocks were reconstructed, finish the turn as `toolUse` so the agent still executes those tools. Do NOT fall back to the raw provider message.
-- **Strict parsing**: reject malformed XML/JSON instead of coercing into invalid strings (precedent: `morph-xml` array<object> handling).
-- **Delegate to `json-mix.ts`** for any new JSON-inside-delimiters protocol — minimizes drift across Hermes-family parsers.
-- **`xml-tool-tag-scanner.ts`** is the canonical streaming boundary detector; reuse it for any XML-tag-based protocol.
+- **Validation after repair**: parser-specific coercion may repair input (ANTML), but invalid arguments never become executable calls. Shared parser choices are documented in `protocols/AGENTS.md`.
+- **Recovery selection**: explicit text-tool format disables automatic invoke recovery. Kimi thinking cleanup runs before the tool-recovery gate, even with no tools.
 - **Non-mutating context transform**: `context-transformer.ts` strips `tools`, injects the protocol prompt, serializes assistant tool calls, and rewrites tool results as user text — it returns new structures.
 - **Recovery replays sanitized calls only**: raw truncated markup never re-enters context; incomplete calls come back as canonical calls paired with error results.
 
 ## ANTI-PATTERNS
 
-- Coercing malformed input into a "best-effort" string — produces invalid downstream `tool_call.arguments`. Reject instead.
-- Duplicating Hermes-style parsing in a new file — extract a shared helper in `json-mix.ts`.
+- Letting repaired or incomplete arguments bypass validation or lose their paired error result.
+- Dropping symbol-keyed metadata (including Cursor exec-resolution markers) while projecting recovered messages.
 - Forgetting to inject the protocol-specific system-prompt block in `context-transformer.ts` — model never emits tool calls.
-- Writing tests against live OpenRouter without `describe.skipIf(!process.env.OPENROUTER_API_KEY)` gating.
+- Activating live tests from credential presence alone; require the opt-in gate from `test/live-api-gates.ts`.
 
 ## NOTES
 
 - `TESTING.md` documents the canonical live-API test commands per protocol (Qwen for Hermes, Gemini for MorphXML, Gemma 4 for delimiter, and Anthropic XML). Update it when adding new protocols.
-- This package's middleware is fork-modified — see `changes.md` for the architectural rewrite toward `minpeter/ai-sdk-tool-call-middleware` style.
 - `compat.toolCallFormat` on a custom model in `~/.senpi/agent/models.json` is what activates middleware for that model.

--- a/packages/ai/src/tool-call-middleware/protocols/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/protocols/AGENTS.md
@@ -1,0 +1,42 @@
+# packages/ai/src/tool-call-middleware/protocols
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+Parser implementations beneath the middleware registry; activation and outer stream projection stay in the parent directory. Score 9: dense parsing code and distinct wire-format domains.
+
+## WHERE TO LOOK
+
+| Change | Boundary |
+|---|---|
+| Hermes-family JSON inside delimiters | `json-mix.ts` shared machinery, `hermes.ts` format binding |
+| Morph XML argument structure or truncation | `morph-xml.ts` |
+| YAML-valued arguments inside XML | `yaml-xml.ts` |
+| Gemma delimiter parser | `gemma4.ts` |
+| Shared XML tool-tag recognition | `xml-tool-tag-scanner.ts` |
+| Invoke/parameter scanner and stream lifecycle | `anthropic-xml/`; owns shared invoke machinery |
+| Claude-style tolerant argument repair | `antml/`; configures the shared invoke implementation |
+| Kimi channel markers and thinking recovery | `kimi-xtml/`; separate channel-aware state machine |
+
+## CONVENTIONS
+
+- JSON-delimiter variants reuse `json-mix.ts`; do not copy Hermes parsing into another protocol.
+- Invoke-shaped protocols use `InvokeProtocolConfig` from `anthropic-xml/invoke-protocol.ts`, not the JSON-delimiter helper.
+- Shared invoke scanning is format-agnostic; protocol identity, call-id prefix, and argument coercion come from that config.
+- XML tool-tag scanning and invoke-boundary scanning are different layers. Reuse the matching scanner rather than routing every XML-like protocol through one helper.
+- `anthropic-xml` strict coercion and `antml` schema-validated repairs are intentionally different contracts.
+- Protocol implementations include both batch parsing and incremental `feed`/`finish`; keep terminal truncation consistent with the format's incomplete-call rules.
+- `xml` maps to the Morph XML implementation for compatibility; new format integrations use `morph-xml`.
+
+## ANTI-PATTERNS
+
+- Treating the outer recovery wrapper as the place to repair protocol-specific argument syntax.
+- Assuming Gemma or Kimi delimiters have XML nesting semantics.
+- Recognizing nested protocol-looking text inside an argument value as a new executable call.
+- Updating batch parsing without checking incremental splits and end-of-stream behavior.
+
+## VALIDATION
+
+- Parser and stream suites are flat under `packages/ai/test/tool-call-middleware/`, not nested to mirror this directory.
+- `stream-integration.test.ts` and `truncation-e2e.test.ts` exercise the shared cross-protocol contract.

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/AGENTS.md
@@ -1,0 +1,44 @@
+# packages/ai/src/tool-call-middleware/protocols/anthropic-xml
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+Strict Anthropic XML formatting/coercion plus shared invoke scanners consumed by ANTML and leaked-call recovery. Score 8: exported parser boundary with dense shared implementation.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Configurable invoke parser contract | `invoke-protocol.ts` |
+| Tag syntax and nested block scanning | `invoke-tag-syntax.ts`, `invoke-tag-scanner.ts`, `invoke-match.ts` |
+| Batch call extraction | `parse.ts` |
+| Incremental invoke parsing | `stream.ts`, `invoke-stream-helpers.ts` |
+| Incremental close matching and retained-input limit | `stream-boundary.ts` |
+| Strict schema-aware parameter conversion | `coerce-parameters.ts`, `xml-entities.ts` |
+| Tool/system/result serialization | `format.ts` |
+| Eager leaked-call recovery state machine | `recovery-stream.ts`, `recovery-wrapper-state.ts` |
+| Registered-tool wire alias lookup | `tool-resolver.ts` |
+
+## CONVENTIONS
+
+- Strict coercion rejects duplicate parameter names and validates the assembled record with `Value.Check`.
+- Remove one raw boundary newline on each side before XML entity decoding; preserve meaningful string whitespace.
+- Booleans accept literal `true`/`false`; array/object arguments require valid JSON of the expected shape.
+- Parameter keys are defined as own properties, including special property names; do not replace this with unsafe prototype mutation.
+- Recovery name lookup prefers exact names, then unambiguous case-insensitive names, then normalized wire aliases.
+- Alias normalization strips CC-SDK `mcp__server__tool` and hashed `mcp_<hash>-` prefixes; collisions remain unresolved.
+- Retained incomplete invoke fragments are capped at 64 Ki UTF-16 code units by `stream-boundary.ts`.
+- Recovery emits an eager start for a known tool. Invalid or interrupted arguments end with `incomplete` and an error, not an executable guessed call.
+
+## ANTI-PATTERNS
+
+- Importing ANTML's lenient coercion into the strict Anthropic XML config.
+- Selecting an arbitrary tool after normalized alias collisions.
+- Counting the retained-fragment limit as bytes rather than UTF-16 code units.
+- Repeatedly rescanning the whole retained fragment instead of feeding the incremental close matcher.
+
+## VALIDATION
+
+- Run `anthropic-xml-*.test.ts` plus `invoke-recovery-tool-alias.test.ts` and `invoke-recovery-resource*.test.ts` under the middleware test directory.
+- Shared scanner changes also affect `antml-parser.test.ts`, `antml-stream.test.ts`, and invoke recovery suites.

--- a/packages/ai/src/tool-call-middleware/protocols/antml/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/AGENTS.md
@@ -1,0 +1,42 @@
+# packages/ai/src/tool-call-middleware/protocols/antml
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+ANTML's Claude-style argument repair policy over the shared invoke parser. Score 8: exported domain boundary with coercion rules that intentionally differ from strict XML.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Protocol identity and injected coercer | `config.ts` |
+| Parameter aliases, scalar coercion, schema filtering | `coerce-parameters.ts` |
+| Broken Unicode escapes and lone-surrogate repair | `repair.ts` |
+| Delegate batch, stream, or recovery parsing | `parse.ts`, `stream.ts`, `recovery-stream.ts` |
+| Tool-call/system/result formatting | `format.ts` |
+| Supported exports | `index.ts` |
+
+## CONVENTIONS
+
+- Resolve declared property names by exact match, then unique case/separator-insensitive match, then the explicit alias groups.
+- Alias groups cover file paths, old/new replacement strings, and command/cmd; expand only with schema-backed regression cases.
+- Duplicate parameters are last-wins here, unlike strict Anthropic XML's rejection.
+- Recursively filter unknown object keys unless `additionalProperties` permits them or supplies a schema.
+- Repairs narrow values; the final `Value.Check` is mandatory. Failed known-value coercion rejects the call.
+- Numeric/boolean scalar spellings can be unwrapped from JSON strings; arrays and objects still require parseable JSON of the right shape.
+- Broken `\u` escapes are made literal only when malformed and not already escaped. Valid escapes remain unchanged.
+- Replace lone UTF-16 surrogates in strings and object keys without destroying valid surrogate pairs.
+- Use own-property definitions while rebuilding objects so special keys remain data.
+
+## ANTI-PATTERNS
+
+- Forking the shared invoke scanner to implement an argument-coercion difference.
+- Returning repaired arguments before schema validation or converting a failed object parse to a string.
+- Globally deleting unknown keys when the schema explicitly permits additional properties.
+- Applying Unicode escape repair to already-escaped backslash runs.
+
+## VALIDATION
+
+- Focused coverage: `antml-coerce.test.ts`, `antml-repair.test.ts`, `antml-parser.test.ts`, `antml-stream.test.ts`, and `antml-e2e.test.ts` in the middleware test directory.
+- Keep strict Anthropic XML tests unchanged when broadening ANTML-only tolerance.

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/AGENTS.md
@@ -1,0 +1,42 @@
+# packages/ai/src/tool-call-middleware/protocols/kimi-xtml
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+Kimi XTML channel parsing, leaked-call recovery, and thinking-to-response projection. Score 8: exported channel-specific state machines and recovery boundary.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Structural tokens, channel markers, partial suffixes | `markers.ts` |
+| Batch calls and typed argument values | `parse.ts` |
+| Incremental tools/call/argument modes | `stream.ts` |
+| Tool/system/result formatting | `format.ts` |
+| Leaked XTML call parser | `recovery-stream.ts` |
+| Repair a completed message's thinking channels | `thinking-recovery.ts` |
+| Project thinking recovery through stream events | `thinking-recovery-stream.ts` |
+
+## CONVENTIONS
+
+- Structural call/argument markers include attributes and a separator; bare channel-marker stripping must not consume their contents as ordinary channel noise.
+- Incremental modes distinguish text, tools, call headers/body, argument headers/value, and discarded calls.
+- Unknown tools enter discard mode; a recognized call starts only after its complete header has been parsed.
+- Argument deltas carry the accumulated argument object; preserve this format when changing chunk handling.
+- `finish()` flushes ordinary trailing text, but an active unfinished call ends with `incomplete` rather than successful execution.
+- Thinking recovery starts in the thinking channel; an opened response channel moves content to visible text, and closing it returns to thinking.
+- Code-masked segments remain literal during channel cleanup; examples in fenced code must not trigger projection.
+- Unchanged completed messages retain their identity. Changed thinking adds a `kimi_xtml_thinking_recovery` diagnostic with whether response content was recovered.
+
+## ANTI-PATTERNS
+
+- Treating XTML as angle-bracket XML or stripping every `<|open|>` substring without channel context.
+- Letting invalid argument coercion end as a complete successful call.
+- Combining completed-message repair and streamed event projection without checking event/content index consistency.
+- Dropping valid text around split channel markers when retaining a partial suffix.
+
+## VALIDATION
+
+- Use `kimi-xtml-{parser,stream,marker-leak,thinking-recovery,recovery-stream,recovery-activation}.test.ts` under the middleware test directory.
+- Activation tests cover the model selector outside this directory; parser changes alone do not establish recovery eligibility.

--- a/packages/ai/src/utils/AGENTS.md
+++ b/packages/ai/src/utils/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai/src/utils
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`.
 
-Cross-provider behavior choke points: retry classification, prompt-cache compatibility, overflow detection, tool-schema normalization, stream primitives. 33 files, ~3.5k LOC, no barrel — import each module by explicit path. Scored 12 (33 files, >300 import sites across `src/` and `packages/coding-agent`); it earns its own file because a change here silently reshapes every provider.
+Cross-provider behavior choke points: retry classification, prompt-cache compatibility, overflow detection, tool-schema normalization, stream primitives. 42 TS files, ~4.4k LOC including `retry-profile/`. No top-level barrel; `retry-profile/index.ts` is a deliberate nested barrel. Score 12: shared behavior with measured cross-module stream consumers.
 
 ## FILE MAP
 
@@ -10,10 +10,12 @@ Cross-provider behavior choke points: retry classification, prompt-cache compati
 retry.ts                 Assistant/transient retry policy; NON_RETRYABLE_PROVIDER_ERROR_PATTERN is the allowlist-by-exclusion of permanent failures
 provider-retry.ts        HTTP-status/header-driven provider backoff (Retry-After parsing)
 retry-hint.ts            Retry-after marker encode/decode carried through error messages
+retry-profile/           Typed two-stage retry policy, failure normalization, classifiers, planner; own AGENTS.md
 prompt-cache-ttl.ts      Per-provider cache TTL + capability matrix (getAnthropicCompat, getOpenAICompletionsCompat)
 overflow.ts              Context-overflow / recoverable-length error patterns per provider
 tool-schema-compat.ts    JSON-schema normalization for OpenAI-compat and Moonshot
 tool-pair-repair.ts      Orphaned tool_result repair
+drop-failed-assistant-turns.ts Removes failed assistant turns before replay
 tool-call-id.ts          Tool-call id shaping
 tool-choice-fallback.ts  Tool-choice degradation when a provider rejects the requested mode
 deferred-tools.ts        splitDeferredTools
@@ -34,13 +36,14 @@ server-fallback-receipt.ts, typebox-helpers.ts, unavailable-tool-text.ts
 - Provider quirks are encoded as explicit named patterns/constants with a comment naming the provider and the observed error text (see `retry.ts`, `overflow.ts`). Do not add a bare regex without the wire evidence that motivated it.
 - Compatibility detection is layered: provider id / base URL / model id heuristic first, then explicit per-model `compat` overrides win.
 - `tool-schema-compat.ts` deliberately strips JSON-schema `deprecated` annotations during normalization — providers reject the keyword.
-- Retry classification is exclusion-based: everything is retryable unless it matches a permanent-failure pattern (quota, credits, malformed request shape). Adding a pattern makes failures terminal for every provider.
+- The legacy `retry.ts` message classifier is exclusion-based; permanent-failure patterns affect every caller. Typed profile classifiers in `retry-profile/` use a separate structured failure contract, not a blanket retry-everything rule.
 
 ## WHERE TO LOOK
 
 | Task | File |
 |---|---|
-| A transient failure is being treated as permanent (or vice versa) | `retry.ts` classification patterns |
+| A transient failure is being treated as permanent (or vice versa) | `retry.ts` message patterns or `retry-profile/classifiers.ts` typed failures |
+| Provider-request versus turn retry budget | `retry-profile/profiles.ts`; stage planning in `retry-profile/planner.ts` |
 | Provider returns 429 with a Retry-After we ignore | `provider-retry.ts`, `retry-hint.ts` |
 | Cache TTL / cache-write accounting wrong for a model | `prompt-cache-ttl.ts` |
 | "Context length exceeded" not detected for a new provider | `overflow.ts` |
@@ -49,6 +52,6 @@ server-fallback-receipt.ts, typebox-helpers.ts, unavailable-tool-text.ts
 
 ## ANTI-PATTERNS
 
-- Adding a top-level `node:*` import here — these modules are reachable from the browser-safe package root.
+- Adding a top-level runtime `node:*` import here — these modules are reachable from the browser-safe package root.
 - Duplicating a provider quirk in an adapter under `../api/` when it belongs in the shared matrix here.
 - Widening a retry pattern to "fix" one provider without checking the other providers that share the classifier.

--- a/packages/ai/src/utils/retry-profile/AGENTS.md
+++ b/packages/ai/src/utils/retry-profile/AGENTS.md
@@ -1,0 +1,41 @@
+# packages/ai/src/utils/retry-profile
+
+Generated: 2026-09-10. Commit `2d0fa41c5`.
+
+## OVERVIEW
+
+Typed retry profiles separate provider-request and whole-turn policy without owning execution. Score 8: exported module boundary with its own failure, classifier, and planner contracts.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Public profile types and stage policies | `types.ts`, re-exported by `index.ts` |
+| Builtin budgets, hint ceilings, jitter modes | `profiles.ts` |
+| Normalize Anthropic SDK/SSE failures | `failure.ts` |
+| Classify normalized Kimi or default failures | `classifiers.ts` |
+| Compute exponential delay with supplied randomness | `backoff.ts` |
+| Combine backoff with server hints | `planner.ts` |
+
+## CONVENTIONS
+
+- `SENPI_DEFAULT_RETRY_PROFILE` declares separate request and turn stages; changes to one stage must not implicitly widen the other.
+- `KIMI_CODE_RETRY_PROFILE` disables the request stage so callers cannot stack a second hidden retry budget on its turn retries.
+- The planner consumes a supplied random number; execution, timers, and retry loops belong to callers.
+- Positive override hints replace computed delay even when shorter. Zero is accepted only by stages with `acceptZero`.
+- A hint strictly above a finite ceiling returns `over-ceiling`; it is not clamped. A null ceiling permits any positive hint.
+- Tiered planning returns the `delegated` sentinel. Actual tier decisions remain in coding-agent's `core/retry-fallback/hint-policy.ts`; the default strategy requires caller injection.
+- Anthropic normalization retains declared facts, not raw response bodies/headers; messages are capped at 500 characters.
+- SDK timeout/connection errors are identified by constructor name, timeout first, rather than eager imports of SDK error classes.
+
+## ANTI-PATTERNS
+
+- Importing coding-agent to implement the tier strategy here; that reverses the package dependency.
+- Turning `over-ceiling` into a shorter sleep and silently ignoring a server-requested wait.
+- Retaining credentials or raw headers/body objects on `RetryFailure`.
+- Replacing additive Kimi jitter with the default request-stage subtractive policy.
+
+## VALIDATION
+
+- `packages/ai/test/retry-profile-{backoff,classifiers,failure,planner,profiles}.test.ts` covers this domain.
+- Use explicit random inputs and assert planner result kinds, hint semantics, and separate stage budgets.

--- a/packages/ai/test/AGENTS.md
+++ b/packages/ai/test/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai/test
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`.
 
-Flat Vitest suite for the whole `pi-ai` package: 228 top-level `.ts` files, ~53k LOC, plus `tool-call-middleware/` (own AGENTS.md), `fixtures/` (catalog JSON), `data/red-circle.png`. Earns its own file on size and on gating/harness conventions that exist nowhere in `src/`.
+Flat Vitest suite for the whole `pi-ai` package: 268 top-level `.ts` files (255 suites), ~60k LOC, plus `tool-call-middleware/` (own AGENTS.md), `fixtures/` (catalog JSON), `data/red-circle.png`. Score 12: suite size and shared opt-in gating/harness conventions.
 
 ## LAYOUT
 
@@ -17,19 +17,20 @@ No mirroring of `src/` structure. Filenames encode provider + behavior: `anthrop
 | `azure-utils.ts` | `hasAzureOpenAICredentials`, `resolveAzureDeploymentName` |
 | `bedrock-utils.ts` / `cloudflare-utils.ts` | `hasBedrockCredentials`, `hasCloudflareWorkersAICredentials`, `hasCloudflareAiGatewayCredentials` |
 | `cursor-agent-exec-lifecycle-harness.ts` + `.cases.ts` | HTTP/2 + protobuf frame harness; `registerCursorExecLifecycleTests()` |
+| `anthropic-tool-reference-harness.ts` | Captured Anthropic requests, SSE builders, native-search/tool-reference assertions |
 | `model-switch-replay-fixtures.ts` | `HISTORY`, `APPLY_PATCH_TOOL`, `makePatchHistory`, `makeModel` — shared by both model-switch replay tests |
 | `scratch.ts`, `codex-websocket-cached-probe.ts` | Manual probes, NOT Vitest entries; run via `node test/<file>.ts` |
 
 ## LIVE-TEST GATING
 
 - Every network-touching case is opt-in. `PI_ENABLE_LIVE_API_TESTS=1` enables all; per-provider flags (`PI_ENABLE_LOCAL_LLM`, `PI_ENABLE_OPENROUTER_LIVE`, `PI_ENABLE_BASETEN_LIVE`, `PI_ENABLE_QWEN_TOKEN_PLAN_LIVE`, `PI_ENABLE_ANTHROPIC_OAUTH_LIVE`, `PI_ENABLE_GITHUB_COPILOT_LIVE`, `PI_ENABLE_OPENAI_CODEX_LIVE`) enable one.
-- Gate through `live-api-gates.ts` (15 suites do), not raw `process.env` reads. Ollama availability is probed by `which ollama`, never assumed.
+- Gate through `live-api-gates.ts`, not raw `process.env` reads. Ollama availability is probed by `which ollama` (`where ollama` on Windows), never assumed.
 - Credential-only presence checks belong in the `*-utils.ts` helpers so setup is not duplicated per suite.
 
 ## CONVENTIONS
 
 - Relative imports into source carry the explicit `.ts` extension (`from "../src/compat.ts"`), matching the package's NodeNext build.
-- Offline default: fake `fetch`, local Node HTTP/HTTP2 servers, or `src/providers/faux.ts` (12 suites). Assertions target serialized wire payloads, headers, event order, stop reasons, and usage — not implementation names.
+- Offline default: fake `fetch`, local Node HTTP/HTTP2 servers, or `src/providers/faux.ts`. Assertions target serialized wire payloads, headers, event order, stop reasons, and usage — not implementation names.
 - `vitest.config.ts` sets `globals: true`, node env, 30s `testTimeout`, dot reporter, `silent: "passed-only"`, and aliases `@earendil-works/pi-telemetry` to `../telemetry/src/index.ts`. Suites still import `describe`/`it`/`expect` explicitly.
 - Env mutation and temp credential stores are isolated per suite via `beforeEach`/`afterEach`; faux-provider registrations keep their unregister handle and are cleaned up.
 - Large fixtures live in `fixtures/*.json` (dated catalog snapshots) — characterization tests, refresh them deliberately.
@@ -37,7 +38,7 @@ No mirroring of `src/` structure. Filenames encode provider + behavior: `anthrop
 ## ANTI-PATTERNS
 
 - Never make a live provider call part of default success. Ungated network access breaks CI and every offline dev loop.
-- Never assert on timing/sleep in stream or protocol tests — await the captured event or frame predicate. OAuth expiry tests use fake timers.
+- Never assert on timing/sleep in stream or protocol tests: subscribe to the exact event/frame before triggering it, then await that signal with a bounded timeout. OAuth expiry tests use fake timers.
 - Never let secret values reach assertions; credential tests assert metadata shape only.
 - Do not mutate caller-owned tool/schema objects in normalization tests; the suite asserts source objects survive untouched.
 - Do not leak faux-provider or model registrations across tests; superseded providers must not publish late.
@@ -53,4 +54,4 @@ PI_ENABLE_LIVE_API_TESTS=1 bun run --cwd packages/ai test   # opt into live suit
 
 ## HOTSPOTS
 
-`openai-codex-stream.test.ts` (2850), `openai-completions-tool-choice.test.ts` (1969), `stream.test.ts` (1802, multi-provider matrix + local Ollama process), `models-runtime.test.ts` (1193, provider/auth/refresh/cancel runtime), `total-tokens.test.ts` (912), `unicode-surrogate.test.ts` (866), `empty.test.ts` (861), `anthropic-provider-native-replay.test.ts` (832). Touch shared conventions here first.
+`openai-codex-stream.test.ts`, `openai-completions-tool-choice.test.ts`, `stream.test.ts`, and `models-runtime.test.ts` dominate streaming/runtime coverage. `anthropic-tool-reference-*.test.ts` covers native-search replay; `retry-profile-*.test.ts` and `credential-pool-*.test.ts` cover structured retry and account failover.

--- a/packages/ai/test/tool-call-middleware/AGENTS.md
+++ b/packages/ai/test/tool-call-middleware/AGENTS.md
@@ -1,12 +1,12 @@
 # packages/ai/test/tool-call-middleware
 
-Generated: 2026-08-24. Commit `baf15a54d`.
+Generated: 2026-09-10. Commit `2d0fa41c5`. Score 9: protocol/recovery integration fixtures.
 
-58 files / ~12.5k LOC covering `src/tool-call-middleware`: text-tool protocol parsers, the stream wrapper, and the leaked-invoke recovery state machine. Distinct domain — the only suite in this package built on registration-module fixtures rather than self-contained `.test.ts` files.
+58 TS files / ~12.5k LOC covering `src/tool-call-middleware`: text-tool protocol parsers, the stream wrapper, and the leaked-invoke recovery state machine. Distinct domain: registration-module fixtures compose the larger recovery/wrapper suites alongside self-contained parser tests.
 
 ## FIXTURE / CASE SPLIT
 
-16 non-`.test.ts` modules. A thin `*.test.ts` aggregator calls `register*Cases(...)` from `.ts` case modules; the cases import shared fixtures. Look for the behavior in the case module, not the test file.
+Shared non-`.test.ts` modules carry fixtures and case registrations. A thin `*.test.ts` aggregator calls `register*Cases(...)` from `.ts` case modules; the cases import shared fixtures. Look for the behavior in the case module, not the test file.
 
 | Module | Role |
 |---|---|
@@ -20,10 +20,11 @@ Generated: 2026-08-24. Commit `baf15a54d`.
 ## CONVENTIONS
 
 - Per-protocol coverage is split by concern, not bundled: `<proto>-format`, `-parser`, `-stream`, edge/resource, recovery, then `e2e.test.ts` against the faux provider.
-- Stream tests feed input at exhaustive and randomized chunk boundaries and assert the full event sequence, terminal flush, metadata identity, and content indices — never just the final text.
+- Stream tests feed input at exhaustive and fixed-seed randomized chunk boundaries and assert the full event sequence, terminal flush, metadata identity, and content indices — never just the final text.
 - Recovery tests drive synthetic `AssistantMessageEventStream` harnesses for both native and text event paths; source ordering and content index preservation are part of the contract.
 - Tool schemas use `typebox` `Type`; one export-purity check runs `spawnSync(process.execPath, ["--input-type=module", "--eval", ...])` to prove imports are side-effect free.
 - Adding a protocol means adding `<name>*.test.ts` here (step 5 of ADD A PROTOCOL in `src/tool-call-middleware/AGENTS.md`).
+- ANTML coercion/repair tests distinguish schema-validated tolerance from strict Anthropic XML. Kimi activation, marker-leak, thinking-recovery, and tool-recovery tests exercise separate paths.
 
 ## ANTI-PATTERNS
 

--- a/packages/client/AGENTS.md
+++ b/packages/client/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/client
 
-Transport-neutral client for remote pi sessions: `PiClient` exchanges framed CBOR through an injected `ByteTransportFactory`. Sole runtime dependency is `@earendil-works/pi-protocol`; the core stays runtime-neutral (no Node imports).
+Transport-neutral client for remote pi sessions: `PiClient` exchanges framed CBOR through an injected `ByteTransportFactory`. Sole runtime dependency is `@earendil-works/pi-protocol`; the core stays runtime-neutral. Score 12: 24 files, package/config boundary, dense lifecycle symbols, 19 public barrel exports.
 
 ## STRUCTURE
 
@@ -11,6 +11,7 @@ src/state.ts           Authoritative snapshots, event and listener fan-out
 src/session-handle.ts  SessionLease / PiSessionHandle semantics
 src/transport.ts       ByteTransport / ByteTransportFactory contracts
 src/errors.ts          PiServerError and client error taxonomy
+src/promise.ts         Resolver helper pending the TypeScript ES2024 lib baseline
 src/unix.ts            Node Unix-domain transport (separate ./unix subpath)
 src/index.ts           Public barrel
 test/                  Vitest suites plus support harness
@@ -22,10 +23,12 @@ test/                  Vitest suites plus support harness
 |---|---|
 | Connection lifecycle, reconnect | `src/connection.ts` |
 | Session leases, attach/detach, reconciliation | `src/client.ts` |
-| Lease modes and invalidation | `src/session-handle.ts` |
+| Lease interface and forwarding | `src/session-handle.ts`; ownership, generations and invalidation in `src/client.ts` |
 | Snapshot vs event state | `src/state.ts` |
 | New transports | implement `ByteTransportFactory` per `src/transport.ts` |
-| Unix-domain sockets | `src/unix.ts` via `@earendil-works/pi-client/unix` |
+| Unix-domain sockets | `src/unix.ts` via `@earendil-works/pi-client/unix`; rejects Windows and overlong UTF-8 paths |
+| Client behavior harness | `test/support.ts` (`MemoryByteServer`); lifecycle regressions in `test/connection.test.ts`, `test/sessions.test.ts`, `test/disposal.test.ts` |
+| CLI-facing adapter | `packages/coding-agent/src/client/remote-session.ts` consumes `PiClient` |
 
 ## CONVENTIONS
 
@@ -33,23 +36,29 @@ test/                  Vitest suites plus support harness
 - `package.json` exports map is `.`, `./unix`, `./package.json`; `sideEffects: false`. Extend the map rather than adding side-effectful entry points.
 - Build and tests resolve `@earendil-works/pi-protocol` via `paths`/vitest alias (`../protocol/dist` for build, `../protocol/src` for tests); keep both in sync when files move.
 - Imports carry explicit `.ts` extensions per root `tsconfig.base.json`.
-- Engines: Node >=22.19.0 (repo root requires >=24). Published as CalVer `@earendil-works/pi-client`.
+- Engines: Node >=22.19.0 (repo root requires >=24). Workspace package name: `@earendil-works/pi-client`.
+- `SessionLease` is an interface (`PiSessionHandle` is its alias), not a public constructor. `createSession()` reserves exclusive ownership; `attachSession()` acquires a shared lease.
+- Failed explicit `detach()` restores the lease for retry; failed `dispose()` relinquishes ownership and requires cleanup reconciliation before reacquisition.
+- Diagnostics callbacks cannot alter connection/client state. Handshake callbacks may disconnect or reconnect synchronously; stale connection completions must not revive them.
 
 ## ANTI-PATTERNS
 
 - No auto-reconnect: `PiClient` requires explicit `reconnect()` after disconnection; do not add hidden retry loops.
 - Never apply optimistic state mutation from progress events; server snapshots and successful response snapshots are authoritative.
-- Do not construct `SessionLease` directly; leases exist only via `acquireSession()`, `createSession()`, or `attachSession()`.
-- Do not add Node/builtin imports outside `src/unix.ts`.
+- Do not export or construct the internal `SessionHandle` directly; leases exist only via `acquireSession()`, `createSession()`, or `attachSession()`.
+- Do not add Node/builtin imports elsewhere in `src/`; keep them confined to `src/unix.ts`.
 - Keep `maxFrameLength` bounded and matching the server; transports must preserve send order and bound queued bytes.
 - Disconnection or server removal invalidates every lease for the affected attachment; disposing an invalidated lease is a no-op — preserve that behavior.
 
 ## COMMANDS
 
-From the package root, or with `--workspace=@earendil-works/pi-client` from the repo root:
+From the repository root (build protocol first for the client's declaration alias):
 
 ```bash
-bun run build        # tsc -p tsconfig.build.json
-bun run test             # vitest --run
-bun run typecheck    # tsc -p tsconfig.test.json
+bun run --cwd packages/protocol build
+bun run --cwd packages/client build       # tsc -p tsconfig.build.json
+bun run --cwd packages/client test        # vitest --run
+bun run --cwd packages/client typecheck   # tsc -p tsconfig.test.json
 ```
+
+`ci.yml`'s explicit workspace-test list currently omits this package; run its suite directly for client changes.

--- a/packages/coding-agent/AGENTS.md
+++ b/packages/coding-agent/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent
 
-`@code-yeongyu/senpi` is the user-facing CLI and the highest-conflict upstream fork surface. Use the extension API before editing `src/core/`.
+`@code-yeongyu/senpi` is the user-facing CLI and the highest-conflict upstream fork surface (score 12: package boundary, dense runtime and test domains). Use the extension API before editing `src/core/`.
 
 ## STRUCTURE
 
@@ -20,13 +20,13 @@ src/core/model-config.ts           Per-model config resolution
 src/core/models-store.ts           Persisted model store
 src/core/provider-composer.ts      Provider payload composition
 src/core/remote-catalog-provider.ts Remote model-catalog fetch
-src/core/runtime-credentials.ts    Credential resolution and refresh
-src/core/auth-providers.ts         Provider auth registration
+src/core/runtime-credentials.ts, auth-providers.ts  Credential resolution + provider auth registration
+src/core/credential-pool/          Shared slot health, leases, rotation and failover
 src/core/provider-timeout-retry.ts Provider timeout/retry policy
 src/core/retry-fallback/           Model fallback chains + billing classification
 src/core/project-trust.ts, trust-manager.ts  Project trust decisions
 src/core/resource-loader.ts        Bundled extension/resource resolution
-src/core/session-resident-store.ts Session-resident state store
+src/core/session-resident-store.ts, session-work-barrier.ts  Resident state + pending-work coordination
 src/core/session-discovery.ts, session-record.ts, session-summary*.ts  Session listing, record shape, summary cache/LRU
 src/core/extensions/               Public extension API and loader
 src/core/extensions/builtin/       In-tree fork extensions; bundled extensions (e.g. codemode) resolved via resource-loader.ts
@@ -38,7 +38,7 @@ src/modes/app-server/              App-server transport and RPC registry; runtim
 src/modes/rpc/                     JSONL RPC mode/client/types, shared Unix-socket multi-session host,
                                    ensureHost handshake, lifecycle supervisor/watchdog, and the ordered command
                                    surface (get_commands / commands_changed)
-src/modes/print-mode.ts            One-shot mode
+src/modes/print-mode.ts            One-shot mode; src/client/ owns the ./client RemoteSession facade
 test/suite/harness.ts              Preferred faux-provider harness
 test/                              Test domains, fixtures, QA, integration gates
 examples/                          Extension and SDK examples
@@ -55,7 +55,7 @@ src/changes.md                     Root fork-change record
 | Change model/provider/catalog/auth runtime | `src/core/model-runtime.ts` + related `model-*/provider-*` modules |
 | Change keybinding | `src/core/keybindings.ts` |
 | Change interactive UI | `src/modes/interactive/` |
-| Change RPC/app-server | matching directory under `src/modes/` |
+| Change RPC/app-server or remote facade | matching directory under `src/modes/`; `src/client/` for `RemoteSession` over `pi-client` (not JSONL RPC) |
 | Add regression | `test/suite/regressions/` |
 | Add or update an example | `examples/` and the matching public docs |
 
@@ -89,4 +89,4 @@ src/changes.md                     Root fork-change record
 - Keep `src/changes.md`, nested `changes.md`, public docs, and examples aligned with fork behavior.
 
 ---
-Generated: 2026-08-22 | Commit: `a5eed4453`
+Refreshed: 2026-09-10 | Commit: `2d0fa41c5`

--- a/packages/coding-agent/docs/AGENTS.md
+++ b/packages/coding-agent/docs/AGENTS.md
@@ -1,14 +1,14 @@
 # packages/coding-agent/docs/
 
 Public documentation for `@code-yeongyu/senpi`. Shipped inside the npm package: `package.json`
-`files` array includes `"docs"`, so every file here lands in the published tarball.
+`files` array includes `"docs"`, so every file here lands in the published tarball. Existing guide retained for the navigation/spec domain (score 4: file count + manifest).
 
 ## Navigation manifest
 
 `docs.json` has two top-level keys: `navigation` (ordered section and page list) and `redirects`.
 Sections are `{ "title", "items": [{ "title", "path" }] }`; page paths are relative to this directory.
 
-- Every new `.md` file needs an entry in `docs.json` under `navigation`.
+- Every new public guide page needs an entry in `docs.json` under `navigation`; this contributor guide is not a navigation page.
 - Renamed or moved pages need a `redirects` entry to avoid broken links.
 - Navigation-only stubs without real content belong in `redirects`, not `navigation`.
 
@@ -61,7 +61,7 @@ Consistent names: CLI binary is `senpi`, config directory is `.senpi`, npm packa
 
 ## Anti-patterns
 
-- No new `.md` file without a `docs.json` entry.
+- No new public guide page without a `docs.json` entry.
 - Don't edit protocol page prose without checking whether `task20-doc-example-check.ts` would break.
 - Don't copy claims from upstream Pi docs without verifying they apply to the senpi fork.
 - Don't embed bearer tokens, session IDs, or raw API keys in example output.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/examples
 
-Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
+Runnable examples for the public Senpi SDK and extension API (score 9: code-heavy catalog with dense symbols/exports). Examples are documentation-quality code and must reflect shipped APIs, not private core internals. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
 
 ## STRUCTURE
 
@@ -35,7 +35,7 @@ Largest examples carry real complexity, not toy scope: `extensions/overlay-qa-te
 - Deferred-tool examples preserve the Kimi flow: expose search first, activate via `pi.setActiveTools()`, and register lifecycle work in `session_start`.
 - Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
 - Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.
-- Kebab-case filenames and slash-command names; camelCase named exports; one example per file default-exporting its extension factory.
+- Extension examples default-export their factory; numbered SDK programs and `rpc-extension-ui.ts` are standalone programs, not `senpi -e` entry points. Keep kebab-case filenames and slash-command names.
 - UI examples guard on `ctx.hasUI` and clean up timers/child processes on `session_shutdown`; stateful atomic tools (games, questionnaires) set `executionMode: "sequential"`.
 - Tool schemas use TypeBox; handlers follow the `(toolCallId, params, signal, onUpdate, ctx)` shape.
 

--- a/packages/coding-agent/examples/extensions/AGENTS.md
+++ b/packages/coding-agent/examples/extensions/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/examples/extensions
 
-Flat catalog of executable extension examples plus multi-file extension packages. Own file because it is the densest `pi.*` registration surface in the repo (score 14: 110+ files, 10 subdirs, heavy symbol/export density). Load any single file with `senpi -e <path>.ts`; per-example docs live in `README.md`.
+Flat catalog of executable extension examples plus multi-file extension packages. Own file for the dense `pi.*` registration surface (score 11: 70 direct TypeScript examples, 10 subdirs, heavy symbol/export density). Load an extension file with `senpi -e <path>.ts`; per-example docs live in `README.md`.
 
 ## STRUCTURE
 
@@ -41,8 +41,8 @@ doom-overlay/               WASM Doom rendered as live overlay; doom/build/ is g
 ## ANTI-PATTERNS
 
 - Custom tools MUST truncate output (`truncated-tool.ts` demonstrates ripgrep wrapping with 50KB/2000-line caps).
-- Games never expose the user's cursor and never split a tool-call sequence across responses.
-- Never leave timers or child processes alive past `session_shutdown`.
+- Game examples never expose the user's cursor and never split a tool-call sequence across responses.
+- Stateful examples must not leave timers or child processes alive past `session_shutdown`; stateless providers need no artificial lifecycle scaffolding.
 - Shell/process-delegating examples (`ssh.ts`, `interactive-shell.ts`, `inline-bash.ts`, `auto-commit-on-exit.ts`, `git-merge-and-resolve.ts`) cross trust boundaries; adopt deliberately, never as boilerplate.
 
 ---

--- a/packages/coding-agent/scripts/AGENTS.md
+++ b/packages/coding-agent/scripts/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/scripts
 
-Developer tooling for the coding-agent package: vendoring upstream extension packages, app-server protocol codegen, reload benchmarking, legacy session migration. The app-server QA harness lives in `qa-app-server/` (own AGENTS.md). Own file because this is a distinct tooling domain (score 13) with a shared vendoring seam into `src/core/extensions/builtin/`.
+Developer tooling for the coding-agent package: vendoring upstream extension packages, app-server protocol codegen, reload benchmarking, legacy session migration. App-server QA lives in `qa-app-server/` (own AGENTS.md); shared JSONL RPC socket/host probes live separately in `qa-rpc-socket/`. Own file because this is a distinct tooling domain (score 9: file count, code ratio, symbol/export density) with a shared vendoring seam into `src/core/extensions/builtin/`.
 
 ## STRUCTURE
 
@@ -11,6 +11,7 @@ generate-app-server-protocol.sh  Regenerate src/modes/app-server/protocol/genera
 bench-reload.mjs                 DefaultResourceLoader.reload() benchmark vs synthetic extensions
 migrate-sessions.sh              Legacy one-off: ~/.pi/agent/*.jsonl -> session dirs (v0.30.0 bug)
 qa-app-server/                   App-server QA harness; see its AGENTS.md
+qa-rpc-socket/                   Socket routing, ensure-host, host lifecycle, interactive/compiled host probes
 ```
 
 ## WHERE TO LOOK
@@ -20,7 +21,8 @@ qa-app-server/                   App-server QA harness; see its AGENTS.md
 | Update a vendored builtin | `sync-builtin-extensions.mjs` + `vendor-transform.mjs` |
 | Update app-server protocol types | `generate-app-server-protocol.sh` |
 | Diagnose reload slowness | `bench-reload.mjs` (`--ext-count/--runs/--procs/--out`) |
-| Run transport QA | `qa-app-server/run-all.mjs` |
+| Run app-server transport QA | `qa-app-server/run-all.mjs` |
+| Exercise shared JSONL RPC hosts | `qa-rpc-socket/{run,ensure-host,host-lifecycle,interactive-host,compiled-host}.mjs`; compiled probe needs `--binary <path>` |
 
 ## CONVENTIONS
 
@@ -33,7 +35,7 @@ qa-app-server/                   App-server QA harness; see its AGENTS.md
 ## ANTI-PATTERNS
 
 - Re-copying a `MANUAL_PACKAGES` builtin — it clobbers hand-maintained divergence.
-- Hand-editing `protocol/generated/` or vendored builtin trees instead of going through the sync script + transform.
+- Hand-editing `protocol/generated/` or mechanically copied `DIR_SYNCS` trees instead of using codegen or the sync transform; `MANUAL_PACKAGES` behavior is intentionally ported by hand.
 - Running `bench-reload.mjs` against the real agent directory.
 
 ---

--- a/packages/coding-agent/scripts/qa-app-server/AGENTS.md
+++ b/packages/coding-agent/scripts/qa-app-server/AGENTS.md
@@ -1,6 +1,6 @@
 # scripts/qa-app-server
 
-Real-surface QA harness for app-server. `bun run qa:app-server` runs `run-all.mjs`, which executes handshake, multiclient, approval-roundtrip, real-client, and real-client-sweep probes against the locally built CLI. `differential/` is the source-oracle parity harness referenced by `src/modes/app-server/AGENTS.md`. 27 standalone `.mjs` files, ~3.5k LOC. Score 15 — own driver/oracle/compare stack, no other directory owns this surface.
+Real-surface QA harness for app-server. `bun run qa:app-server` runs `run-all.mjs`, which executes handshake, multiclient, approval-roundtrip, real-client, and real-client-sweep probes against `src/cli.ts` through repo-local tsx. `differential/` is the source-oracle parity harness referenced by `src/modes/app-server/AGENTS.md`. Score 9 — own driver/oracle/compare stack, no other directory owns this surface.
 
 ## STRUCTURE
 
@@ -10,7 +10,7 @@ handshake.mjs, multiclient.mjs, approval-roundtrip.mjs,
 real-client.mjs, real-client-sweep.mjs   packaged probes
 lib/                      shared spawn/env/rpc/cleanup helpers
                           (run-node.mjs, env.mjs, fake-model.mjs, rpc.mjs,
-                          cleanup.mjs + two vitest-runnable *.test.mjs)
+                          cleanup.mjs + two Vitest *.test.mjs and their *-fixture.mjs children)
 differential/             source-vs-oracle parity harness: driver.mjs (RawWebSocketDriver),
                           run.mjs, build-oracle.mjs, compare.mjs, normalize.mjs, diff.mjs,
                           cell.mjs, readiness.mjs, transcript-validation.mjs, allowlist.json
@@ -18,7 +18,7 @@ differential/             source-vs-oracle parity harness: driver.mjs (RawWebSoc
 
 ## CONVENTIONS
 
-- All probes spawn the repo-local CLI with explicit env overrides from `lib/env.mjs`: temp `SENPI_CODING_AGENT_DIR`, `PI_OFFLINE=1`, ports drawn from the fixed `qaPortRange` (18990-18999). Never hardcode other ports.
+- `lib/env.mjs` selects source from `SENPI_QA_REPO_ROOT` or this repo, clears known provider keys, sets temp agent/session dirs and `PI_OFFLINE=1`, and uses `qaPortRange` (18990-18999). Never hardcode other ports.
 - Temp state via `mkdtempSync`; `lib/cleanup.mjs` tracks and reaps spawned process groups (`cleanupAllAndWait`) — probe exit must not leak children.
 - Differential scenarios run through `differential/driver.mjs` / `run.mjs`, never as individual node invocations; scenario bodies live in `test/qa/app-server/differential/`.
 - `build-oracle.mjs` cargo-builds `codex-app-server` from a local codex-rs checkout (`ORACLE_MANIFEST` pins the path); without that checkout only the senpi side runs.

--- a/packages/coding-agent/src/AGENTS.md
+++ b/packages/coding-agent/src/AGENTS.md
@@ -1,0 +1,48 @@
+# packages/coding-agent/src
+
+## OVERVIEW
+
+Runtime bootstrap and public entry points (score 13: large code tree, public barrel, dense exports); this guide owns startup boundaries, not the core or mode implementations.
+
+## STRUCTURE
+
+```text
+cli.ts -> cli-main.ts -> main.ts   Runtime selection, lightweight dispatch, full CLI
+index.ts                         Public SDK exports; not the executable entry
+rpc-entry.ts                     Dedicated RPC executable entry
+cli/                             Argument/auth/startup adapters
+client/                          RemoteSession facade exported as package ./client
+bun/                             Compiled-Bun entry and provider registration adapters
+beta/                            Removable OMO local-update feature
+core/                            Session/services/providers/resources
+modes/                           Interactive, print, RPC and app-server hosts
+utils/                           Platform and terminal support
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Boundary |
+|---|---|---|
+| Bun-installed CLI starts under Node | `cli.ts`, `bun-runtime.ts`, `bun-global-launcher.ts` | Resolve the symlink target before re-exec |
+| Startup latency / debugger inheritance | `compile-cache.ts`, `inspector-policy.ts` | Cache setup follows Bun selection and precedes full CLI loading |
+| Broken installed dependency repair | `self-update-bootstrap.ts` | Runs before loading the full engine |
+| Install/update/config commands | `package-manager-cli.ts` | Separate package-management dispatch |
+| Config, brand, install and asset paths | `config.ts` | Source, installed package and compiled binary have different roots |
+| Agent-directory migrations | `brand-dir-migration.ts`, `legacy-senpi-dir-migration.ts`, `extension-system-migration.ts`, `migrations.ts` | Preserve migration-specific entry paths |
+| Invalid launch directory | `valid-cwd.ts` | Imported before the rest of CLI bootstrap |
+| Local OMO beta update | `beta/omo-local-update.ts` | Production API is `runOmoLocalUpdateBeta`; other helpers are test seams |
+
+## CONVENTIONS
+
+- `cli.ts` answers root `--version` without loading the engine; keep the deferred `cli-main.ts` import boundary.
+- The CLI stays in-process unless custom Node `execArgv` or inherited Inspector options require a child. Forward the child's exit code or signal.
+- Bun re-exec deliberately drops Node `execArgv`; `SENPI_RUNTIME` controls the explicit runtime choice.
+- Compile-cache setup also publishes its directory for a spawned `cli-main` child; preserve both startup paths.
+- `config.ts` distinguishes source, package-manager and Bun-binary installs. Asset lookup must not manufacture `dist/dist/` paths.
+
+## ANTI-PATTERNS
+
+- Static-importing the full CLI engine above the version/bootstrap-repair fast paths.
+- Treating `bin/senpi` as launcher implementation; it is only a link to built output.
+- Importing beta test helpers as production APIs or folding removable beta behavior into the ordinary bootstrap.
+- Conflating `src/client/` with JSONL RPC: it wraps the separate `pi-client` / `pi-protocol` session stack.

--- a/packages/coding-agent/src/cli/AGENTS.md
+++ b/packages/coding-agent/src/cli/AGENTS.md
@@ -1,0 +1,41 @@
+# packages/coding-agent/src/cli
+
+## OVERVIEW
+
+CLI parsing, auth commands, startup UI and experimental command composition (score 9: 23 TypeScript files with dense symbols/exports); session construction remains in `../main.ts`.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|---|---|---|
+| Flags, positional text, `@file`, help | `args.ts` | `parseArgs`, `Args`, thinking-level validation |
+| Auth subcommand grammar | `auth-command.ts` | `check`, `print-api-key`, `print-bearer-token` |
+| Auth checks / credential output | `auth-check.ts`, `credential-print.ts` | Keep checking separate from explicit credential emission |
+| App-server command parsing | `app-server-command.ts` | Separate subcommand, not an `Args.mode` value |
+| Initial attachments / user input | `file-processor.ts`, `initial-message.ts` | File conversion before session dispatch |
+| Startup feedback and selection | `startup-ui.ts`, `startup-loading-indicator.ts`, `session-picker.ts`, `config-selector.ts` | TUI startup adapters |
+| Trust / experimental UI gate | `project-trust.ts`, `grok-neo-gate.ts` | Resolve the gate before enabling its flags |
+| Experimental fluent command parser | `experimental/command.ts`, `command-options.ts` | Typed parse and execution results |
+| Experimental command tree | `experimental/cli.ts`, `experimental/commands/` | Composes pi, server and client commands |
+| Transport address / auth options | `experimental/transport-address.ts`, `experimental/auth.ts` | Shared experimental option handling |
+
+## CONVENTIONS
+
+- `Args.mode` is `text | json | rpc`; interactive selection and app-server routing happen elsewhere.
+- The main parser preserves unknown flags in `unknownFlags` for extension registration. Auth validation instead rejects unknown flags.
+- `--` ends option parsing but still recognizes subsequent `@file` arguments as attachments.
+- `--append-system-prompt` accumulates values rather than replacing the previous one.
+- Auth `--json`, `--credentials`, and `--no-refresh` belong only to `auth check`; `--min-expiry` belongs only to bearer-token printing.
+- Both checks and credential-printing require a provider or model selector; auth commands reject positional messages, files and `--api-key` overrides.
+
+## ANTI-PATTERNS
+
+- Collapsing the ordinary CLI parser and experimental fluent command tree into one presumed grammar.
+- Rejecting extension flags in `parseArgs` before resource loading can register them.
+- Printing credentials as incidental startup diagnostics; credential output is an explicit auth-command surface.
+- Moving session policy into these presentation/parsing adapters.
+
+## VALIDATION
+
+From the repository root: `bun run --cwd packages/coding-agent test -- test/args.test.ts test/experimental-cli-command.test.ts test/experimental-cli-resolution.test.ts`.
+These are existing parser targets, not substitutes for the affected auth/startup or real-CLI checks when behavior changes.

--- a/packages/coding-agent/src/client/AGENTS.md
+++ b/packages/coding-agent/src/client/AGENTS.md
@@ -1,0 +1,34 @@
+# packages/coding-agent/src/client
+
+## OVERVIEW
+
+Public `./client` package surface: `RemoteSession` wraps `@earendil-works/pi-client` leases and protocol snapshots (score 8: package boundary, barrel and lifecycle symbols).
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|---|---|---|
+| Public exports | `index.ts` | Re-exports remote-session and transcript types/functions |
+| Attach/create/reconnect/dispose | `remote-session.ts` | Exclusive `SessionLease`, operation lifecycle and cleanup |
+| Snapshot/progress merge | `transcript.ts` | Immutable state, revision guard and streamed tool-input buffers |
+| Protocol client transport | `@earendil-works/pi-client` | This package consumes it; transport implementation is outside this subtree |
+
+## CONVENTIONS
+
+- `RemoteSession` is stateful but exposes immutable snapshots: lifecycle is `unbound | ready | busy | disposed`.
+- `open` and `create` replace an idle attachment only after the new lease supplies a snapshot; failed replacement detaches the candidate and preserves useful errors.
+- `submit` prompts while idle and steers during a turn. `abort` may preempt a submit, while model and thinking changes require idle phase.
+- Disposal races are explicit: pending attachment operations are tracked, the dispose signal rejects in-flight work, and cleanup errors are aggregated.
+- Transcript progress is merged by item ID; stale snapshots are ignored, partial tool JSON remains a string until valid, and finished tool buffers are removed.
+- Listener failures go only to `onListenerError`; they must not change transport or session state.
+
+## ANTI-PATTERNS
+
+- Mutating protocol snapshots or transcript items in place; use the immutable state helpers.
+- Detaching the old lease before the replacement has a valid snapshot, or leaving a candidate lease undisposed after a failed replacement.
+- Allowing concurrent operations by bypassing the busy lifecycle guard.
+- Treating `RemoteSession` as the RPC wire protocol itself; server events and leases remain owned by `pi-client`.
+
+## VALIDATION
+
+Focused tests: `test/client/remote-session.test.ts`, `test/client/remote-session-lifecycle.test.ts`, `test/client/remote-session-ownership.test.ts`, and `test/client/transcript.test.ts`.

--- a/packages/coding-agent/src/core/AGENTS.md
+++ b/packages/coding-agent/src/core/AGENTS.md
@@ -1,19 +1,23 @@
 # packages/coding-agent/src/core
 
-Session runtime, model/provider stack, session persistence, settings, resources. 72 flat `.ts` files (~28.8k LOC) plus six subtrees with their own AGENTS.md (`tools/`, `extensions/`, `dynamic-prompt/`, `compaction/`, `export-html/`, `retry-fallback/`). Reach for the extension API before adding anything here.
+Session runtime, model/provider stack, session persistence, settings, resources. 85 flat `.ts` files (~31.6k LOC) plus seven subtrees, including the shared `credential-pool/`. Score 11: large code-heavy domain with dense symbols/exports and seven module subtrees. Reach for the extension API before adding anything here.
 
 ## HOTSPOTS (flat files >500 LOC)
 
 | File | LOC | Owns |
 |---|---|---|
-| `agent-session.ts` | 8007 | `AgentSession`: prompt/steer/follow-up, tool registry, compaction admission/recovery, retry/fallback, abort provenance, navigation, extension binding |
-| `package-manager.ts` | 2760 | `DefaultPackageManager`: install/update/remove, source parsing, git/npm, resource precedence |
-| `settings-manager.ts` | 2022 | Layered global/project settings, JSONC, locking, queued writes, migrations |
-| `session-manager.ts` | 1818 | Append-only JSONL entry stream, version-3 migrations, branching, labels, bounded header scans |
-| `resource-loader.ts` | 1609 | `DefaultResourceLoader`: extension/hook/prompt/skill/theme discovery, precedence, generated shims |
-| `model-resolver.ts` | 1054 | Scope parsing, minimatch narrowing, Cursor legacy aliases, ambiguity diagnostics, CLI/initial/session selection |
-| `model-runtime.ts` | 931 | `ModelRuntime`: provider catalog composition, auth, refresh, availability snapshots, streaming |
-| `auth-storage.ts` | 724 | `AuthStorage` + file/read-only/in-memory backends; lock-backed JSON, 0600 credentials |
+| `agent-session.ts` | 9031 | `AgentSession`: prompt/steer/follow-up, tool registry, compaction admission/recovery, retry/fallback, abort provenance, navigation, extension binding |
+| `package-manager.ts` | 2777 | `DefaultPackageManager`: install/update/remove, source parsing, git/npm, resource precedence |
+| `settings-manager.ts` | 2086 | Layered global/project settings, JSONC, locking, queued writes, migrations |
+| `session-manager.ts` | 2035 | Append-only JSONL entry stream, version-3 migrations, branching, labels, bounded header scans |
+| `resource-loader.ts` | 1576 | `DefaultResourceLoader`: extension/hook/prompt/skill/theme discovery, precedence, generated shims |
+| `model-resolver.ts` | 1056 | Scope parsing, minimatch narrowing, Cursor legacy aliases, ambiguity diagnostics, CLI/initial/session selection |
+| `model-runtime.ts` | 1094 | `ModelRuntime`: provider catalog composition, auth, refresh, availability snapshots, streaming |
+| `auth-storage.ts` | 766 | `AuthStorage` + file/read-only/in-memory backends; lock-backed JSON, 0600 credentials |
+| `provider-composer.ts` | 606 | Provider auth composition and availability |
+| `model-config.ts` | 578 | Model validation and config resolution |
+| `sdk.ts` | 570 | Session factories and runtime wiring |
+| `skills.ts` | 529 | Skill discovery and invocation formatting |
 
 `ModelRegistry` (`model-registry.ts`) is a synchronous compatibility facade over `ModelRuntime` — not a second implementation.
 
@@ -26,7 +30,9 @@ Session runtime, model/provider stack, session persistence, settings, resources.
 | Wire services into a session | `agent-session-services.ts` |
 | Model selection / scope resolution | `model-resolver.ts` |
 | Provider auth composition | `provider-composer.ts`, `provider-api-key-auth.ts`, `provider-header-auth.ts` |
-| Credential storage | `auth-storage.ts` |
+| Credential storage / account listing | `auth-storage.ts`, `credential-accounts.ts` |
+| Shared credential rotation / health | `credential-pool/{rotation-stream,state-store,classify,failover,env-slots}.ts` |
+| Pending-work coordination / write ownership | `session-work-barrier.ts`, `session-write-reservation.ts` |
 | Session persistence / branching | `session-manager.ts` |
 | Settings read/write | `settings-manager.ts` |
 | Bash execution (local or injected remote ops) | `bash-executor.ts` |
@@ -47,13 +53,13 @@ Session runtime, model/provider stack, session persistence, settings, resources.
 ## ANTI-PATTERNS
 
 - Implementing an extension-capable feature here instead of `extensions/builtin/`.
-- Mutating credentials through `ReadOnlyAuthStorage` (mutators throw by design) or bypassing lock/revision handling in the file backend.
+- Mutating credentials through `ReadOnlyAuthStorage` (mutators throw by design) or bypassing lock/revision handling in the file backend. `credential-pool/state-store.ts` is a health-only sidecar: never persist credential material there; env slots use installation-local HMAC revisions.
 - Assuming a session operation owns terminal state during compaction/retry/abort — ownership, deferred queues, epochs, and provenance exist to prevent duplicate transitions.
 - Relying on `provider-composer.ts`'s `@deprecated` field for authentication; it is retained only for extension-source compatibility.
 - Dropping legacy Cursor model aliases or model compatibility flags when touching resolution paths.
 
 ## NOTES
 
-- `core/changes.md` (3.5k lines) is the fork ledger for this directory — read the relevant dated section before touching a hotspot.
+- `core/changes.md` is the fork ledger for this directory — read the relevant dated section before touching a hotspot.
 - `output-guard.ts` holds process-global mutable stdio state with retry/backpressure timing; treat it as a process-wide singleton, not a helper.
 - `session-summary-lru.ts` / `session-summary-cache.ts` enforce byte budgets; summary regeneration is not free.

--- a/packages/coding-agent/src/core/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/compaction/AGENTS.md
@@ -1,14 +1,17 @@
 # packages/coding-agent/src/core/compaction
 
-Core compaction **mechanics** — token estimation, cut-point selection, summary generation, branch summarization, stream watchdogs. Distinct from `extensions/builtin/compaction/`, which owns compaction **policy** (speculative, circuit breaker, restoration, remote route). Core is what the extension calls; the extension is what decides when.
+Core compaction **mechanics** — token estimation, cut-point selection, summary generation, branch summarization, stream watchdogs. Distinct from `extensions/builtin/compaction/`, which owns compaction **policy** (speculative, circuit breaker, restoration, remote route). Core is what the extension calls; the extension is what decides when. Score 8: distinct mechanics boundary with dense symbols/exports.
 
 ## FILES
 
 ```
 compaction/
 ├── index.ts                  # Selective barrel: branch-summarization, compaction, utils ONLY
-├── compaction.ts             # 1367 LOC — token estimation, threshold decisions, cut-point selection,
-│                             # generateSummary, prepareCompaction, compact orchestration
+├── compaction.ts             # Token estimation, cut-point selection, summary generation/preparation
+├── compaction-execution.ts   # AgentSession compaction execution adapter
+├── compaction-settings.ts    # Base CompactionSettings + DEFAULT_COMPACTION_SETTINGS
+├── ideal-compaction-settings.ts # Adaptive threshold/reserve defaults
+├── stuck-overflow.ts         # Distinguish truly stuck overflow from completed answers
 ├── branch-summarization.ts   # Branch collection/preparation/generation for forked sessions
 ├── utils.ts                  # Conversation serialization + file-operation tracking
 ├── lifecycle.ts              # Compaction lifecycle state/coordinator (imported directly, not via barrel)
@@ -21,8 +24,8 @@ compaction/
 | Task | File |
 |---|---|
 | Change token estimation or cut-point math | `compaction.ts` |
-| Change the summarization system prompt | `compaction.ts` (`SUMMARIZATION_SYSTEM_PROMPT`) |
-| Change default thresholds | `compaction.ts` (`DEFAULT_COMPACTION_SETTINGS`) |
+| Change the summarization system prompt | `utils.ts` (`SUMMARIZATION_SYSTEM_PROMPT`) |
+| Change default thresholds | `compaction-settings.ts`, `ideal-compaction-settings.ts` (re-exported through `compaction.ts`) |
 | Fork/branch summary behavior | `branch-summarization.ts` |
 | Detect a stalled summary stream | `stream-watchdog.ts` |
 | Serialize conversation for a summary request | `utils.ts` |
@@ -39,10 +42,10 @@ compaction/
 ## ANTI-PATTERNS
 
 - Adding policy (when to compact, retry, circuit-break) here instead of in the builtin extension — this directory answers "how", not "whether".
-- Pinning summarization prose in tests. The prompt contains deliberate "Do NOT" directives that are machine-consumed prompt contracts; assert parsed structure, not sentences.
+- Pinning summarization prose in tests. Assert parsed structure or machine-consumed sentinels, not ordinary prompt sentences.
 - Regenerating summaries without checking `warm-anchor.ts` staleness — a stale warm result applied after context moved silently drops turns.
 
 ## NOTES
 
-- `compaction.ts` is the highest-behavioral-risk file in `core/`; changes here reach every provider path.
+- `compaction.ts` remains the token/cut-point hotspot; execution is split into `compaction-execution.ts`. Changes to shared mechanics reach every provider path.
 - Overflow detection lives outside this directory: `core/agent-session.ts` calls `isContextOverflow` from `packages/ai/src/utils/overflow.ts`, then drives blocking compaction through the extension.

--- a/packages/coding-agent/src/core/dynamic-prompt/AGENTS.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/dynamic-prompt
 
-Fork-introduced system-prompt assembler. Replaces upstream's static `buildSystemPrompt()` with a layered builder: identity → intent gate → working-task → verification → tool reference → policies → style → optional per-model tuning. Every preset under `extensions/builtin/prompt-preset/` ultimately calls into this builder. See `changes.md` for the full evolution.
+Fork-introduced system-prompt assembler. Replaces upstream's static `buildSystemPrompt()` with a layered builder: identity → intent gate → working-task → verification → tool reference → policies → style → optional per-model tuning. Every preset under `extensions/builtin/prompt-preset/` ultimately calls into this builder. Existing prompt-domain guide retained (score 6: code ratio, barrel, exports); see `changes.md` for the full evolution.
 
 ## FILES
 
@@ -17,6 +17,7 @@ dynamic-prompt/
 ├── tool-section.ts         # CATEGORY_ORDER + CATEGORY_LABELS for rendering
 ├── policies.ts             # Hard blocks injected into every prompt
 ├── style.ts                # buildStyleSection() — output formatting + length norms
+├── workstation.ts          # Cached host facts + default/claude/codex/kimi execution-context dialects
 └── changes.md              # Dense fork tracker (dated sections)
 ```
 
@@ -29,6 +30,7 @@ dynamic-prompt/
 | Change parallel-tool/exploration guidance | `working-task.ts` |
 | Add new "Don't do X" rule | `policies.ts` |
 | Tune verification tier definitions | `verification.ts` |
+| Host execution facts / dialect | `workstation.ts`; caller passes `workstationDialect` |
 | Add/remove a tool category | `types.ts` (`AvailableTool["category"]`) + `tool-categorization.ts` + `tool-section.ts` |
 | Per-model addendum to the prompt | callers pass `tuningSection` (see `extensions/builtin/prompt-preset/`) |
 | Full per-model core rewrite | callers pass `corePrompt` (see `prompt-preset/gpt-5.5.ts`) — replaces identity→style, keeps tool section/context/skills/date/cwd assembly |
@@ -42,16 +44,17 @@ dynamic-prompt/
 5. **Tool reference** — categorized snippets + guidelines from registered tools
 6. **Policies** — hard blocks
 7. **Style** — execution stance + output formatting
-8. **Optional `tuningSection`** — per-model preset addendum (appended last)
+8. **Optional `tuningSection`** — per-model preset addendum after the core sections
+9. **Context files, skills, workstation, date/cwd** — shared trailing assembly
 
-When `corePrompt` is set, sections 1–7 are replaced by the override's output (the rendered tool section is handed to it via `DynamicPromptCoreContext`); tuning, context files, skills, and date/cwd assembly are unchanged.
+When `corePrompt` is set, sections 1–7 are replaced by the override's output (the rendered tool section is handed to it via `DynamicPromptCoreContext`); tuning and the shared trailing assembly are unchanged.
 
 ## CONVENTIONS
 
 - **Forced verbalization** (2026-04-30): every prompt mandates a `I read this as [intent] - [plan].` line. Do NOT silently revert to "internal-only" routing — the 2026-04-30 entry reversed that experiment.
 - **Anti-leakage guard preserved**: the prompt forbids narrating "Step 0", "Thinking level", or XML tool-call examples in user-visible output. Keep this even if routing is verbalized.
 - **No coding-specific language in the default** (2026-04-11): identity is domain-agnostic. Coding-specific tuning belongs in a preset, not here.
-- **Section builders are pure functions** taking only the data they need from `BuildDynamicSystemPromptOptions` — easy to test in isolation and reuse from presets.
+- **Core text-section builders take only their inputs**. The full assembler reads the current date; `workstation.ts` caches process host facts and supports a `facts` override. Do not claim the complete prompt is input-only or time-independent.
 - **Tool categories are fork-narrowed to 4** (search/session/command/other). LSP and AST categories were removed (2026-04-11).
 
 ## ANTI-PATTERNS

--- a/packages/coding-agent/src/core/export-html/AGENTS.md
+++ b/packages/coding-agent/src/core/export-html/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/export-html
 
-Self-contained HTML session export (`/export`): renders a session JSONL file plus its system prompt and tool metadata into one styled HTML document. Isolated from the agent loop — `agent-session.ts` calls in through `exportSessionToHtml` only.
+Self-contained HTML session export (`/export`): renders a session JSONL file plus its system prompt and tool metadata into one styled HTML document. Isolated from the agent loop — `agent-session.ts` calls in through `exportSessionToHtml` only. Existing offline-viewer guide retained (score 4: barrel and viewer symbol density).
 
 ## FILES
 
@@ -19,7 +19,7 @@ Self-contained HTML session export (`/export`): renders a session JSONL file plu
 | Change export output/wiring | `index.ts` |
 | Change terminal-output rendering fidelity | `ansi-to-html.ts` |
 | Change how extension tools appear | `tool-renderer.ts` + the `ToolHtmlRenderer` implementation in `agent-session.ts` |
-| Change viewer styling/behavior | `template.*` (assets, not TS) |
+| Change viewer styling/behavior | `template.*` (maintained source assets, not vendored or generated) |
 
 ## CONVENTIONS
 

--- a/packages/coding-agent/src/core/extensions/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions
 
-The extension system. **The fork's most important architectural surface** — every fork feature that *can* be an extension *is* one. `types.ts` is ~2367 lines of public API contract. Treat changes here as breaking until proven otherwise.
+The extension system. **The fork's most important architectural surface** — every fork feature that *can* be an extension *is* one. `types.ts` is ~2431 lines of public API contract. Score 13: public barrel, dense symbols/exports and a large extension subtree. Treat changes here as breaking until proven otherwise.
 
 ## FILES
 
@@ -8,15 +8,15 @@ The extension system. **The fork's most important architectural surface** — ev
 extensions/
 ├── types.ts             # Public API: ExtensionAPI, Extension, ExtensionContext, ExtensionUIContext,
 │                        # ExtensionEvent union (30+ events), all *EventResult types, ToolDefinition.
-│                        # ~2367 LOC — VERY HIGH merge-conflict risk on every upstream sync.
+│                        # ~2431 LOC — VERY HIGH merge-conflict risk on every upstream sync.
 ├── loader.ts            # Discovery + jiti-based TS import. Shared importer per `loadExtensions()` batch
 │                        # (perf fix 2026-05-08). Aliases `@mariozechner/pi-*` → workspace packages.
 ├── runner.ts            # ExtensionRunner — owns the runtime, dispatches events, holds shutdown handlers,
 │                        # exposes `bindCore()` to wire `pi.*` stubs to real implementations.
-├── wrapper.ts           # 30-line wrapper utility used to track extension origin per UI message
+├── wrapper.ts           # Wrapper utility used to track extension origin per UI message
 ├── index.ts             # Re-exports from runner/loader/types
 ├── notice/              # Shared extension notice surface (spec.ts, box.ts, adapters.ts) reused by builtin renderers
-├── builtin/             # 39 builtin extensions + 4 global defaults + bundled codemode (`core/resource-loader.ts`) — see builtin/AGENTS.md
+├── builtin/             # 41 builtin extensions + 4 global defaults + bundled codemode (`core/resource-loader.ts`) — see builtin/AGENTS.md
 └── changes.md           # Fork tracker — DENSE. Every public-API change must add a section.
 ```
 
@@ -50,22 +50,22 @@ extensions/
 
 - **Every public API change** in `types.ts` MUST add a section to `changes.md` with explicit *expected merge-conflict zones*.
 - **Event handlers can return values** that the runner uses — see `model_select` returning `ModelSelectEventResult` (2026-04-30) and `session_before_compact` returning a snapshot.
-- **Extension factories are pure**: no top-level side effects, no fs reads, no environment captures. All side effects belong inside `pi.on("session_start", …)`.
+- **Registration is factory-local; session work is lifecycle-bound**: avoid module-scope I/O or environment captures. Do not use captured `pi` or command `ctx` after `newSession()`, `fork()`, `switchSession()`, or `reload()` replaces the session binding.
 - **`bindCore()` is privileged**: only the host (senpi `agent-session.ts` or interactive-mode shortcut path) may call it. Extensions consume the bound API only.
 - **Shared jiti importer** per `loadExtensions()` call — preserve `moduleCache: false` so reloads see fresh source, but reuse the importer to avoid multi-second per-extension TS resolution cost.
 
 ## ANTI-PATTERNS
 
-- Adding a new event without adding an `*EventResult` type and `pi.on` overload + a `runner.ts` emit helper — silent breakage downstream.
+- Adding an event without its typed `pi.on` overload and runner dispatch path; result-bearing events also need a result type and merge/return semantics. Not every notification needs a dedicated emit helper.
 - Static-importing extension modules at the top of `loader.ts` — extensions are user-supplied; loading must stay dynamic.
 - Removing the `@mariozechner/pi-*` alias in `loader.ts` — installed pi-mono extensions still resolve those peer names, and without the alias jiti pulls a duplicate runtime from the extension's own `node_modules`.
 - Mutating `ExtensionContext` values returned to handlers — context is meant to be read-only.
 
 ## NOTES
 
-- The ~2367-line `types.ts` is "the API"; treat its diffs like a public package release.
+- The ~2431-line `types.ts` is "the API"; treat its diffs like a public package release.
 - `ToolRenderContext` now includes `imageProtocol` (terminal image protocol, or null when images can't render) and `hasResult` (lets a call renderer yield to the result renderer).
 - `changes.md` already documents major fork-introduced APIs: `ModelSelectEventResult`, `SystemPromptChangeEvent`, `getCompactionSettings`, lazy/shared jiti, default-extension factory resolver. Read it before extending.
 
 ---
-Generated: 2026-08-22 | Commit: `a5eed4453`
+Refreshed: 2026-09-10 | Commit: `2d0fa41c5`

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin
 
-39 in-tree extensions plus 4 global defaults. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
+41 in-tree extensions plus 4 global defaults. Each is the canonical answer to "can senpi do X without core changes?". Score 13: dense registry and distinct extension subdomains. Registration order matters; `index.ts` is the authority, not prose numbering.
 
 ## INVENTORY (registration order from `builtin/index.ts`)
 
@@ -40,11 +40,13 @@
 | 32 | `cache-keepalive` | `cache-keepalive/` | Warms the provider prompt cache between turns (`warmPromptCache`, Anthropic-aware TTL) and renders a `cache-keepalive` notice entry |
 | 33 | `ttsr` | `ttsr/` | Stream-rule detection (collapse + control-token-leak) with abort→remediate→retry; ported from oh-my-pi — see `ttsr/changes.md` |
 | 34 | `btw` | `btw/` | `/btw` side-question command that queries in parallel without touching the main session |
-| 35 | `claude-sdk-oauth` | `claude-sdk-oauth/` | Claude SDK OAuth provider: multi-account OAuth, resume-first session continuity, stream-safe failover — see `claude-sdk-oauth/AGENTS.md` + `changes.md` |
-| 36 | `cursor-cli-oauth` | `cursor-cli-oauth/` | Cursor CLI OAuth provider lane: multi-account OAuth, spawn/stream parsing, failover; registers unconditionally and reports executable/auth state through its oauth check — see `cursor-cli-oauth/AGENTS.md` |
-| 37 | `config-reload` | `config-reload/` | Hash-gated watcher for trusted global/project config surfaces that defers a full session reload until idle and exposes the `config-watch:*` event protocol; registered after settings-dependent builtins so a reload rebuilds their resolved settings, and before final MCP observation |
-| 38 | `tool-search` | `tool-search/` | Shared tool catalog + `tool_search` exposure tool; loads before MCP, which feeds its tools into the same catalog |
-| 39 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — kept last so its provider-payload tap observes all co-resident builtin mutations; see `mcp/changes.md` |
+| 35 | `account` | `account/` | Provider-neutral account listing through `core/credential-accounts.ts`; registered before provider-specific account commands |
+| 36 | `gpt-account` | `gpt-account.ts` | OpenAI Codex account management via the shared account-change notification seam |
+| 37 | `claude-sdk-oauth` | `claude-sdk-oauth/` | Claude SDK OAuth provider: multi-account OAuth, resume-first session continuity, stream-safe failover — see `claude-sdk-oauth/AGENTS.md` + `changes.md` |
+| 38 | `cursor-cli-oauth` | `cursor-cli-oauth/` | Cursor CLI OAuth provider lane: multi-account OAuth, spawn/stream parsing, failover; registers unconditionally and reports executable/auth state through its oauth check — see `cursor-cli-oauth/AGENTS.md` |
+| 39 | `config-reload` | `config-reload/` | Hash-gated watcher for trusted global/project config surfaces that defers a full session reload until idle and exposes the `config-watch:*` event protocol; registered after settings-dependent builtins so a reload rebuilds their resolved settings, and before final MCP observation |
+| 40 | `tool-search` | `tool-search/` | Shared tool catalog + `tool_search` exposure tool; loads before MCP, which feeds its tools into the same catalog |
+| 41 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — kept last so its provider-payload tap observes all co-resident builtin mutations; see `mcp/changes.md` |
 
 Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`). Shared non-factory modules: `rule-activation/` (appendRuleActivation + renderer, consumed by `rules/` and `ttsr/`) and `monitor-state-event.ts` (consumed by `goal/` and `terminal/`).
 
@@ -68,13 +70,11 @@ Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by
 
 - Reordering `builtinExtensions` for cosmetic reasons — registration order is load-bearing for tools and permission hooks.
 - Expecting context inside the factory body — `ExtensionContext` only arrives as the `ctx` parameter of event handlers. Do side effects inside `pi.on("session_start", …)`.
-- Importing from `core/` directly — extensions must use the public `pi.*` API.
+- Adding ad-hoc core coupling instead of public `pi.*` APIs; existing account, compaction, and provider adapters use deliberate shared core seams, not a general exemption.
 - Splitting an existing single-file extension into a folder "for symmetry" — only split when there's actual code to split.
 
 ## NOTES
 
 - MCP search exposure tool is `tool_search`, owned by the registered `tool-search` builtin (`builtin/tool-search/tool.ts`). Do not reintroduce `mcp_search` references anywhere.
-- Sub-directory detail lives in per-extension `AGENTS.md` files (compaction, mcp, goal, loop, terminal, permission-system, prompt-preset, gpt-apply-patch, claude-sdk-oauth, cursor-cli-oauth).
-
----
-Generated: 2026-08-22 | Commit: `a5eed4453`
+- Sub-directory detail lives in per-extension `AGENTS.md` files (compaction, config-reload, mcp, goal, loop, terminal, permission-system, prompt-preset, gpt-apply-patch, claude-sdk-oauth, cursor-cli-oauth).
+Refreshed: 2026-09-10 | Commit: `2d0fa41c5`

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -1,8 +1,8 @@
 # claude-sdk-oauth
 
-Claude SDK OAuth provider extension. Registers a builtin provider that runs turns through the `@anthropic-ai/claude-agent-sdk` subprocess with native multi-account OAuth, HRW session affinity, stream-safe account failover, and resume-first session continuity. Renamed from `claude-agent-sdk` on 2026-07-31; old persisted identities are intentionally not aliased.
+Claude SDK OAuth provider extension (score 11: 52 TypeScript modules, barrel, dense symbols/exports). Registers a builtin provider that runs turns through the `@anthropic-ai/claude-agent-sdk` subprocess with native multi-account OAuth, HRW session affinity, stream-safe account failover, and resume-first session continuity. Renamed from `claude-agent-sdk` on 2026-07-31; old persisted identities are intentionally not aliased.
 
-Generated: 2026-08-07 | Commit: `4f26b8282`
+Refreshed: 2026-09-10 | Commit: `2d0fa41c5`
 
 ## FILE ROLES (verified subset)
 
@@ -24,7 +24,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 | `system-prompt.ts` | `systemPromptMode` handling (`full` default, `preset-append` deprecated, `override` from file); no array-splitting, the CLI joins arrays |
 | `prompt-directive-dedupe.ts` | `dedupeUltraworkBlocks`: collapses repeated `<ultrawork-mode>` spans in flatten output; never mutates `context.messages` |
 | `custom-tools.ts` | Senpi tools exposed as an SDK MCP server; execution denied SDK-side (`denyCustomToolExecution`), executed by senpi |
-| `sdk-boundary.ts` | Single import boundary over `@anthropic-ai/claude-agent-sdk` (`query`, `createSdkMcpServer`, types) |
+| `sdk-boundary.ts`, `sdk-boundary.lazy.ts` | Injectable SDK boundary and its lazy runtime import over `@anthropic-ai/claude-agent-sdk` |
 | `options.ts` | `buildClaudeSdkOauthQueryOptions`: settings + `SENPI_CLAUDE_SDK_OAUTH_*` env resolution, append assembly |
 | `executable.ts` | Claude Code executable resolution |
 | `changes.md` | Fork-change record; read before touching anything here |
@@ -48,7 +48,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 
 ## TESTS
 
-Flat cluster at `test/claude-sdk-oauth-*.test.ts` (51 files): accounts, affinity, auth-lane, binding, continuity decisions, failover, custom-tools schema, guidance, login, model switch, observability, and more. Keep edited test files below the 250-pure-LOC ceiling (see 2026-07-31 rename entry).
+Existing flat cluster at `test/claude-sdk-oauth-*.test.ts` (57 files; new lifecycle regressions belong in `test/suite/`): accounts, affinity, auth-lane, binding, continuity decisions, failover, custom-tools schema, guidance, login, model switch, observability, and more. Keep edited test files below the 250-pure-LOC ceiling (see 2026-07-31 rename entry).
 
 ## MERGE RISK
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/compaction
 
-Builtin extension #20. Owns senpi's compaction *policy* (mechanics live in `core/compaction/`): speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, absolute session cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
+Builtin compaction extension (score 11: 46 TypeScript modules, entry boundary, dense symbols/exports). Owns senpi's compaction *policy* (mechanics live in `core/compaction/`): speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, absolute session cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
 
 ## FILES
 
@@ -35,7 +35,7 @@ compaction/
 ├── deterministic-fallback.ts # Classification + construction when summarization fails outright
 ├── summarization-retry.ts, transient-failure.ts, retained-message-safety.ts  # Retry/safety predicates
 ├── openai-remote-{convert,model,schema,timeout,responses-v2}.ts  # Remote-route support modules
-├── model-usability-budget.ts # Startup/switch/resume context admission projection
+├── model-usability-budget.ts, resume-admission.ts # Startup/switch/resume context admission projection
 └── changes.md                # Fork tracker (restoration tracker, extension hook wiring)
 ```
 
@@ -63,14 +63,14 @@ compaction/
 ## CONVENTIONS
 
 - **Each sub-policy is a pure module** with explicit state passed through. Don't add singletons.
-- **The 13 per-feature compaction fixtures** under `packages/coding-agent/test/fixtures/compaction/` map 1:1 onto these sub-policies — when you change a policy, update its fixture (and add a new one if you split a behavior).
+- **The per-feature compaction fixtures** under `packages/coding-agent/test/fixtures/compaction/` map 1:1 onto these sub-policies — when you change a policy, update its fixture (and add a new one if you split a behavior).
 - **Restoration tracker is opt-in via `CompactionSettings`** — don't make it unconditional; tests rely on the on/off path.
 - **`session_compact` is the canonical event**; everything else (degradation, restoration) hangs off it.
 
 ## ANTI-PATTERNS
 
 - Wiring compaction logic into `core/agent-session.ts` — that's the seam this extension was built to remove. See upstream `core/compaction/` for the bare policy constants.
-- Changing the `prompts.ts` summarization template without regenerating the relevant goldens.
+- Changing machine-consumed summary structure without updating the relevant fixture/golden; do not add tests pinning ordinary prompt prose.
 - Bypassing `tool-truncation.ts` for "small" tool results — the policy uses a global token budget; even small additions matter.
 - Mutating `restoration-tracker.ts` queue from a non-compaction hook.
 - Treating provider-owned SDK-native compaction as ordinary extension cancellation — `lane-policy.ts` must preserve `external-owner` ownership.
@@ -80,5 +80,5 @@ compaction/
 ## NOTES
 
 - The fork's compaction differs significantly from upstream pi (speculative + restoration + degradation are all senpi additions). Upstream has a much simpler `core/compaction/` policy.
-- The 13 per-feature fixtures (under `packages/coding-agent/test/fixtures/compaction/`) are documented in their own `README.md` — each isolates one subsystem to avoid spooky-action regressions.
+- The per-feature fixtures (under `packages/coding-agent/test/fixtures/compaction/`) are documented in their own `README.md` — each isolates one subsystem to avoid spooky-action regressions.
 - `restoration-tracker.ts` is the marquee feature: post-compact, the agent re-reads its prior file/skill context so summarization doesn't lose tool grounding.

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/AGENTS.md
@@ -1,0 +1,41 @@
+# builtin/config-reload
+
+## OVERVIEW
+
+Hash-gated config watching and idle reload handoff (score 8: nine TypeScript modules, entry boundary, dense symbols/exports); watches configuration, not extension runtime state.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|---|---|---|
+| Hook wiring, validation, reload handoff | `index.ts` | `configReloadExtension`, session-keyed `ConfigReloadHandoffRegistry` |
+| Public in-process watch contract | `protocol.ts` | `config-watch:*` channels, payload guards, registration/filter rules |
+| Hash snapshots / OS subscriptions | `watch-engine.ts` | `ConfigReloadWatchEngine`, directory-only targets and injectable clock/source |
+| Worker-backed filesystem events | `watch-event-source.ts` | Platform-specific watcher ownership |
+| Loaded extension entry scope | `extension-watch-scope.ts` | Mirrors loader discovery and `pi.extensions` manifest entries |
+| Generated shim suppression | `generated-shim-filter.ts` | Avoid reacting to managed resource writes |
+| Settings-only changes | `routine-settings.ts` | Settings content filtering |
+| Veto deferral | `reload-deferral.ts` | Defer without losing pending changes |
+| Redacted JSONL log | `log.ts` | Agent-directory `logs/config-reload.log` |
+
+## CONVENTIONS
+
+- `pi.events` is untyped; validate every external `config-watch:*` payload with `protocol.ts` guards. Later duplicate registration IDs replace earlier ones.
+- Protocol targets are `file | dir`; the watch engine converts coverage into `dir | dir-recursive` directory watches so atomic file replacement remains visible.
+- Recursive targets subscribe only to scanned in-scope directories, not a whole recursive OS subtree. Preserve the exclusions for dependency trees, `.git`, symlinks and filtered paths.
+- Content hashes gate events; an OS notification alone is not a reload. Default debounce is 200 ms and tests can inject the clock, source and hash function.
+- Extension watch scope follows one-level loader discovery except manifest-declared entries, which may be deeper. Goal persistence JSON is state, not reloadable source.
+- Busy/compacting/vetoed sessions defer reload. Successful reload transfers a session-keyed handoff to the replacement factory so changes during reload are not lost.
+- Shutdown retires watchers and continuations; a reload handoff survives only its intended replacement lifecycle.
+
+## ANTI-PATTERNS
+
+- Watching individual files directly; editor atomic renames invalidate that strategy.
+- Treating filter strings as a full glob language: plain names, suffixes and leading-star suffixes only; a leading `/` anchors to the watch root.
+- Reloading on every write anywhere under `extensions/`; runtime stores would trigger a feedback loop.
+- Dropping pending changes when an extension vetoes reload or letting retired contexts request a new reload.
+
+## VALIDATION
+
+Existing targets: `test/config-reload-{protocol,watch-engine,extension-watch-scope,generated-shim}.test.ts` and `test/suite/config-reload-*.test.ts`.
+Use injected watcher/clock events for deterministic cases; no fixed waits to guess whether a reload happened.

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/AGENTS.md
@@ -2,7 +2,7 @@
 
 The native Cursor provider (`cursor`, the api2.cursor.sh protobuf transport shipped in v2026.8.16) is the first-party, primary way to use Cursor from senpi. This extension is the documented FALLBACK lane: reach for it when the native path does not work well (protocol drift, transport failures) or when Cursor's own agent harness - running turns through the official `cursor-agent` CLI in print mode - is explicitly wanted. It never replaces or modifies the native provider, and `/cursor-account status` recommends the native provider whenever both are configured.
 
-Generated: 2026-08-17
+Refreshed: 2026-09-10 | Score 8: provider entry boundary with dense symbols/exports.
 
 ## FILE ROLES
 
@@ -15,7 +15,7 @@ Generated: 2026-08-17
 | `affinity.ts` | HRW (rendezvous) account selection keyed by senpi session id (sha256 `BigUInt64BE` score), pinned account wins unless blocked, expired `rate_limit` blocks cleared while `auth_error` blocks persist, `AllCursorAccountsBlockedError` carrying the soonest unblock time |
 | `errors.ts` | Closed ten-kind error union and `classifyCursorCliError`: exact-line matchers on probe-observed stderr wording plus typed `binary_missing`/`malformed_stream` kinds, retryability flags, rate-limit block durations (server hint else 60 s, capped at 48 h); the `context_overflow` wordings list is currently empty (the ceiling probe recorded no verbatim wording), so that kind is defined but unmatched |
 | `executable.ts` | `cursor-agent` resolution chain: `SENPI_CURSOR_CLI_OAUTH_EXECUTABLE`, then `CURSOR_AGENT_EXECUTABLE`, then settings `executablePath`, then explicit PATH probing, then the newest `~/.local/share/cursor-agent/versions/*`; typed `CursorAgentNotInstalledError` naming the install command; `probeCursorAgentVersion` under a 10 s deadline |
-| `spawn-args.ts` | Pure argv serializer for one print-mode invocation (`-p`, `--output-format stream-json`, `--stream-partial-output`, `--trust`, optional `--model`/`--resume`/`--force`/`--mode plan`/`--sandbox`); applies no execution policy |
+| `spawn-args.ts`, `spawn-model.ts` | Pure argv serializer plus `renderCursorCliModelString` reasoning-model encoding for one print-mode invocation (`-p`, `--output-format stream-json`, `--stream-partial-output`, `--trust`, optional `--model`/`--resume`/`--force`/`--mode plan`/`--sandbox`); applies no execution policy |
 | `stream-parser.ts` | Incremental NDJSON parser for the stream-json dialect: typed init/thinking/assistant/tool_call/result events, split-line tolerance, a bounded pending buffer (1 MiB) with `line_overflow` handling, unknown events counted, non-JSON noise routed to a bounded diagnostic ring, `malformed_stream` events instead of throws |
 | `transport.ts` | Spawns the resolved executable detached in its own process group with an explicit env allowlist (`HOME` = the account home, `AGENT_CLI_CREDENTIAL_STORE=file`, `PATH`/`TERM`/`LANG`/`LC_ALL`/`FORCE_COLOR`); rejects prompts over 130 KB pre-spawn; abort sends SIGTERM to the group then SIGKILL after 5 s; exposes the pid, parsed events, bounded stderr, and a settled outcome |
 | `home-store.ts` | Durable per-account HOMEs under `<agentDir>/cursor-cli-oauth/accounts/<slot>/home`: rewrites `.cursor/auth.json` (`accessToken`/`refreshToken`/`apiKey: null`/`bedrockCredentials: null`) at mode 0600 inside 0700 directories immediately before each run, reads back rotated refresh tokens after; logs byte lengths only; traversal-checked paths; never deletes a HOME |
@@ -43,7 +43,7 @@ Generated: 2026-08-17
 
 ## TESTS
 
-`packages/coding-agent/test/cursor-cli-oauth/*.test.ts` (20 suites) plus the hermetic `test/fixtures/fake-cursor-agent.mjs`; every unit/integration test points `SENPI_CURSOR_AGENT_EXECUTABLE` at the fixture, so no test needs the real binary, the network, or credentials. Real-CLI probes are opt-in behind `SENPI_CURSOR_CLI_LIVE=1` under `.agents/skills/senpi-qa/scripts/probes/cursor-cli/`.
+`packages/coding-agent/test/cursor-cli-oauth/*.test.ts` (27 suites) plus the hermetic `test/fixtures/fake-cursor-agent.mjs`; spawn tests use injected fixtures or `SENPI_CURSOR_CLI_OAUTH_EXECUTABLE`, not a real binary, network, or credentials. Real-CLI probes are opt-in behind `SENPI_CURSOR_CLI_LIVE=1` under `.agents/skills/senpi-qa/scripts/probes/cursor-cli/`.
 
 ## MERGE RISK
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -1,26 +1,27 @@
 # builtin/goal
 
-Builtin extension #30. Persistent per-thread **goal** tracking, ported from standalone
+Builtin goal extension (score 11: code-heavy multi-module domain with dense exports). Persistent per-thread **goal** tracking, ported from standalone
 `pi-goal` with **zero dependency on it** and **budget-driven behavior fully removed**.
 Registers codex-aligned `create_goal` / `update_goal` / `get_goal` plus `/goal`, persists one
-goal per thread, re-engages the agent via hidden continuation prompts. 34 `.ts` files, flat;
+goal per thread, re-engages the agent via hidden continuation prompts. 35 `.ts` files, flat;
 `changes.md` is the fork tracker.
 
 ## FILES (by cluster)
 
-- **Entry/registration**: `index.ts` (441 LOC; lifecycle, accounting, UI),
+- **Entry/registration**: `index.ts` (437 LOC; lifecycle, accounting, UI),
   `tool-registration.ts`, `command-registration.ts`, `command.ts`.
 - **Domain/persistence**: `types.ts` (Goal, statuses, inert `tokenBudget`), `store.ts`
   (serialized mutations), `persistence.ts` (atomic writes, legacy migration),
-  `validation.ts`, `errors.ts`.
-- **Continuation**: `monitor-continuation.ts` (603 LOC — timers, wake sources, direct-input
+  `validation.ts`, `errors.ts`, `transitions.ts`, `store-ref.ts`, `store-changed-event.ts`.
+- **Continuation**: `monitor-continuation.ts` (673 LOC — timers, wake sources, direct-input
   holds, cache-warm scheduling, admission, recovery, disposal) plus `continuation.ts`,
   `lifecycle-helpers.ts`, `direct-input-lifecycle.ts`, `agent-end-continuation.ts`,
-  `continuation-recovery.ts`, `reload-reengagement.ts`.
+  `continuation-recovery.ts`, `reload-reengagement.ts`, `channel-state-subscriptions.ts`, `stale-context.ts`.
 - **Prompt/format**: `prompt.ts` (untrusted-objective + completion audit), `format.ts`,
   `todo-gate.ts`, `last-assistant-message.ts`, `terminal-provider-error.ts`.
 - **UI/tickers**: `ui.ts` (footer segment), `elapsed-ticker.ts`, `wait-ticker.ts`,
-  `wait-progress.ts`, `cache-warm.ts`, `cache-warm-renderer.ts`.
+  `wait-progress.ts`, `cache-warm.ts`, `cache-warm-renderer.ts`, `renderers.ts`.
+- **Usage accounting**: `turn-usage.ts` checkpoints streamed usage without double counting at `agent_end`.
 
 ## NO BUDGET-DRIVEN BEHAVIOR
 

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/gpt-apply-patch
 
-Builtin extension #4. For `gpt-*` models on Responses-family APIs, swaps `write` / `edit` for a freeform Codex-style `apply_patch` tool with a Lark-style grammar; for `gpt-*` models on `openai-completions`, exposes `apply_patch` as a plain JSON function tool instead. Applies multi-file patches (add / update / delete / move). Keeps standard edit tools for all other models and APIs. Largest single builtin (18 files).
+Codex patch domain (score 11). For `gpt-*` models on Responses-family APIs, swaps `write` / `edit` for a freeform Codex-style `apply_patch` tool with a Lark-style grammar; for `gpt-*` models on `openai-completions`, exposes `apply_patch` as a plain JSON function tool instead. Applies multi-file patches (add / update / delete / move). Keeps standard edit tools for all other models and APIs. `builtin/index.ts` owns registration order.
 
 ## FILES
 
@@ -18,6 +18,7 @@ gpt-apply-patch/
 ├── patch-replace.ts    # Replace algorithms (anchor matching, seek fallback)
 ├── seek-sequence.ts    # Strict context-line seek with N-line tolerance
 ├── apply.ts            # Apply parsed patch to workspace
+├── recovery.ts         # Partial-failure disclosure; reread only context-mismatch files
 ├── workspace.ts        # File I/O + path normalization for patches
 ├── preview.ts          # Preview before apply (used by permission-system parser)
 ├── preview-format.ts   # Render preview as TUI nodes (opencode-style diff)
@@ -34,6 +35,7 @@ gpt-apply-patch/
 | Fix a parse error from a real GPT output | `parser.ts` — add a regression test in `test/suite/gpt-apply-patch-extension.test.ts` |
 | Improve strict-seek tolerance | `seek-sequence.ts` |
 | Change render | `preview-format.ts` + `streaming-render.ts` |
+| Change partial-failure recovery | `recovery.ts` + `types.ts`; applied actions are not rolled back |
 | Add a new file op (e.g. `*** Rename File:`) | `types.ts` + `parser.ts` + `apply.ts` |
 | Adjust which models opt in | `extension.ts` — `APPLY_PATCH_FREEFORM_APIS` + `gpt-` id prefix in `isOpenAIGptModel()` |
 
@@ -43,7 +45,7 @@ gpt-apply-patch/
 - **Strict context lines**: `seek-sequence.ts` requires exact context-line match (with bounded fuzz). Bypassing strict mode masks real grammar bugs.
 - **Mirror upstream Codex grammar** in `parser.ts` — the canonical reference is `openai/codex` `apply_patch` source. The schema golden (`test/goldens/codex-apply-patch-schema.json`) is extracted from there via the repo-root `scripts/extract-codex-apply-patch-golden.mjs`.
 - **Permission-system integration**: `parsers.ts` in `permission-system/` extracts file paths from patch bodies for per-file approval (see `permission-system/changes.md` 2026-04-13).
-- **Render diffs like opencode** (recent commit f1d24c2f): the preview UI mirrors opencode's diff formatting.
+- **Render diffs like opencode**: the preview UI mirrors opencode's diff formatting.
 
 ## ANTI-PATTERNS
 

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/AGENTS.md
@@ -1,0 +1,37 @@
+# builtin/hooks
+
+## OVERVIEW
+Lifecycle command-hook domain (score 11): layered configuration, explicit command trust, and event-specific result handling.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Connect a host event | `index.ts` and the matching adapter |
+| Parse supported/unsupported config | `schema.ts`, `handler.ts`, `types.ts` |
+| Resolve source precedence | `config-loader.ts`, `plugin-loader.ts`, `plugin-manifest.ts` |
+| Match and dispatch handlers | `matcher.ts`, `dispatcher.ts` |
+| Spawn a hook process | `command-runner.ts` |
+| Trust hashing and persistence | `trust.ts`, `trust-storage.ts`, `trust-state-json.ts` |
+| Prompt submission context/blocking | `prompt-adapter.ts` |
+| Pre/post tool decisions | `tool-adapter.ts` |
+| Session/compaction hooks | `lifecycle-adapter.ts` |
+| Stop-hook continuation | `stop-adapter.ts` |
+| User command/status UI | `command.ts` |
+| Bound and redact output | `output-bounds.ts`, `output-parser.ts`, `safety.ts`, `diagnostics.ts` |
+
+## CONVENTIONS
+
+- `index.ts` exports the extension, config parser, and selected types/constants; adapter APIs remain direct-file imports.
+- Source metadata carries scope and load timing; plugin, project, global, and runtime handlers are not interchangeable.
+- Project trust state is merged only when the project is trusted; reloading config does not imply approval to execute it.
+- Prompt contexts queue for `before_agent_start`; pre-tool contexts are keyed by tool-call ID and consumed by the corresponding result.
+- Accepted compactions alone trigger post-compaction handling; rejected compactions do not represent a state change.
+- Running-handler status is emitted through the host's tool-hook status callback, not through raw process output.
+
+## ANTI-PATTERNS
+
+- Treating known-but-unsupported event/handler kinds as supported silently.
+- Bypassing trust checks, bounded output, or diagnostic redaction while adding an adapter.
+- Leaking one tool call's pending context into another call or a later prompt.
+- Running the user-prompt hook recursively for extension-originated input.

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/AGENTS.md
@@ -1,0 +1,35 @@
+# builtin/imagegen
+
+## OVERVIEW
+Client image-generation domain (score 8), sharing auth and bypass state with the sibling native OpenAI image lane.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Register the tool and bundled skill | `index.ts` |
+| Generate and save images | `tool.ts` |
+| Resolve credentials | `auth.ts` |
+| Validate tool parameters | `params.ts` |
+| Choose safe output filenames | `paths.ts` |
+| Load reference images | `reference-images.ts` |
+| Registry override/native bypass | `state.ts` |
+| Model-facing image workflow | `skill/SKILL.md` |
+
+## CONVENTIONS
+
+- Tool registration is separate from credential-gated skill discovery and prompt augmentation.
+- `registerImageGenExtension` accepts a base directory so copied and embedded assets can be exercised independently.
+- Node distribution uses the copied skill; Bun compilation can resolve an embedded file asset.
+- Auth is resolved through the model registry: stored OpenAI, a pinned gateway, sorted gateways, then environment fallback.
+- Shared native-generation integration belongs in `state.ts`; the native lane can bypass client-side execution.
+- Default outputs go under `generated-images/`; generated names sanitize and bound the tool-call identifier.
+- Output creation uses exclusive writes; partial multi-image saves are rolled back if a later save fails.
+- Reference-image inputs have a separate 50 MiB per-file boundary, not look-at's limits.
+
+## ANTI-PATTERNS
+
+- Reading `models.json` or `auth.json` directly instead of using registry auth resolution.
+- Logging or returning key material, or accepting placeholder sentinel keys as credentials.
+- Overwriting an existing image path to make a generation call succeed.
+- Removing the compiled-binary skill fallback because the source-tree skill exists locally.

--- a/packages/coding-agent/src/core/extensions/builtin/look-at/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/look-at/AGENTS.md
@@ -1,0 +1,36 @@
+# builtin/look-at
+
+## OVERVIEW
+Vision-delegation domain (score 8): `look_at` lets a non-vision active model query an available vision-model chain.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Tool activation on session/model changes | `index.ts` |
+| Normalize compatibility argument forms | `arguments.ts` |
+| Read attachments, paths, and base64 | `image-input.ts` |
+| Pick an available vision model | `model-selector.ts` |
+| Execute the delegated request | `runner.ts` |
+| Session override and configured chain | `settings.ts` |
+| `/lookat` command | `commands.ts` |
+| Call/result display and details | `render.ts` |
+| Description and delegated prompt | `prompts.ts` |
+
+## CONVENTIONS
+
+- Activation requires enablement, an active model without image input, and an available vision candidate.
+- Keep registration distinct from activation; model switches resynchronize the active tool list.
+- External parameters are snake_case; singular inputs and legacy `path` normalize into plural forms.
+- Image loading accepts local paths, attachment references, and base64, not remote URLs.
+- Input limits are 10 MiB per image and 25 MiB aggregate, with configured resize/block behavior.
+- Chain selectors support provider/model patterns and thinking-level suffixes.
+- The runner owns auth, timeout, and abort handling; render details preserve model, source, and MIME metadata.
+- The model-facing result is the delegated response body, not a synthetic transcript of the request.
+
+## ANTI-PATTERNS
+
+- Leaving `look_at` active after switching to an image-capable primary model.
+- Giving remote URLs filesystem semantics or bypassing aggregate image limits.
+- Duplicating legacy-input normalization in the executor or command handler.
+- Replacing unavailable-model feedback with fabricated visual detail.

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/AGENTS.md
@@ -1,0 +1,35 @@
+# builtin/loop-guard
+
+## OVERVIEW
+Tool-loop detection domain (score 8): advisory similar/cyclic notices plus episode-scoped escalation for identical calls.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Wire execution, call, turn, and session events | `index.ts` |
+| Canonical signatures and bounded history | `tracker.ts` |
+| Identical/similar/cycle detection | `detectors.ts` |
+| Notice admission and thresholds | `detectors.ts`, `policy.ts` |
+| Blocking/hard-stop episode state | `escalation.ts` |
+| Text similarity | `similarity.ts` |
+| Model-facing notice construction | `notice.ts` |
+| Transcript display | `renderer.ts` |
+
+## CONVENTIONS
+
+- `ToolCallTracker` observes tool-call records, not adjacent transcript messages; its history window is bounded.
+- `NoticeGate` controls notice admission separately from detection.
+- `IdenticalLoopEscalation` correlates execution attempts with `tool_call` via tool-call ID.
+- Reaching the identical-notice threshold schedules blocking after that attempt; the triggering attempt is still allowed.
+- A changed tool/argument signature resets the episode and its pending attempt map together.
+- Similar and cyclic detections never enter the blocking episode.
+- Hard-stop announcement is emitted once per episode even if additional identical calls arrive.
+- Shared notice rendering supplies the semantic error tone and ASCII marker.
+
+## ANTI-PATTERNS
+
+- Blocking calls that never passed through `tool_execution_start` observation.
+- Assuming tool-call adjacency matches transcript-message adjacency.
+- Resetting only a hard-stop counter while retaining stale episode fingerprints.
+- Turning similarity warnings into hard vetoes without changing the explicit escalation policy.

--- a/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/loop
 
-Fork-only builtin extension porting Claude Code's `/loop`: recurring (fixed-interval) and
+Scheduling domain (score 8), porting Claude Code's `/loop`: recurring (fixed-interval) and
 self-paced (dynamic) scheduled prompts inside one session. A loop re-delivers a prompt or a
 loop-file sentinel on a cadence; dynamic loops pick their own next delay through the
 `schedule_wakeup` tool.
@@ -9,7 +9,7 @@ loop-file sentinel on a cadence; dynamic loops pick their own next delay through
 
 - **Impure**: `index.ts` (extension entry: timers, store wiring, tick dispatch, lifecycle),
   `store.ts` (atomic versioned sidecar, fail closed), `command.ts` (/loop → scheduler),
-  `tools.ts` (`schedule_wakeup`, flat TypeBox schema).
+  `command-registration.ts` (command/completion wiring), `tools.ts` (`schedule_wakeup`).
 - **Pure**: `scheduler.ts` (state machine: arm/fire/settle/pause/resume/stop/suspend/restore),
   `parse.ts` (/loop argument grammar), `cron-planner.ts` (normalizeInterval/describeCron/
   computeNextFireAt), `tick-prompt.ts` (sentinel expansion, full-vs-reminder), `status.ts`

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
@@ -1,11 +1,11 @@
 # packages/coding-agent/src/core/extensions/builtin/mcp
 
-Fork-native builtin MCP client. Registration #39 in `builtin/index.ts` — kept last so its provider-payload tap observes all co-resident builtin mutations. Entry: `index.ts` exports `default function mcpExtension(pi: ExtensionAPI): void`. `changes.md` is the active fork ledger; every divergence from upstream MCP SDK behavior goes there.
+Fork-native MCP client domain (score 11). Kept last in `builtin/index.ts` so its provider-payload tap observes all co-resident builtin mutations; do not encode its ordinal here. Entry: `index.ts` exports `default function mcpExtension(pi: ExtensionAPI): void`. `changes.md` is the active fork ledger; every divergence from upstream MCP SDK behavior goes there.
 
 ## SUBTREES
 
 - `auth/` OAuth 2.1: discovery, PKCE S256, RFC 8707 resource binding, loopback callback or paste flow. Token store in `auth/token-store.ts`: `<agentDir>/mcp-auth/<sha256(serverUrl)>/tokens.json`, dir 0700, files 0600, cross-process lock via `proper-lockfile`.
-- `expose/` Tool naming (`naming.ts`), exposure policy (`policy.ts`), pagination, BM25 search, proxy gateway, schema compat. Tool names: `mcp_<server>_<tool>`, sanitized, 64-char hard cap (`MCP_TOOL_NAME_MAX_LENGTH = 64`), hash suffix on collision.
+- `expose/` Tool naming (`naming.ts`), exposure policy (`policy.ts`), pagination, proxy gateway, schema compat. BM25 catalog search is owned by sibling `tool-search/engine/`. Tool names: `mcp_<server>_<tool>`, sanitized, 64-char hard cap (`MCP_TOOL_NAME_MAX_LENGTH = 64`), hash suffix on collision.
 - `guard/output-guard.ts` Output size limits + spill file creation.
 
 ## CONFIG
@@ -45,4 +45,4 @@ Docs: `packages/coding-agent/docs/mcp.md` — keep prose aligned with `config-sc
 - No raw secrets in config values; use `${ENV_VAR}` references.
 - Proxy mode is never selected automatically; opt-in only via `exposure: "proxy"`.
 - New tools from `list_changed` are never active by default; only `directTools` entries become active immediately.
-- Never import from `core/` directly; use `pi.*` API only.
+- Do not create a second search catalog here: MCP entries join the provider-scoped `ToolSearchService` owned by sibling `tool-search/`.

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/AGENTS.md
@@ -1,0 +1,36 @@
+# builtin/nested-agents-md
+
+## OVERVIEW
+Directory-guidance injection domain (score 8): bounded, session-scoped discovery of nearby instruction files after file reads.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Host events and toggle command/flag | `index.ts` |
+| Compose discovery, reads, budget, and cache | `core/inject-directory-context.ts` |
+| Canonical containment | `core/containment.ts` |
+| Walk ancestors for guidance | `core/find-agents-md-up.ts` |
+| Session identity | `core/session-key.ts` |
+| Deduplicate injected directories | `core/injection-cache.ts` |
+| Filename and byte-limit defaults | `core/types.ts` |
+| Format and truncate injected text | `core/format.ts`, `core/truncate.ts` |
+| Typed file-read failures | `core/errors.ts` |
+| Injection status/widget | `ui/reporter.ts` |
+
+## CONVENTIONS
+
+- Resolve containment before walking from the canonical file's parent to the canonical root.
+- Cache keys pair session identity with the instruction file's directory, not just the requested filename.
+- Defaults cap file content at 32 KiB and aggregate content per read at 128 KiB.
+- Each file consumes the smaller of its per-file cap and the remaining read budget.
+- Mark a directory injected only after a successful read and formatting pass.
+- Read failures are returned in `InjectionResult.errors`; later candidates remain eligible.
+- Metadata records original/injected byte counts and truncation separately from formatted text.
+
+## ANTI-PATTERNS
+
+- Using lexical path prefixes as a substitute for canonical containment.
+- Sharing one injected-directory set across unrelated sessions.
+- Charging character counts against a byte budget or splitting UTF-8 text unsafely.
+- Caching failed reads as successful injections and thereby preventing later recovery.

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/permission-system
 
-Builtin extension #3. Full port of opencode's permission flow. Loads preset/rule policy from CLI (`--permission-preset`, `--permission tool=action`), settings (`permissionPreset`, `permission`), and per-session approvals. Defaults to the `full-access` preset, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
+Permission-policy domain (score 8). Full port of opencode's permission flow. Loads preset/rule policy from CLI (`--permission-preset`, `--permission tool=action`), settings (`permissionPreset`, `permission`), and per-session approvals. Defaults to the `full-access` preset, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
 
 ## FILES
 
@@ -56,7 +56,7 @@ Pattern syntax: tool name + optional arg pattern, e.g. `bash:rm *`, `write:/etc/
 ## CONVENTIONS
 
 - **JSONL storage is the contract**: `storage.ts` writes append-only newline-delimited JSON. Schema changes require a migration. Other tools (audit, replay) parse this format.
-- **Parsers are tool-aware**: `parsers.ts` extracts the *meaningful* arg per tool — file path for read/write/edit, command prefix for bash, file paths for `apply_patch` body (2026-04-13).
+- **Parsers are tool-aware**: `parsers.ts` extracts file paths for read/write/edit and `apply_patch`, command prefixes for shell execution. `bash_input.input` and `monitor.command` are command execution too; do not treat them as passive terminal operations.
 - **`external-dir.ts` emits an extra permission** when target path is outside repo root. `workspace` and `read-only` ask for that permission unless a later explicit rule allows it.
 
 ## ANTI-PATTERNS

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #7. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, gpt-6-astra, claude-fable-5, claude-fable-5-1, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, glm-5.3, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Model-prompt domain (score 11). On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, gpt-6-astra, claude-fable-5, claude-fable-5-1, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, glm-5.3, deepseek-v4-{flash,flash-0731,pro}, grok-4.{5,6}, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. Presets share `buildDynamicSystemPrompt()` assembly; thin tuning wrappers and deliberate full-core overrides coexist.
 
 ## FILES
 
@@ -29,6 +29,8 @@ prompt-preset/
 ├── deepseek-v4-flash.ts # DeepSeek V4 Flash preset (thin tuningSection over the shared core)
 ├── deepseek-v4-flash-0731.ts # DeepSeek V4 Flash 0731 snapshot preset — dated snapshot resolves before the generic flash alias
 ├── deepseek-v4-pro.ts   # DeepSeek V4 Pro preset (deep-reasoner calibration)
+├── grok-4.5.ts          # Full-core CEO posture; retains its existing file-operations tuning exception
+├── grok-4.6.ts          # Full-core engineering posture; no GPT file-operations tuning
 ├── kimi-k2-{6,7}.ts     # Kimi K2.6 / K2.7 presets (kimi-k2-6.ts, kimi-k2-7.ts)
 ├── kimi-k3.ts           # Kimi K3 preset — full-core rewrite via `corePrompt` on the Fable 5.1 skeleton, tuned for Moonshot's documented K3 "excessive proactiveness" (Scope section: request = deliverable, pre-existing problems are follow-ups, test scope; reflect-then-ask ambiguity gate; bounded failure cap; delegation with propagated stop condition) + binding stop contract (declared stop condition in the routing line)
 └── changes.md           # Fork tracker (model-family rename 2026-04-30, file-operations 2026-05-07)
@@ -51,26 +53,24 @@ prompt-preset/
 ## PRESET SHAPE (post 2026-04-30)
 
 ```typescript
-function buildGpt55Tuning(): string {
-   return `…model-specific addenda…
-
-${buildFileOperationsTuning()}`;
-}
-
-export function buildGpt55Prompt(options: BuildDynamicSystemPromptOptions): string {
-   return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt55Tuning() });
+export function buildGpt5Prompt(options: BuildDynamicSystemPromptOptions): string {
+   return buildDynamicSystemPrompt({
+      ...options,
+      tuningSection: buildGpt5Tuning(),
+      workstationDialect: "codex",
+   });
 }
 ```
 
-Each preset is ~10 lines. The shared default in `dynamic-prompt/` carries identity, intent gate, exploration, parallel-tools, verification, policies, style. Preset only carries **what's different for that model family**.
+Thin presets contain only family-specific tuning; full-core presets are intentionally larger. The shared default in `dynamic-prompt/` carries identity, intent gate, exploration, parallel-tools, verification, policies, style. Preset only carries **what's different for that model family**.
 
-Exception: `gpt-5.5.ts`, `gpt-5.6.ts`, `gpt-6-astra.ts`, `kimi-k3.ts`, `claude-fable-5.ts`, and `claude-opus-5.ts` pass `corePrompt` instead of `tuningSection` — full core rewrites (the two Claude 5 presets are dieted per the Fable 5 prompting guide — strong instruction following makes the shared scaffolding over-prescriptive — and carry the binding declared-stop-condition contract) (GPT-5.5+ wants short, outcome-first prompts, not the shared scaffolding; GPT-5.6 additionally over-compresses under generic brevity wording, so its style rules are prioritization/preserve-first, and its core is dieted per its own guide's simplify-first doctrine — previously duplicated rules stated once, probe-audited; Kimi K3 uses the Fable 5.1 skeleton with the boundaries Moonshot's K3 release notes call for — K3's documented failure is excessive proactiveness, acting on minor issues and ambiguous intent instead of asking, so the core states scope, ambiguity, and failure-cap rules once each and drops the K2.6-era act-bias repetition that used to outvote them). The 5.6 core is modeled on the oh-my-opencode Hephaestus GPT-5.6 prompt (autonomous deep worker: implement-don't-propose, Manual QA Gate, failure-recovery circuit breaker, stop rules), minus omo-only tool contracts. They still reuse `buildTestDisciplineSection()` (and, GPT-only, `buildFileOperationsTuning()`) plus the builder's dynamic assembly, so shared rules stay single-sourced.
+Exception: `gpt-5.5.ts`, `gpt-5.6.ts`, `gpt-6-astra.ts`, `kimi-k3.ts`, `claude-fable-5.ts`, `claude-fable-5-1.ts`, `claude-opus-5.ts`, `grok-4.5.ts`, and `grok-4.6.ts` pass `corePrompt` instead of `tuningSection` — full core rewrites (the Claude 5 presets are dieted per the Fable 5 prompting guide — strong instruction following makes the shared scaffolding over-prescriptive — and carry the binding declared-stop-condition contract) (GPT-5.5+ wants short, outcome-first prompts, not the shared scaffolding; GPT-5.6 additionally over-compresses under generic brevity wording, so its style rules are prioritization/preserve-first, and its core is dieted per its own guide's simplify-first doctrine — previously duplicated rules stated once, probe-audited; Kimi K3 uses the Fable 5.1 skeleton with the boundaries Moonshot's K3 release notes call for — K3's documented failure is excessive proactiveness, acting on minor issues and ambiguous intent instead of asking, so the core states scope, ambiguity, and failure-cap rules once each and drops the K2.6-era act-bias repetition that used to outvote them). The 5.6 core is modeled on the oh-my-opencode Hephaestus GPT-5.6 prompt (autonomous deep worker: implement-don't-propose, Manual QA Gate, failure-recovery circuit breaker, stop rules), minus omo-only tool contracts. They still reuse `buildTestDisciplineSection()` (and where applicable `buildFileOperationsTuning()`, including the existing Grok 4.5 exception) plus the builder's dynamic assembly, so shared rules stay single-sourced.
 
 ## CONVENTIONS
 
 - **Model-family naming, not personas**: presets are named after the model they target (`gpt-5.ts`, not `coder.ts`). The 2026-04-30 rename removed persona-style names.
 - **`file-operations.ts` is appended to EVERY GPT-5.x preset**. New GPT preset → mirror this. Negative-only directives lose to model priors; pair them with positive routing.
-- **`resolvePresetName()` is cheap** (used by startup header). `resolvePreset()` builds the full prompt — call only when needed.
+- **`resolvePresetName()` is cheap** (used by startup header). Explicit settings win over `model.promptPreset` metadata, then family matching. Mythos 5/5.1 aliases route to the corresponding Fable preset. `resolvePreset()` builds the full prompt — call only when needed.
 - **Don't duplicate identity / intent / exploration** in a preset — they're already in the default builder. The dieted core (2026-09-02/03) also carries one-plan commitment, scope fidelity, the conditional delegation rule, and the auto-compaction continuation fact — a tuning line that restates any of these is dead weight (2026-09-03 audit removed such lines from every Opus 4.x and GLM preset).
 - **A tuning line must be documented for the target model**: cite the guide section (or the preset's own probe evidence) in `changes.md`. A preset whose guide documents nothing beyond the core renders execution tooling only (`claude-opus-4-6.ts`).
 
@@ -78,8 +78,8 @@ Exception: `gpt-5.5.ts`, `gpt-5.6.ts`, `gpt-6-astra.ts`, `kimi-k3.ts`, `claude-f
 
 - Renaming a preset file to a persona ("coder", "architect", "thinker") — was tried, reverted.
 - Embedding full prompt scaffolding in a `tuningSection` — defeats the point of the 2026-04-30 thin-wrapper architecture. A deliberate full rewrite goes through the builder's `corePrompt` override (see `gpt-5.5.ts`), never by duplicating shared sections as tuning text.
-- Adding a non-GPT preset that copies `buildFileOperationsTuning()` — the apply_patch routing is GPT-specific.
-- Mutating `BuildDynamicSystemPromptOptions` before passing through — pass via spread, add only `tuningSection`.
+- Copying Grok 4.5's existing `buildFileOperationsTuning()` exception into new non-GPT presets — it is not the general routing rule; Grok 4.6 omits it.
+- Mutating `BuildDynamicSystemPromptOptions` before passing through — spread options and set only the intended tuning/core/dialect overrides.
 
 ## NOTES
 

--- a/packages/coding-agent/src/core/extensions/builtin/rules/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/AGENTS.md
@@ -1,0 +1,36 @@
+# builtin/rules
+
+## OVERVIEW
+Project-rule domain (score 8): static prompt rules and path-triggered dynamic rules share discovery but not injection state.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Host events and activation records | `index.ts` |
+| Environment/flag defaults | `config.ts`, `rules/types.ts` |
+| `/rules` and reload behavior | `commands.ts`, `ui/` |
+| Static/dynamic lifecycle and fingerprints | `rules/engine.ts` |
+| Locate rule sources | `rules/finder.ts`, `rules/project-root.ts` |
+| Scan and parse `.md` / `.mdc` rules | `rules/scanner.ts`, `rules/parser.ts` |
+| Match target paths and globs | `rules/matcher.ts` |
+| Format injection blocks | `rules/formatter.ts` |
+| Extract paths from tool results | `rules/tool-paths.ts` |
+
+## CONVENTIONS
+
+- Modes are `static`, `dynamic`, `both`, and `off`; CLI flags synchronize engine config on each relevant hook.
+- The engine receives candidate discovery, file reads, project-root lookup, and tool-path extraction as dependencies.
+- Static rules append to the base prompt every turn, even when a prior static-injection mark exists.
+- Native context files are excluded using both supplied and canonical path keys.
+- Dynamic fingerprints track all target paths, not just the first path displayed in the activation entry.
+- Dynamic deduplication uses the `live-context` scope and remains separate from static marks.
+- Accepted compaction resets session rule state; rejected compaction does not.
+- Formatting limits default to 12,000 characters per rule and 40,000 per result.
+
+## ANTI-PATTERNS
+
+- Omitting a static block because an earlier turn already marked it injected.
+- Injecting dynamic rules for errored tool results or rules already represented by native/static context.
+- Invalidating the whole discovery cache for every unchanged target instead of checking fingerprints.
+- Treating rule-activation display entries as the engine's authoritative injection state.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/terminal
 
-Builtin extension #18. Replaces one-shot bash with a **PTY-backed persistent session** model: `bash` plus companion tools `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and `monitor`. Registered after `bash-timeout` (so the resolved default timeout reaches PTY bash) and after `anthropic-bash` (so a native Anthropic bash tool makes terminal step aside).
+Persistent-terminal domain (score 11). Replaces one-shot bash with a **PTY-backed persistent session** model: `bash` plus companion tools `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and `monitor`. Registered after `bash-timeout` (so the resolved default timeout reaches PTY bash) and after `anthropic-bash` (so a native Anthropic bash tool makes terminal step aside).
 
 ## FILES
 
@@ -12,7 +12,7 @@ terminal/
 ├── runtime-session.ts   # TerminalRuntimeSession: one live PTY
 ├── session-bundle.ts    # TerminalSessionBundle: reload parking/claiming across extension generations
 ├── monitor-registry.ts  # MonitorRegistry: registered watches over session output
-├── monitor-notify.ts    # Event → notification delivery (283 LOC, largest non-tool file)
+├── monitor-notify.ts    # Event → notification delivery; monitor-registry.ts owns watch state
 ├── monitor-status*.ts   # Footer status text + 1s unref'd ticker
 ├── notify.ts            # TerminalNotifier
 ├── output-format.ts     # Output shaping/sanitization

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/AGENTS.md
@@ -1,0 +1,38 @@
+# builtin/todotools
+
+## OVERVIEW
+Phased task-state domain (score 8): the `todo` tool, `/todo`, Markdown interchange, and session-backed sidebar share one state model.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Lifecycle restoration and native todo mirroring | `index.ts` |
+| Public state API | `state.ts` |
+| Schema and operation entry types | `todo-types.ts` |
+| Mutate phases/tasks | `todo-operations.ts`, `normalize.ts` |
+| Resolve task/phase targets | `todo-resolution.ts`, `todo-query.ts` |
+| Restore branch entries | `todo-storage.ts` |
+| Tool schema, execution, rendering | `tools/todo.ts` |
+| Slash-command parsing and actions | `commands.ts`, `fuzzy-match.ts` |
+| `TODO.md` import/export | `markdown.ts` |
+| Native Cursor todo conversion | `native-todo-mirror.ts` |
+| Sidebar model and component | `todo-widget.ts`, `todo-widget-component.ts` |
+| Result text and prompt contract | `todo-format.ts`, `prompt.ts` |
+
+## CONVENTIONS
+
+- Exact task-content strings are identifiers; phases use stable short names rather than generated IDs.
+- Statuses are `pending`, `in_progress`, `completed`, and `abandoned`.
+- State access clones phases; mutable UI state is not handed directly to consumers.
+- Restore from the current branch on both session start and session-tree changes.
+- Persist full snapshots as `senpi.todo-state` with schema `v2`; operation/replay helpers live behind the state barrel.
+- Cursor-native assistant `todo` calls without an `op` are mirrored into phases, persisted, and shown in the widget.
+- Completion transitions are supplied separately to sidebar rendering, not inferred from display strings.
+
+## ANTI-PATTERNS
+
+- Renaming task text after introduction or adding numeric phase prefixes that change identity.
+- Collapsing or dropping user checklist items during Markdown import or normalization.
+- Treating a native todo snapshot as an op-based tool call.
+- Reading one implementation module to reconstruct state when the public `state.ts` API already owns that operation.

--- a/packages/coding-agent/src/core/extensions/builtin/tool-search/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/tool-search/AGENTS.md
@@ -1,0 +1,35 @@
+# builtin/tool-search
+
+## OVERVIEW
+Shared deferred-tool discovery domain (score 8): extension and MCP catalogs feed custom `tool_search` and Anthropic native search.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Bind extension lifecycle and lazy activation | `index.ts` |
+| Catalog ownership, activation, and rehydration | `service.ts` |
+| Custom search tool schema/execution | `tool.ts` |
+| Anthropic request/response adaptation | `native-search.ts`, `native-support.ts` |
+| Search ranking | `engine/bm25.ts` |
+| Catalog documents | `engine/document.ts` |
+| Persisted activation markers | `engine/marker.ts` |
+
+## CONVENTIONS
+
+- Provider-scoped sessions install their own `ToolSearchService`; the fallback singleton is for runtimes without provider scope.
+- The service binds a tool registrar and only registers the custom search tool when a catalog needs it.
+- Rehydrate promoted tools at session start and replay markers on `context` events.
+- The lazy activator and model-callable search path both delegate to the service's activation logic.
+- Extension definitions are deferrable while inactive; MCP native deferral also checks the MCP-native-search setting.
+- Native adaptation observes response status so an injection failure can fall back to the custom path.
+- Marker V2 is emitted while legacy markers remain parseable for existing sessions.
+- MCP discovery supplies catalog entries here; MCP does not own a separate BM25 engine.
+
+## ANTI-PATTERNS
+
+- Deferring the custom `tool_search` tool itself.
+- Combining `defer_loading` and `cache_control`, or adding cache control to injected inactive definitions.
+- Registering/activating search for an empty catalog.
+- Letting tool activation or restored markers leak across provider-scoped sessions.
+- Assuming every registered definition is active or should be sent eagerly to a provider.

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/AGENTS.md
@@ -1,0 +1,37 @@
+# builtin/ttsr
+
+## OVERVIEW
+Stream-remediation domain (score 11): detect degeneration/control-token leaks, arbitrate one abort owner, and settle a retry or nudge.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Host lifecycle, abort provenance, settlement | `index.ts` |
+| Rule state, matching, and injection history | `manager.ts` |
+| Per-stream delta extraction and watching | `message-update.ts`, `watch.ts` |
+| Generation-level arbitration | `coordinator.ts` |
+| Builtin/user rules and conditions | `builtin-rules.ts`, `discovery.ts`, `rule-parser.ts`, `rule-condition.ts`, `scope.ts` |
+| Collapse detectors | `detectors/collapse*.ts` |
+| Transcript/control-token leaks | `detectors/control-leak.ts`, `detectors/leak-context.ts`, `detectors/token-grammar.ts` |
+| Repeated completed turns | `repetitive-turns-lane.ts`, `detectors/repetitive-turns.ts` |
+| Stream replacement and nudges | `stream-remediation.ts`, `remediation.ts`, `prompts.ts` |
+| Commands and public settings | `commands.ts`, `types.ts` |
+
+## CONVENTIONS
+
+- Stream identity includes source, stream key, and generation; text, thinking, and tool deltas are distinct lanes.
+- `claimAbort` and generation state prevent competing detectors from independently interrupting one generation.
+- User input or user abort cancels pending remediation and disarms repeated-turn recovery.
+- `message_end` clears buffered stream tails so later messages cannot match earlier deltas.
+- Message replacement is prepared at message end; a pending nudge is sent only after `agent_settled`.
+- Accepted injection history uses shared `rule-activation` entries; legacy TTSR entries are also restored.
+- Rule interrupt modes are explicit `always`/`never` values, not inferred from detector names.
+- Repetitive-turn history is restored separately from current-generation stream state.
+
+## ANTI-PATTERNS
+
+- Emitting a recovery nudge after a user cancellation.
+- Keeping stream tails until the next turn and thereby matching across completed messages.
+- Reusing generation-local abort ownership for a provider retry without resetting it.
+- Conflating advisory rule matches, stream-error replacement, and model-facing nudge delivery.

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/AGENTS.md
@@ -1,0 +1,35 @@
+# builtin/webfetch
+
+## OVERVIEW
+URL-retrieval domain (score 8): bounded network reads and lazy HTML conversion feed the `webfetch` tool.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Enablement and tool registration | `index.ts` |
+| Tool arguments, progress, output cap | `webfetch/tool.ts` |
+| HTTP request, redirect, timeout, body limits | `webfetch/fetcher.ts` |
+| Response draining/destruction | `webfetch/response-body.ts` |
+| Conversion facade | `webfetch/content.ts` |
+| Heavy HTML conversion dependencies | `webfetch/content.lazy.ts` |
+| Typed fetch failures | `webfetch/errors.ts` |
+| Call/result display | `webfetch/renderers.ts` |
+
+## CONVENTIONS
+
+- `PI_WEBFETCH` is default-on; explicit `0`, `false`, `no`, or `off` disables registration entirely.
+- Unknown enablement values retain the default-on behavior.
+- Formats are `markdown`, `text`, and `html`; network handling and conversion remain separate stages.
+- Network response budget is 5 MiB; converted tool output has its own 50 KiB cap.
+- Timeout defaults to 30 seconds and clamps to 120; redirect traversal caps at 20.
+- Caller cancellation and timeout share the request abort path, with timer/listener cleanup.
+- `jsdom`, Readability, and Turndown remain behind the existing lazy conversion boundary.
+- Response disposal destroys the body even if discard fails; this cleanup exception is intentionally narrow.
+
+## ANTI-PATTERNS
+
+- Eagerly importing the HTML conversion stack into startup registration.
+- Treating the output cap as a substitute for bounding downloaded bytes.
+- Following redirects without preserving abort, timeout, and response-body cleanup.
+- Expanding the documented discard-error exception into silent failure of fetch or conversion.

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/AGENTS.md
@@ -1,0 +1,36 @@
+# builtin/websearch
+
+## OVERVIEW
+Provider-backed search domain (score 11): `web_search` routes configured providers and capability-gated native search through one result model.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Tool/command lifecycle | `index.ts` |
+| Config loading, free fallback, validation | `websearch/config.ts` |
+| Endpoint restrictions | `websearch/provider-endpoints.ts` |
+| Tool schema and output formatting | `websearch/tool.ts` |
+| Routing strategy and fallback attempts | `websearch/search.ts` |
+| Provider registry | `websearch/providers.ts` |
+| Provider request/response adapters | `websearch/providers/` |
+| Native capability and enablement checks | `websearch/native.ts` |
+| Shared result/config types | `websearch/types.ts` |
+| Display route and result rendering | `websearch/renderers.ts` |
+
+## CONVENTIONS
+
+- Provider modules implement `buildRequest` and `normalizeResponse`; filenames alone do not register a backend.
+- Config accepts `priority`, `round-robin`, and `fill-first` strategies with explicit fallback/auto settings.
+- The free default is DuckDuckGo HTML, priority routing, fallback enabled, auto enabled, and ten results.
+- Provider endpoint rules are centralized; provider-specific URL/auth requirements remain in validation/adapters.
+- DeepSeek reuses the Anthropic-compatible adapter; xAI reuses the OpenAI Responses adapter.
+- Native bypass requires the exact capability and enablement checks, not a matching provider display name.
+- Display text omits strategy while structured metadata preserves routing information.
+
+## ANTI-PATTERNS
+
+- Adding a provider without updating the typed registry, config validation, and response normalization together.
+- Assuming absence of configured credentials means no search path exists.
+- Replacing native capability checks with a provider-name allowlist.
+- Leaking raw provider responses or credentials into route/status rendering.

--- a/packages/coding-agent/src/core/retry-fallback/AGENTS.md
+++ b/packages/coding-agent/src/core/retry-fallback/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/retry-fallback
 
-Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pure/injectable modules only — every clock, timer, and registry probe is injected; `core/agent-session.ts` owns the single impure wiring. No local `changes.md`: fork changes track in `src/changes.md` / `core/changes.md`.
+Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`; retained policy boundary (score 6). Pure/injectable modules only — every clock, timer, and registry probe is injected; `core/agent-session.ts` owns the single impure wiring. No local `changes.md`: fork changes track in `src/changes.md` / `core/changes.md`.
 
 ## FILES
 
@@ -35,7 +35,7 @@ Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pu
 - Billing-class errors pin the fallback candidate as the session model and NEVER release; refusal pins release when a senpi-owned compaction successfully applies (context changed => one fresh primary attempt); `transient`/`hard-error` fallbacks revert per `fallbackRevertPolicy` (`cooldown-expiry` | `never`).
 - `canonicalizeFallbackChains` is memoized on chains content — provider-error handling calls it several times per error.
 - `fallback.log` scrubs by construction: blocked keys (`headers`, `env`, `authorization`, …), allowlisted data keys only, bearer/api-key text patterns truncated.
-- Consumers: `agent-session.ts` (controller wiring), `settings-manager.ts` (resolution), `builtin/model-fallback/` (validate + canonicalize for `/model-fallback`), `builtin/cursor-cli-oauth/settings.ts` (`isFallbackEligible` probe).
+- Consumers: `agent-session.ts` (controller wiring), `settings-manager.ts` (resolution), `builtin/model-fallback/` (validate + canonicalize for `/fallback`), `builtin/cursor-cli-oauth/settings.ts` (`isFallbackEligible` probe).
 
 ## ANTI-PATTERNS
 
@@ -47,5 +47,5 @@ Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pu
 
 ## NOTES
 
-- Tests: `test/suite/retry-fallback-*.test.ts` (20 files) — engine, chains, expansion eligibility, cooldown, hint tiers, probe scheduler, billing swap, revert, validate, log.
+- Tests: `test/suite/retry-fallback-*.test.ts` — engine, chains, expansion eligibility, cooldown, hint tiers, probe scheduler, billing swap, revert, validate, log.
 - `streamRetryTimeoutMs` reconciles to `max(cap, streamStartTimeoutMs)` so a granted stream-start budget is never cut short; `0` disables.

--- a/packages/coding-agent/src/core/tools/AGENTS.md
+++ b/packages/coding-agent/src/core/tools/AGENTS.md
@@ -1,13 +1,14 @@
 # packages/coding-agent/src/core/tools
 
-Built-in tool implementations. **Prefer extensions for new tools** — this dir exists only for tools that ship in upstream `pi-mono` and need parity. The senpi-specific extras (`apply_patch`, web search, code execution, computer use) are builtin extensions, not core tools.
+Upstream-parity tool domain (score 11). **Prefer extensions for new tools** — this dir exists only for tools that ship in upstream `pi-mono` and need parity. The senpi-specific extras (`apply_patch`, web search, code execution, computer use) are builtin extensions, not core tools.
 
 ## FILES
 
 ```
 tools/
-├── index.ts                     # Tool definition exports (read, write, edit, bash, grep, find, ls)
+├── index.ts                     # Eight tool definitions; four-tool coding/read-only factories
 ├── bash.ts                      # Bash tool — promptSnippet uses `rg` (not `grep`) per fork tuning
+├── powershell.ts                # PowerShell definition + injectable spawn/operations
 ├── read.ts                      # File read tool with image/binary handling
 ├── write.ts                     # File create/replace tool
 ├── edit.ts                      # In-place edit tool (uses `edit-diff.ts` for hunks)
@@ -20,6 +21,10 @@ tools/
 ├── tail-window.ts               # Bounded decoded tail window used by OutputAccumulator
 ├── output-accumulator.ts        # Bounded streaming output snapshots; temp-file fallback preserves full output
 ├── path-utils.ts                # Path normalization, repo-root resolution
+├── filesystem-policy.ts         # Canonical containment policy for filesystem tools
+├── bounded-realpath.ts          # Resolution deadlines; serialization-key fallback is not a policy path
+├── read-classifiers.ts          # Read input classification
+├── unified-diff.ts, write-result.ts # Shared diff text and write-result shaping
 ├── render-utils.ts              # ANSI / chalk / panel helpers shared across renders
 ├── tool-definition-wrapper.ts   # Helper to wire ToolDefinition + render + execute
 ├── truncate.ts                  # Output truncation policy
@@ -32,12 +37,12 @@ tools/
 {
    name: "<tool>",
    description: "...",
-   inputSchema: <typebox schema>,
+   parameters: <typebox schema>,
    promptSnippet: "...",                // baked into system prompt
    promptGuidelines: ["…"],             // Tool Guidelines section
-   execute: async (input, ctx) => {…},
-   renderCall: (input) => <terminal output>,
-   renderResult: (result) => <terminal output>,
+   execute: async (toolCallId, params, signal, onUpdate, ctx) => {…},
+   renderCall: (params, theme, context) => <TUI component>,
+   renderResult: (result, options, theme, context) => <TUI component>,
 }
 ```
 
@@ -55,10 +60,11 @@ tools/
 - Adding a new tool here when the same effect can be a builtin extension — bloats merge surface.
 - Bypassing `file-mutation-queue.ts` — concurrent writes on the same path will corrupt.
 - Hardcoding output limits — go through `truncate.ts` policy.
-- Importing from `extensions/` — core tools must not depend on extension code.
+- Depending on builtin extension implementations here. The shared `extensions/types.ts` ToolDefinition contract is intentionally imported.
 
 ## NOTES
 
 - The `apply_patch` tool exists as a **builtin extension** under `extensions/builtin/gpt-apply-patch/`, NOT here. Its hunk math is self-contained (`patch-diff.ts` on the npm `diff` package); the piece it shares with core tools is `diff-render.ts`.
 - `read.ts` handles image bytes via `utils/photon.ts` (WASM resize) before returning to the LLM. PDF handling happens in extensions.
+- `temporarilyDisabledToolNames` in `index.ts` currently withholds `grep` from the model-facing surface while preserving registered-tool resolution for programmatic callers such as Cursor's exec bridge. Do not equate registration with activation.
 - `find.ts` is gitignore-aware; the regression suite covers nested gitignore + glob behavior (`test/suite/regressions/3302-…`, `3303-…`).

--- a/packages/coding-agent/src/extensions/llama/AGENTS.md
+++ b/packages/coding-agent/src/extensions/llama/AGENTS.md
@@ -1,0 +1,35 @@
+# extensions/llama
+
+## OVERVIEW
+Local llama.cpp management domain (score 8): a hidden built-in provider plus interactive `/llama` catalog, load, and download workflows.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Register provider and `/llama` | `index.ts` |
+| Provider identity, auth, and model catalog | `provider.ts` |
+| Router HTTP requests and progress | `client.ts` |
+| Hugging Face search/token/model metadata | `huggingface.ts` |
+| Dialogs, selectors, and cancellable progress | `ui.ts` |
+| Hidden extension registration | `../index.ts` |
+
+## CONVENTIONS
+
+- This extension lives under `src/extensions/`, not the larger `core/extensions/builtin/` registry.
+- Default server URL is `http://127.0.0.1:8080`; configured auth can supply `LLAMA_BASE_URL` or an auth base URL.
+- `/llama` is interactive-only; other modes receive a notice rather than attempting a TUI dialog.
+- A catalog refresh follows successful load/unload/download operations so provider availability stays current.
+- Explicit `/llama` refresh permits network access even in `PI_OFFLINE` because the user already contacted the configured server.
+- Both `loaded` and `sleeping` statuses count as loaded when choosing whether to replace existing models.
+- Replace-and-load records the previous loaded set and attempts restoration on cancellation or failure.
+- Progress operations distinguish cancellation from failure and refresh the catalog after returning to the model list.
+- Hugging Face selections may include `repository:quantization`; gated models require server-side token access too.
+
+## ANTI-PATTERNS
+
+- Treating `hidden: true` as disabling registration; it hides the extension, not its provider functionality.
+- Replacing models without the explicit keep/unload/cancel choice.
+- Reporting a canceled download as a successful completed model load.
+- Letting a restoration failure overwrite the original load failure diagnostic.
+- Assuming the local UI's Hugging Face token automatically configures the remote llama.cpp server.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/modes/app-server
 
-Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
+Codex-compatible app-server domain (score 13). It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
 
 ## STRUCTURE
 
@@ -23,7 +23,7 @@ transports/           stdio, Unix socket, WebSocket auth/backpressure
 protocol/             App-facing facade (account.ts, config.ts, thread.ts, turn.ts,
                       collaboration-mode.ts, fuzzy-search.ts, terminal.ts, …) plus
                       pinned generated Codex evidence; generated/v2/ is the
-                      second-generation tree (~527 files)
+                      second-generation tree (see protocol/AGENTS.md)
 turn-adapter.ts       Agent/session events to app-server turn events
 ```
 
@@ -34,7 +34,7 @@ turn-adapter.ts       Agent/session events to app-server turn events
 - WebSocket listeners bind IP literals. Bearer auth is required unless explicitly disabled for loopback, and `Origin` requests remain rejected.
 - Keep connection subscriptions, thread ownership, archive/unload, and turn cancellation consistent across disconnect and daemon shutdown. Unarchive restores storage only; it must not resume or attach the thread.
 - Preserve the TurnLog for the process lifetime, including idle unload/resume. After a process restart, history reconstruction is intentionally user-message-only; do not present it as complete persisted turn history.
-- Every outbound notification must carry `emittedAtMs`. Preserve response-before-notification ordering for unarchive, goal, and settings mutations; do not emit `thread/compacted` because Codex HEAD does not emit it.
+- Every outbound notification must carry `emittedAtMs`. Preserve response-before-notification ordering for unarchive, goal, and settings mutations; do not emit `thread/compacted` because the pinned Codex compatibility surface does not emit it.
 - Keep `turn/diff/updated` thread-scoped and cumulative over projected file-change diffs. Keep `thread/settings/update` limited to session-scoped model and effort, and keep account reads honest rather than emulating Codex account state.
 - Approval payloads and diagnostics can contain sensitive material. Keep token-file permissions restricted, do not assume diagnostics are redacted, and add explicit redaction before exposing them beyond the local process.
 - Generated files under `protocol/generated/` are protocol evidence and compile-time type inputs, not runtime implementations. Never edit them directly. Prefer the non-generated facade; keep direct type-only imports isolated until the facade covers them.
@@ -45,10 +45,10 @@ turn-adapter.ts       Agent/session events to app-server turn events
 |---|---|
 | Add a method | `rpc/registry.ts` and the matching handler |
 | Change connection lifecycle | `server/connection.ts`, `server/server-core.ts` |
-| Change thread/session projection | `threads/` |
+| Change thread/session projection | `threads/AGENTS.md`, then the matching lifecycle/projection module |
 | Change transport behavior | `transports/` |
 | Change approvals | `server/approval-*.ts`, `server/approvals.ts` |
-| Change wire types | `protocol/` and `packages/coding-agent/docs/app-server.md` |
+| Change wire types | `protocol/AGENTS.md` and `packages/coding-agent/docs/app-server.md` |
 
 ## GENERATED PROTOCOL
 

--- a/packages/coding-agent/src/modes/app-server/protocol/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/protocol/AGENTS.md
@@ -1,0 +1,36 @@
+# modes/app-server/protocol
+
+## OVERVIEW
+Protocol-facade domain (score 9, excluding generated output): handwritten wire contracts plus pinned Codex type evidence and local lint configuration.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Public facade exports | `index.ts` |
+| Request/notification catalogs | `requests.ts`, `notifications.ts`, `methods.ts`, `methods.js` |
+| Common envelopes | `base.ts` |
+| Thread/turn contracts | `thread.ts`, `thread-parity.ts`, `turn.ts` |
+| Models, account, and config | `models.ts`, `account.ts`, `config.ts` |
+| Collaboration projection | `collaboration-mode.ts` |
+| Fuzzy-file and terminal contracts | `fuzzy-search.ts`, `terminal.ts` |
+| Compatibility type checks | `typecheck.ts` |
+| Pin and regeneration policy | `PROTOCOL_VERSION.txt`, `README.md` |
+
+## CONVENTIONS
+
+- The facade is the app-facing contract; generated exporter coverage is not a complete runtime-method inventory.
+- Experimental request families can be supplied from the pinned Codex `common.rs` method evidence even when absent from generated request roots.
+- `SENPI_COLLABORATION_MODE` projects the supported collaboration shape; nested `reasoning_effort` remains snake_case.
+- Fuzzy-file results preserve Codex's `match_type` and `file_name`, unlike most camelCase v2 fields.
+- Account usage/rate-limit values normalize bigint-like source counters to JSON-safe numbers.
+- `generated/package.json` is a local compilation shim and is not part of upstream payload identity.
+- Package builds exclude raw generated TypeScript; extensionless upstream imports are not rewritten to match app ESM conventions.
+- The protocol-pin suite checks recorded artifacts without an ambient checkout; `SENPI_CODEX_CHECKOUT` opts into live byte comparison.
+
+## ANTI-PATTERNS
+
+- Interpreting exporter omission of an experimental root as evidence that Codex removed the runtime method.
+- Converting mixed-case wire fields to a uniform naming convention.
+- Sending JavaScript `bigint` through JSON frames.
+- Counting the local compilation shim as upstream protocol evidence or relying on an unpinned ambient checkout in default tests.

--- a/packages/coding-agent/src/modes/app-server/threads/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/threads/AGENTS.md
@@ -1,0 +1,38 @@
+# modes/app-server/threads
+
+## OVERVIEW
+Thread-lifecycle and event-projection domain (score 9): session-backed registry, RPC handlers, turn execution, wire history, and content search.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Lifecycle entry and method wiring | `handlers.ts` |
+| Session registry and listing | `registry.ts`, `registry-listing.ts` |
+| Start parameters | `start-options.ts`, `handler-params.ts` |
+| List/archive metadata | `list-handlers.ts`, `archive-state.ts`, `metadata-handlers.ts`, `metadata-state.ts` |
+| Settings and goals | `settings-handlers.ts`, `goal-handlers.ts`, `goal-wire.ts` |
+| Turn engine and runtime adaptation | `turns.ts`, `turn-runtime.ts`, `turn-terminal.ts` |
+| In-memory turn history | `turn-log.ts` |
+| Event projection coordinator | `projection.ts`, `projection-types.ts` |
+| Wire items/messages/web search | `projection-wire-items.ts`, `projection-message-items.ts`, `projection-web-search.ts` |
+| File-change and cumulative diff projection | `projection-file-changes.ts`, `projection-turn-diff.ts` |
+| Persisted history and pagination | `history.ts`, `history-pagination.ts`, `wire-thread.ts` |
+| Content search and occurrence pagination | `search.ts`, `search-cache.ts`, `search-occurrences.ts`, `search-params.ts` |
+| MCP wire status | `mcp-wire-status.ts` |
+
+## CONVENTIONS
+
+- Handler clusters own method registration; parsing and wire construction remain separate from registry mutations.
+- `EventProjector` translates engine events; the split projection modules share typed projection state rather than registering methods themselves.
+- `createTurnEngine` composes runtime events, projection, and `TurnLog` instead of treating notifications as persisted history.
+- `TurnLog` returns cloned turns/items; callers do not mutate its backing arrays directly.
+- Completion status excludes `running`; duration is derived from parseable timestamps and otherwise remains null.
+- Thread-content search and its cached occurrences are distinct from sibling `search/` fuzzy filename search.
+
+## ANTI-PATTERNS
+
+- Emitting raw engine events directly as wire items and bypassing the projector.
+- Mutating a returned logged turn expecting to update the authoritative log.
+- Treating filename-search ranking as the thread-content search/pagination contract.
+- Adding another lifecycle dispatcher instead of extending the existing feature-specific handler cluster.

--- a/packages/coding-agent/src/modes/interactive/AGENTS.md
+++ b/packages/coding-agent/src/modes/interactive/AGENTS.md
@@ -1,11 +1,13 @@
 # packages/coding-agent/src/modes/interactive
 
-Interactive mode orchestrates the `senpi` TUI. `interactive-mode.ts` owns startup, session events, key dispatch, overlays, status, and command UI; `components/` owns rendering units.
+Interactive orchestration domain (score 9) for the `senpi` TUI. `interactive-mode.ts` owns startup, session events, key dispatch, overlays, status, and command UI; `components/` owns rendering units.
 
 ## STRUCTURE
 
 ```text
 interactive-mode.ts     Main lifecycle and event-to-UI coordinator
+interactive-host-runtime.ts Shared-host RPC runtime, remote session proxy, reconnect/rebind
+help-content.ts         Help markdown consumed by the builtin help overlay
 startup-tools.ts        Non-blocking fd/rg capability probe
 working-status.ts       Animated working text/frames
 session-info-format.ts  Session/cost/token summaries
@@ -25,6 +27,8 @@ changes.md              Fork-specific interactive behavior
 | Task | File |
 |---|---|
 | Startup and shutdown | `interactive-mode.ts` |
+| Shared-host connection, fallback, session replacement | `interactive-host-runtime.ts` |
+| Help / keybindings overlay content | `help-content.ts` + builtin `help/` |
 | Streaming assistant render | `components/assistant-message.ts` |
 | Streaming tool render | `components/tool-execution.ts` |
 | Working animation | `working-status.ts` and `interactive-mode.ts` |

--- a/packages/coding-agent/src/modes/interactive/components/AGENTS.md
+++ b/packages/coding-agent/src/modes/interactive/components/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/modes/interactive/components
 
-Rendering units for the TUI: message renderers, selectors/dialogs, tool surfaces, layout helpers. 56 flat `.ts` files (~11.6k LOC), no subdirectories. `interactive-mode.ts` (parent dir) drives them; these files never own lifecycle.
+TUI rendering domain (score 11): messages, selectors/dialogs, tool surfaces, layout helpers. Flat `.ts` modules, no subdirectories. `interactive-mode.ts` (parent dir) drives them; these files never own lifecycle.
 
 ## HOTSPOTS
 
@@ -9,7 +9,7 @@ Rendering units for the TUI: message renderers, selectors/dialogs, tool surfaces
 | `tree-selector.ts` | 1434 | `TreeList` + `TreeSelectorComponent`: tree flattening, gutters, active-path, folding, filtering, horizontal viewport, copy/text extraction, label editing |
 | `session-selector.ts` | 1031 | Session tree build/flatten, search/sort/name filtering, loading progress, delete/rename flows |
 | `config-selector.ts` | 942 | Config browse/edit surface |
-| `settings-selector.ts` | 917 | Settings browse/mutate surface |
+| `settings-selector.ts` | 932 | Settings browse/mutate surface |
 | `model-selector.ts` | 459 | Model picker; favorites/search split into helper modules |
 
 Cross-cutting fan-in: `DynamicBorder`, `theme`, and `keybinding-hints` are imported by nearly every selector/renderer — a change there reaches most dialogs. Tool rendering is split across `tool-execution.ts` plus renderer/types/images/fallback/boundary modules and is a second coupled cluster.
@@ -25,7 +25,7 @@ Cross-cutting fan-in: `DynamicBorder`, `theme`, and `keybinding-hints` are impor
 | Markdown/mermaid transforms | `createMarkdownTransform`, `createMermaidMarkdownTransformer` |
 | Border chrome | `dynamic-border.ts` |
 | Key label text | `keybinding-hints.ts` (`keyText`, `keyDisplayText`, `keyHint`) |
-| Public component surface for extensions | `index.ts` (barrel, 33 re-exports) |
+| Public component surface for extensions | `index.ts` (classes, public helpers, and types) |
 
 ## CONVENTIONS
 
@@ -34,12 +34,11 @@ Cross-cutting fan-in: `DynamicBorder`, `theme`, and `keybinding-hints` are impor
 - Layout is width-aware everywhere: `visibleWidth`, `truncateToWidth`, visual-line truncation, footer planning, bounded render signatures, explicit viewport/anchor math.
 - `ProgressiveTranscriptContainer` hydrates only visible/tail content incrementally; input handling must never block during hydration and the progressive watermark never moves backward.
 - Border color is always passed explicitly — jiti creates a separate module cache, so an implicit default resolves to the wrong theme instance.
-- The barrel re-exports only the public UI classes; many helpers stay direct-file APIs by design.
+- The barrel exposes public UI classes plus selected helpers/types such as `renderDiff`, key hints, and visual truncation; implementation helpers remain direct-file APIs.
 
 ## ANTI-PATTERNS
 
-- Recomputing complete message trees per streaming delta — memoization in the assistant/tool renderers is load-bearing.
-- Writing to stdout directly, or emitting arbitrary ANSI. Only established terminal-protocol markers (OSC 133 zones in `assistant-message.ts`) are allowed.
-- Inline key literals instead of `../../core/keybindings.ts` routing.
-- Adding a render path without width, theme, and cancellation states.
+- Resetting `ProgressiveTranscriptContainer`'s hydration watermark during incremental rendering.
+- Resolving `DynamicBorder` colors implicitly across jiti module caches instead of passing the active theme color.
+- Widening the public barrel merely because an internal helper is exported from its implementation file.
 - Hiding the tree gutter/current leaf, or dropping required footer model/context segments during truncation.

--- a/packages/coding-agent/src/modes/interactive/theme/AGENTS.md
+++ b/packages/coding-agent/src/modes/interactive/theme/AGENTS.md
@@ -1,0 +1,35 @@
+# modes/interactive/theme
+
+## OVERVIEW
+Shared theme-runtime domain (score 8): schema-backed colors, cross-loader theme identity, terminal detection, and interactive auto switching.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Theme schema, colors, loaders, adapters | `theme.ts` |
+| Persisted selection, preview, auto-sync | `theme-controller.ts` |
+| External JSON validation contract | `theme-schema.json` |
+| Builtin palettes | `dark.json`, `light.json`, `grok-day.json`, `grok-night.json` |
+| Grok token consumer | `../grok/chrome-tokens.ts` |
+
+## CONVENTIONS
+
+- The exported `theme` is a proxy over a `globalThis` symbol, allowing tsx and jiti module instances to share the active theme.
+- Updates set both current and legacy symbol keys; a loader-local singleton is not equivalent.
+- The proxy throws before initialization; initialize through `initTheme` before rendering consumers.
+- Invalid theme loading falls back to dark; `setTheme` reports failure to callers while retaining that usable fallback.
+- Automatic light/dark selection reserves `/` in setting syntax, so individual theme names cannot contain `/`.
+- Auto detection prioritizes terminal color-scheme reporting and concurrently starts background-color fallback detection.
+- `InteractiveThemeController` owns terminal color-scheme subscriptions and rebinds them when the TUI changes.
+- Explicit single-theme selection disables auto-sync; preview resolves a candidate without committing the selection.
+- Syntax highlighting validates language names before invoking `cli-highlight` to avoid stderr noise.
+- Derived highlight themes and file-watch state are cached separately from the public proxy.
+
+## ANTI-PATTERNS
+
+- Replacing the shared global-symbol lookup with a module-local active-theme variable.
+- Persisting a low-confidence environment guess as if it were a detected terminal preference.
+- Allowing slash-containing names that collide with automatic theme-pair settings.
+- Leaving an old terminal color-scheme listener attached after rebinding the TUI.
+- Calling the highlighter with an unvalidated language identifier.

--- a/packages/coding-agent/src/modes/rpc/AGENTS.md
+++ b/packages/coding-agent/src/modes/rpc/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/modes/rpc
 
-JSONL-over-stdio RPC mode for driving Senpi sessions programmatically (TUI-less). One UTF-8 JSON object per LF-delimited line; requests in, events out. The public protocol reference is `packages/coding-agent/docs/rpc.md`.
+JSONL RPC domain (score 9): classic stdio plus a shared, worker-backed session host over stdio or sockets. One UTF-8 JSON object per LF-delimited line; requests in, events out. The public protocol reference is `packages/coding-agent/docs/rpc.md`.
 
 ## STRUCTURE
 
@@ -8,15 +8,19 @@ JSONL-over-stdio RPC mode for driving Senpi sessions programmatically (TUI-less)
 rpc-mode.ts               Mode entry: session binding, main loop
 connection-handler.ts     Connection lifecycle; owns the command-digest baseline,
                           get_commands responses, commands_changed emission
-jsonl.ts                  Strict LF framing; MAX_RPC_LINE_CHARACTERS (16 MiB)
+jsonl.ts                  Strict LF framing; MAX_RPC_LINE_CHARACTERS (16 * 1024 * 1024 chars)
                           ceiling with oversized-record resynchronization
 rpc-input-validation.ts   Inbound bounds: MAX_RPC_MESSAGE_CHARACTERS (1,000,000)
 rpc-command-surface.ts    RpcSlashCommand snapshot, digest, baseline comparison
 rpc-command-invocation.ts command_invocation / skill_invocation event types
-multi-session-host.ts     Multi-session RPC host
+multi-session-host.ts     Shared RPC host; unlimited logical session admission
 session-binding.ts, session-registry.ts, session-command-router.ts,
 session-event-writer.ts, session-extension-ui-requests.ts   Session wiring
 rpc-client.ts, rpc-types.ts, custom-capability.ts, event-output-buffer.ts
+host-ensure.ts, host-lifecycle.ts, host-watchdog.ts          Host supervision
+ownership-safe-lock.ts, socket-ownership.ts, socket-transport.ts  Ownership/auth
+session-worker*.ts, worker-session-registry.ts              Worker IPC/lifecycle
+session-event-fanout.ts, socket-event-fanout.ts              Attachment-scoped delivery
 changes.md                Fork-specific RPC behavior record
 ```
 
@@ -34,6 +38,9 @@ changes.md                Fork-specific RPC behavior record
 - Inbound messages over `MAX_RPC_MESSAGE_CHARACTERS` are rejected with a typed error; non-object JSON is rejected.
 - Pending work is rejected on disconnect or child exit; preserve request/response correlation.
 - Child stderr is emitted and embedded raw; treat diagnostics as secret-bearing.
+- Session admission has no fixed eight-session cap; idle eviction and empty-host exit reclaim resources. Quarantined workers retain ownership until exit.
+- A socket peer's overflow/stall must not consume shared worker credit or terminate other attachments; keep backpressure and fanout peer-scoped.
+- Socket teardown checks ownership tokens and process identity, not just the pathname. Explicitly empty client capabilities override launch defaults.
 
 ## WHERE TO LOOK
 
@@ -43,11 +50,13 @@ changes.md                Fork-specific RPC behavior record
 | Change framing or input bounds | `jsonl.ts`, `rpc-input-validation.ts` |
 | Invocation metadata on prompts | `rpc-command-invocation.ts` |
 | Session wiring / multi-session | `session-*.ts`, `multi-session-host.ts` |
+| Shared-host startup / ownership | `host-ensure.ts`, `host-lifecycle.ts`, `socket-ownership.ts` |
+| Worker quarantine / socket stalls | `session-command-router.ts`, `session-event-writer.ts`, fanout modules |
 | Protocol documentation | `packages/coding-agent/docs/rpc.md` |
 
 ## VALIDATION
 
-- Focused tests live in `packages/coding-agent/test/rpc-*.test.ts` (rpc-jsonl, rpc-input-validation, rpc-command-invocation, rpc-commands-changed, rpc-multi-session-input, rpc-loaded-surfaces, rpc-classic-compat, rpc-prompt-response-semantics).
+- Focused tests span `packages/coding-agent/test/rpc-*.test.ts` and `test/suite/rpc-*.test.ts` (worker capacity/isolation, socket stalls/ownership, auth, UI, and classic protocol contracts). Use the package's Vitest script: `bun run --cwd packages/coding-agent test -- <test-path>`, not bare `bun test`.
 - End-to-end scenarios: `.agents/skills/senpi-qa/scripts/scenarios/dollar-skill-invocation-qa.mjs` and `rpc-input-hardening-qa.mjs`.
 - Behavior changes update `changes.md` here and `docs/rpc.md` in the same increment.
 - Runtime changes require root `bun run check` and real CLI QA evidence.

--- a/packages/coding-agent/src/utils/AGENTS.md
+++ b/packages/coding-agent/src/utils/AGENTS.md
@@ -1,15 +1,15 @@
 # packages/coding-agent/src/utils
 
-Cross-cutting utilities used by `core/`, `cli/`, `modes/`, and `extensions/`. No domain logic — only deterministic helpers. 29 source files, all leaf-level.
+Cross-cutting platform, parsing, image, and management-I/O helpers used by `core/`, `cli/`, `modes/`, and `extensions/`. 34 implementation files + one TypeScript declaration, all leaf-level. Score 12 — shared utility boundary with high import fan-in.
 
 ## FILES (grouped by concern)
 
 ```
 utils/
-├── git.ts                       # git CLI wrapper (status, diff, stash, commit, current branch)
-├── shell.ts                     # Spawn + capture; safe arg quoting
-├── child-process.ts             # Lower-level spawn helpers used by shell.ts
-├── paths.ts                     # Resolve repo root, home expansion, glob helpers
+├── git.ts                       # Parse package Git sources, refs, and safe host/repository paths
+├── shell.ts                     # Shell selection/env, output sanitization, process-tree termination
+├── child-process.ts             # cross-spawn wrappers + abort-aware child completion
+├── paths.ts                     # Canonicalization, open-free symlink resolution, path normalization
 ├── fs-watch.ts                  # File watcher (used by reload + extension HMR)
 ├── open-browser.ts              # Open URL/file via platform handler; never goes through a shell
 ├── mime.ts                      # File extension → MIME type
@@ -20,18 +20,25 @@ utils/
 ├── image-resize-core.ts         # Photon resize implementation shared by main thread + worker
 ├── image-resize-worker.ts       # worker_threads entry wrapping image-resize-core
 ├── image-convert.ts             # Image format conversion
+├── image-process.ts             # Shared conversion/resize pipeline
+├── tool-result-images.ts        # Normalize tool-result image blocks
 ├── exif-orientation.ts          # EXIF rotation correction
-├── photon.ts                    # @cf/photon WASM bootstrap
+├── photon.ts                    # @silvia-odwyer/photon-node WASM bootstrap
 ├── ansi.ts                      # ANSI escape regex + stripAnsi (vendored from ansi-regex/strip-ansi)
 ├── html.ts                      # HTML entity decoding
 ├── json.ts                      # stripJsonComments — strip // comments + trailing commas
 ├── syntax-highlight.ts          # highlight.js wrapper → themed terminal formatting
+├── highlight-js.d.ts            # highlight.js language-module declarations
 ├── frontmatter.ts               # YAML frontmatter parser (skills, prompt templates)
 ├── sleep.ts                     # Promise-returning timer with abort
+├── abort.ts                     # Operation signals + abort races
+├── text.ts                      # Leading UTF-8 BOM normalization
+├── duration.ts                  # Human-readable duration formatting
 ├── deprecation.ts               # One-shot deprecation warnings (deduped by message)
 ├── tools-manager.ts             # Probe + cache fd/rg presence for startup-tools
 ├── changelog.ts                 # Parse + render the senpi CHANGELOG.md
 ├── version-check.ts             # Senpi latest-version fetch (queries senpi npm, NOT pi.dev)
+├── management-http.ts           # Bounded retries for idempotent management requests
 ├── pi-user-agent.ts             # UA string for update checks; uses runtime app name
 ├── windows-self-update.ts       # Quarantines locked native files so Windows self-update can replace them
 └── changes.md                   # Fork tracker (version-check + pi-user-agent rebrand)
@@ -41,8 +48,8 @@ utils/
 
 | Task | File |
 |------|------|
-| Run a shell command from senpi internals | `shell.ts` — uses `child-process.ts` under the hood |
-| Resolve a path safely | `paths.ts` |
+| Select a shell / spawn a child | `shell.ts` for configuration; `child-process.ts` for spawn/wait |
+| Resolve a path safely | `paths.ts` — strict variants for trust/containment; open-free variants avoid automounts |
 | Detect fd/rg at startup | `tools-manager.ts` (cached, non-blocking; see `modes/interactive/startup-tools.ts`) |
 | Parse a skill / prompt template | `frontmatter.ts` |
 | Image-related work (paste, attachment) | `image-resize.ts`, `image-convert.ts`, `exif-orientation.ts` |
@@ -66,4 +73,6 @@ utils/
 
 - `photon.ts` is a WASM module; first call has a small init cost (cached). Don't move it into the streaming hot path.
 - `tools-manager.ts` powers the fork's non-blocking startup probe (vs. upstream's awaited fd/rg download). See `modes/interactive/changes.md`.
-- `frontmatter.ts` is shared by skill discovery (in `core/resource-loader.ts`) and prompt-template loading; keep its YAML subset deterministic.
+- `frontmatter.ts` uses `yaml.parse`, strips a leading BOM, and is shared by skills and prompt templates.
+- `management-http.ts` retries idempotent version/catalog/download requests, never model operations; caller abort and the overall timeout are terminal.
+- `realpathWithoutOpen` tolerates resolution errors; `realpathWithoutOpenStrict` tolerates missing components only. Do not use an approximate path as proof of containment.

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/test
 
-Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and regressions. New default tests must be deterministic and must not spend tokens.
+Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and regressions. Score 14 — shared harness and quarantine boundary. New default tests must be deterministic and must not spend tokens.
 
 ## STRUCTURE
 
@@ -13,29 +13,29 @@ compaction/        Compaction mechanics and policy (own AGENTS.md)
 session-manager/   Persistence, branching, context construction
 dynamic-prompt/    Dynamic system-prompt + workstation fact coverage
 tool-pair-guard/   Provider payload tool-pair sanitization tests
-client/            RPC/app-server client coverage
-server/            App-server/server surface coverage
+client/            RemoteSession ownership/lifecycle + transcript projection
+server/            CodingAgentHarness construction + system-prompt resolution
 extensions/        Extension loading and API behavior
 cursor-cli-oauth/  Cursor CLI OAuth provider-lane coverage (own AGENTS.md)
 tool-search/       Shared tool-catalog / `tool_search` exposure coverage
-grok/              Grok provider coverage
+grok/              Grok TUI chrome, themes, layout, and render goldens
 ttsr/              Stream-rule (ttsr) extension coverage
-support/           Shared test support modules
-helpers/           Shared subprocess/QA/fixture helpers
+support/           Quarantine, build prerequisites, provider-wire fixtures (own AGENTS.md)
+helpers/           Shared subprocess/QA/fixture helpers (own AGENTS.md)
 benchmarks/        Perf-oriented probes (not part of the default correctness gate)
 examples/          Coverage for the shipped `examples/` extensions
-manual-qa/         Explicit manual QA scripts (not part of default suite)
+manual-qa/         Standalone QA scripts plus two discoverable *.test.ts suites
 qa/app-server/     Real app-server surface drivers (own AGENTS.md)
 integration/       Explicitly gated real-provider tests
 fixtures/, goldens/ Shared deterministic inputs and snapshots
 model-runtime*.test.ts / models-store.test.ts / remote-catalog-provider.test.ts / runtime-credentials.test.ts
                    Model/catalog/auth runtime coverage
 claude-sdk-oauth-*.test.ts
-                   Flat cluster (51 files) at test/ root covering the Claude SDK
+                   Flat cluster (57 test files) at test/ root covering the Claude SDK
                    OAuth provider extension
 ```
 
-The flat `test/*.test.ts` root cluster (~350 files) is legacy/feature-focused placement.
+The flat `test/` root cluster (492 TypeScript files, including helpers/probes) is legacy/feature-focused placement.
 New lifecycle and extension coverage belongs in `suite/`, not at this root.
 Legacy root helpers: `test-harness.ts` (superseded), `utilities.ts`, `model-runtime-test-utils.ts`,
 `test-network-env.ts`, `test-theme-colors.ts`. `setup.ts` is the quarantine entry (see below).
@@ -49,31 +49,31 @@ Legacy root helpers: `test-harness.ts` (superseded), `utilities.ts`, `model-runt
 - Some legacy tests outside `integration/` still activate from ambient Anthropic credentials. Run the suite hermetically and do not copy that activation pattern into new tests.
 - Use `suite/regressions/<issue>-<slug>.test.ts` for issue regressions.
 - Do not extend the legacy `test-harness.ts` unless the preferred harness lacks a required capability.
-- Keep fixtures deterministic, local, and secret-free. Spawned process tests must clean up children, sockets, and temporary directories.
-- Tests involving PTY, MCP, app-server, or other subprocess-heavy surfaces must remain reliable with `CI=1`, where Vitest uses one fork.
+- Keep fixtures deterministic, local, and secret-free. Subscribe to the exact event/state before triggering async work; await it with a bounded timeout, not a sleep or polling delay. Spawned tests must clean up children, sockets, and temporary directories.
+- With `CI=1` or `GITHUB_ACTIONS`, Vitest uses two forks (`maxWorkers: 2`, 20s teardown). Dist-dependent subprocess suites opt into `support/workspace-build-prerequisite.ts`; in-process source aliases do not prove child imports are built.
 
 ## QUARANTINE CONTRACT (load-bearing)
 
-`test/setup.ts` resolves the agent directory through `test/support/quarantine.ts`'s `resolveQuarantineAgentDir`, then calls `scrubAmbientAgentDirEnv` to delete the brand marker (`SENPI_BRAND`) and **every** `*_CODING_AGENT_DIR` lane before pinning the quarantined `SENPI_CODING_AGENT_DIR`. The quarantine **always wins** over any inherited agent-dir env, opting out only with an explicit `SENPI_TEST_USE_REAL_AGENT_DIR=1` paired with the target dir. This is not a courtesy — it is a safety boundary.
+`test/setup.ts` resolves the agent directory through `test/support/quarantine.ts`'s `resolveQuarantineAgentDir`, then calls `scrubAmbientAgentDirEnv` to delete the brand marker (`SENPI_BRAND`) and **every** `*_CODING_AGENT_DIR` / `*_PACKAGE_DIR` lane before pinning the quarantined `SENPI_CODING_AGENT_DIR`. The quarantine **always wins** over any inherited agent-dir env, opting out only with an explicit `SENPI_TEST_USE_REAL_AGENT_DIR=1` paired with the target dir. This is not a courtesy — it is a safety boundary.
 
 - The omo launcher (`omo-ai/bin/lib/launcher.js` → `senpiEnvironment`) sets `OMO_CODING_AGENT_DIR`, `SENPI_CODING_AGENT_DIR`, and `SENPI_BRAND` for **every** spawned child session, and tool children inherit all three. Any `vitest` run launched from inside an omo agent session inherits values pointing at the user's REAL `~/.omo/agent`.
 - Guarding only the `SENPI_` lane is not enough: with the omo brand active, `brandEnvNames` resolves `OMO_CODING_AGENT_DIR` first, so `getAgentDir()` bypassed the quarantine and `settings-tips.test.ts` wiped the live `~/.omo/agent/settings.json` again on 2026-08-25 (reproduced pre-fix against a decoy dir; post-fix the decoy stays intact). The scrub of all lanes plus the brand marker is what closes this; never narrow it back to a single-lane guard, and never reintroduce an `if (!process.env.SENPI_CODING_AGENT_DIR)` short-circuit here.
 - Before this guard always won, an inherited env made the whole suite run against the real config and tests deleted `~/.omo/agent/settings.json` (proven live 2026-08-18: favorite-guard ENOENT crashes matched suite-run windows exactly).
 - To target a specific real directory in a test, pass the agent dir explicitly to `SettingsManager.create` / `SessionManager.create` rather than relying on the ambient env. Use `SENPI_TEST_USE_REAL_AGENT_DIR=1` only for the rare whole-suite opt-in.
-- Tests that spawn the CLI as a subprocess must set `SENPI_CODING_AGENT_DIR` to a temp dir in the child env explicitly (see `test/helpers/rpc-hermetic.ts`); never let the child inherit an unguarded ambient value.
+- Tests that spawn the CLI must scrub branded agent/package overrides and explicitly pin a temp `SENPI_CODING_AGENT_DIR` in the child env; never inherit an unguarded ambient value. Package-dir overrides otherwise load installed runtime assets instead of this checkout.
 
 ## LIVE AND MANUAL SURFACES
 
 - `integration/` is opt-in only with `PI_RUN_INTEGRATION=1`; it may use real credentials and incur cost.
-- `qa/app-server/` contains focused real-surface drivers. The separate `bun run qa:app-server` command runs the packaged handshake, multiclient, approval, and real-client probes.
+- `qa/app-server/` contains focused real-surface drivers. The separate `bun run --cwd packages/coding-agent qa:app-server` command runs the packaged handshake, multiclient, approval, and real-client probes.
 - Runtime changes covered here still require the repository's `senpi-qa` evidence gate when the root guide requires it.
 
 ## VALIDATION
 
-- Run every added or changed test file directly until green.
+- Run every added or changed test file directly; make one run reliable rather than retrying timing-dependent failures.
 - Run the narrow owning directory or package suite when shared harnesses, fixtures, or lifecycle behavior change.
 - Package runner is Vitest: `bun run --cwd packages/coding-agent test <path>` (the `test` script already passes `--run`; passing it again makes vitest reject the duplicated flag).
 - Root `bun run check` is static validation and does not replace tests.
 
 ---
-Generated: 2026-08-24 | Commit: `baf15a54d`
+Refreshed: 2026-09-10

--- a/packages/coding-agent/test/compaction/AGENTS.md
+++ b/packages/coding-agent/test/compaction/AGENTS.md
@@ -1,6 +1,6 @@
 # test/compaction
 
-Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, routing, retry/degradation, tool-pair repair, and OpenAI remote compaction. 57 files / ~13,100 LOC, ~612 test call sites. Score 15 — distinct policy domain with numeric constants pinned as contracts.
+Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, routing, retry/degradation, tool-pair repair, and OpenAI remote compaction. 71 TypeScript files / ~16,900 LOC. Score 7 — existing focused policy guide retained in UPDATE mode; numeric constants are pinned as contracts.
 
 ## WHERE TO LOOK
 
@@ -9,9 +9,11 @@ Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, rout
 | Extension wiring / handlers | `*-characterization.test.ts`, tests importing `src/core/extensions/builtin/compaction/index.ts` |
 | Speculative warm-start | `speculative-compaction.test.ts` (848 LOC), `speculative-budget-handoff.test.ts`, `stale-context-idle-warmup.test.ts`, `stale-warm-blocking-repro.test.ts` |
 | OpenAI remote route | `openai-remote-compaction.test.ts` (1,160 LOC), `openai-remote-abort-standdown.test.ts`, shared fixtures in `openai-remote-test-models.ts` |
-| Checkpoint provenance | `canonical-routes.test.ts` (1,017 LOC) |
+| Checkpoint provenance | `canonical-routes.test.ts`, `agent-checkpoint.test.ts` |
 | Deterministic degradation | `required-compaction-deterministic-fallback.test.ts`, `summarization-body-too-large.test.ts` |
-| Thresholds / budgets | `adaptive-threshold.test.ts`, `context-reduction.test.ts`, `hard-limit-emergency.test.ts`, `idle-compaction.test.ts` |
+| Thresholds / budgets | `adaptive-threshold.test.ts`, `speculation-lead.test.ts`, `large-window-tiers.test.ts`, `threshold-clamp-bounds.test.ts` |
+| Admission / lane ownership | `tool-admission.test.ts`, `lane-policy.test.ts`, `external-owner-breaker-isolation.test.ts` |
+| Required-compaction failures | `before-compact-error-surfacing.test.ts`, `compaction-reason-surfacing.test.ts`, `blocking-compaction-route-guards.test.ts` |
 | Tool-call pairing | `tool-pair-repair.test.ts`, `todo-preservation.test.ts` |
 | Restoration bookkeeping | `restoration-tracker.test.ts` |
 
@@ -22,7 +24,7 @@ Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, rout
 - File names encode route, failure mode, boundary, or incident (`blocking-*`, `stale-*`, `summarization-*`, `openai-remote-*`, `*-characterization`) — deliberately not one-file-per-source-module.
 - Session-manager entries are constructed explicitly (`type`, `id`, `parentId`, `timestamp`, payload), often as complete OpenAI-native branches, to verify replay and provenance.
 - Compaction is exercised through extension harnesses and event callbacks (`beforeAgentStart`, `sessionBeforeCompact`, `agentEnd`, context hooks), not by calling pure functions alone. Provider request/header/context hooks are installed to validate the final pipeline plus redaction.
-- Assertions inspect machine values: route/transport, payload input, persisted details, revisions, reasons, emitted events. Numeric policy constants (37.5% speculative threshold, adaptive ratios, context windows, retry bounds, hard caps) are literal contracts — changing a constant means changing these tests deliberately.
+- Assertions inspect machine values: route/transport, payload input, persisted details, revisions, reasons, emitted events. Numeric policy constants (adaptive ratios, speculation lead, context windows, retry bounds, hard caps) are literal contracts — changing a constant means changing these tests deliberately.
 - Remote OpenAI coverage distinguishes the direct compact endpoint from the Responses WebSocket route and validates provenance against endpoint, stable headers, auth tenant, hook-filtered prefixes, and model identity.
 
 ## ANTI-PATTERNS
@@ -37,6 +39,6 @@ Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, rout
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/compaction/<file>.test.ts
-bun run --cwd packages/coding-agent test --run test/compaction
+bun run --cwd packages/coding-agent test test/compaction/<file>.test.ts
+bun run --cwd packages/coding-agent test test/compaction
 ```

--- a/packages/coding-agent/test/cursor-cli-oauth/AGENTS.md
+++ b/packages/coding-agent/test/cursor-cli-oauth/AGENTS.md
@@ -1,6 +1,6 @@
 # test/cursor-cli-oauth
 
-Provider-lane coverage for the Cursor CLI OAuth extension: accounts, settings, executable resolution, spawn args, stream parsing, session routing, failover, guardrails, shutdown. 27 tests / ~7,000 LOC + committed CLI captures. Score 12 — distinct provider domain with a replay-fixture contract nothing else in `test/` uses.
+Provider-lane coverage for the Cursor CLI OAuth extension: accounts, settings, executable resolution, spawn args, stream parsing, session routing, failover, guardrails, shutdown. 27 test files / ~6,400 TypeScript LOC + committed CLI captures. Score 7 — existing provider/replay-fixture guide retained in UPDATE mode.
 
 ## STRUCTURE
 
@@ -16,15 +16,17 @@ fixtures/cursor-agent-models.txt   model-listing capture
 
 | Task | Location |
 |------|----------|
-| Account slots, pinning, failover | `account-command.test.ts` (463 LOC), `accounts.test.ts`, `affinity.test.ts` |
-| Stream event mapping | `stream.test.ts` (627 LOC) — usage isolation, tool rendering, failover, guardrails |
-| Resume / fresh-chat / recap | `session-router.test.ts` (423 LOC) |
-| Token/context ownership | `context-ownership.test.ts` (450 LOC) |
+| Account slots, pinning, failover | `account-command.test.ts`, `accounts.test.ts`, `affinity.test.ts` |
+| Stream event mapping | `stream.test.ts` — usage isolation, tool rendering, failover, guardrails |
+| Resume / fresh-chat / recap | `session-router.test.ts` |
+| Token/context ownership | `context-ownership.test.ts` |
 | Executable probe + bootstrap | `executable.test.ts`, `native-bootstrap.test.ts` |
-| Login and ambient opt-in | `oauth-login.test.ts`, `ambient-optin.test.ts`, `nonthrowing-checks.test.ts` |
-| Process lifecycle | `transport.test.ts`, `shutdown.test.ts`, `fixture-process.test.ts` |
+| Login and ambient opt-in | `oauth-login.test.ts`, `ambient-opt-in.test.ts`, `check-nonthrowing.test.ts` |
+| Process lifecycle | `transport.test.ts`, `shutdown.test.ts`, `fixture.test.ts` |
+| Model/reasoning resolution | `models.test.ts`, `reasoning-catalog.test.ts`, `reasoning-model-string.test.ts` |
+| Spawn serialization / settings cache | `spawn-args.test.ts`, `settings-cache.test.ts` |
 
-Highest production fan-in: `accounts.ts` (11 test files), `settings.ts` (8), `index.ts` (5), `executable.ts` (5), `oauth-login.ts` (4).
+Production seams live in `src/core/extensions/builtin/cursor-cli-oauth/`; account/settings modules feed multiple lifecycle and routing tests.
 
 ## CONVENTIONS
 
@@ -41,11 +43,12 @@ Highest production fan-in: `accounts.ts` (11 test files), `settings.ts` (8), `in
 - Never spawn when the lane is disabled, no account is bound, or force acknowledgement is missing.
 - Malformed/unknown stream frames and zero-output "success" are failures, not empty successes.
 - Fresh-chat retry is bounded; transcript text must not persist beyond the recap window; CLI-reported usage must never land in assistant usage fields.
-- `shutdown.test.ts` / `transport.test.ts` use interval-and-timeout PID death observation — that is process-lifecycle synchronization at a real OS boundary, not a pattern to copy into ordinary async tests.
+- `shutdown.test.ts` / `transport.test.ts` contain legacy PID polling; do not copy it. New lifecycle tests subscribe to child exit/close or explicit fixture acknowledgements before triggering shutdown.
+- `buildCursorCliArgs` serializes the supplied `force` even in plan mode; force policy belongs to the caller, not this argv builder.
 
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/cursor-cli-oauth/<file>.test.ts
-CI=1 bun run --cwd packages/coding-agent test --run test/cursor-cli-oauth
+bun run --cwd packages/coding-agent test test/cursor-cli-oauth/<file>.test.ts
+CI=1 bun run --cwd packages/coding-agent test test/cursor-cli-oauth
 ```

--- a/packages/coding-agent/test/helpers/AGENTS.md
+++ b/packages/coding-agent/test/helpers/AGENTS.md
@@ -1,0 +1,37 @@
+# test/helpers
+
+## OVERVIEW
+
+Shared subprocess, provider, compaction, and UI fixtures. Score 9 - distinct cross-suite harness domain; AST inspection finds 34 references to `createInMemoryExtensionSessionSettings`.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Fake Anthropic-compatible HTTP model | `rpc-fake-model.ts` - `startFakeModelServer`, request capture, mock provider/model IDs |
+| CLI RPC session + models.json | `rpc-hermetic.ts` - `startHermeticRpcSession`, `hermeticProviderEnv`, `writeRpcModelsJson` |
+| Child exit and root cleanup | `process-teardown.ts` - `teardownChildProcessesAndRoots` |
+| Localhost QA listener | `qa-port.ts` - `listenOnQaPort`, `qaPortsFrom`, `QaPort` |
+| In-memory extension settings | `extension-session-settings.ts` - facade backed by `SettingsManager.inMemory`, `HARD_LIMIT_SETTINGS` |
+| Blocking compaction extension context | `blocking-compaction-harness.ts` |
+| Scripted Claude SDK query / account lane | `claude-sdk-oauth-scripted-sdk.ts` |
+| Claude resident restart fixtures | `claude-sdk-oauth-restart-fixture.ts`, `claude-sdk-oauth-local-probe.ts` |
+| ESM import-graph probes | `esm-import-graph-probe.ts` |
+| Stream reveal / footer rendering | `streaming-reveal.ts`, `footer-test-fixtures.ts` |
+
+## CONVENTIONS
+
+- Helpers export directly from individual files; no barrel owns this fixture surface.
+- `hermeticProviderEnv` blanks its explicit provider-key list. It does not scrub branded agent/package directory overrides; that separate contract is in the parent guide.
+- `startHermeticRpcSession` writes a fake-model catalog and launches the source CLI through `RpcClient`; its `close` stops the client, closes the fake server, then removes session state.
+- `teardownChildProcessesAndRoots` consumes its input arrays, sends TERM, awaits exit, escalates to KILL on the bounded deadline, and removes roots only after children exit.
+- Cooperative children can supply `awaitTermAcknowledged`; register acknowledgement observation before triggering teardown so the exit deadline does not race cleanup side effects.
+- `listenOnQaPort` binds loopback using the typed 18990-18999 fallback set and reports every failed candidate if exhausted.
+- `HARD_LIMIT_SETTINGS.toolAdmissionEnabled = false` deliberately pins the pre-admission blocking-compaction path; changing it changes the test seam.
+
+## ANTI-PATTERNS
+
+- `rpc-hermetic.ts` still has a 200ms `waitForSessionWrites` sleep. It is legacy reliability debt, not a persistence-completion signal to reuse in new tests.
+- Do not remove roots while a child can still write into them or bypass teardown's post-KILL failure.
+- Do not replace the in-memory settings facade with inert setters: tests depend on updates and flushes reaching the backing SettingsManager.
+- Do not turn fake-model wire fixtures into full provider mocks when the assertion concerns RPC, stream framing, or child-process behavior.

--- a/packages/coding-agent/test/mcp/AGENTS.md
+++ b/packages/coding-agent/test/mcp/AGENTS.md
@@ -1,6 +1,6 @@
 # test/mcp
 
-MCP transport, lifecycle, OAuth, exposure, and configuration coverage plus the fixture servers/workers that back it. 48 top-level files + `fixtures/` (15 modules, 2 schema JSON). Score 16 — the only test subtree that ships its own runnable MCP servers and fault-injection harness.
+MCP transport, lifecycle, OAuth, exposure, and configuration coverage plus the fixture servers/workers that back it. 48 top-level files + `fixtures/` (15 modules, 2 schema JSON). Score 12 — distinct protocol-fixture domain with highly reused runnable servers and fault-injection helpers.
 
 ## STRUCTURE
 
@@ -29,7 +29,7 @@ fixtures/schema/       nasty-input.schema.json + nasty-input.typebox.golden.json
 
 - Every test creates an isolated temporary root/config and resets the singleton MCP service between cases (`getMcpService` / `resetMcpServiceForTests`). Skipping the reset leaks connections into the next file.
 - Fixture servers expose capabilities deliberately (tools, resources, prompts, logging, list-changed, subscriptions) and take argv flags for crashes, wedges, delays, expiry, counters, bearer tokens, huge output/schema, and list changes. Add new failure modes as flags in `fixtures/options.ts`, not as new servers.
-- Async waits go through named helpers (`waitForCondition`, `awaitMcpToolRegistration`, service/session attach helpers) — never inline timers.
+- `waitForCondition` and `awaitMcpConnected` currently poll every 25ms; they are legacy synchronization debt, not templates. New async coverage registers exact connection/registration/fixture signals before the action and awaits them with a bounded timeout.
 - The harness does **not** emit `session_start` automatically; attach and await the lifecycle signal before asserting.
 - Test names/comments carry numbered TODO tracks (todo 27, 29-42); coverage is split one file per concern.
 - JSON schema fixtures live beside their golden typebox output; regenerate both together.
@@ -46,6 +46,6 @@ fixtures/schema/       nasty-input.schema.json + nasty-input.typebox.golden.json
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/mcp/<file>.test.ts
-CI=1 bun run --cwd packages/coding-agent test --run test/mcp   # subprocess-heavy: one fork
+bun run --cwd packages/coding-agent test test/mcp/<file>.test.ts
+CI=1 bun run --cwd packages/coding-agent test test/mcp
 ```

--- a/packages/coding-agent/test/permission/AGENTS.md
+++ b/packages/coding-agent/test/permission/AGENTS.md
@@ -1,29 +1,30 @@
 # test/permission
 
-Permission-system coverage: parsers, evaluation, presets, config merge/expand, service lifecycle, persistence, CLI, and non-interactive handling. 15 files / ~6,000 LOC. Score 11 — distinct domain, dense end-to-end scenarios that no parent file can summarize.
+Permission-system coverage: parsers, evaluation, presets, config merge/expand, service lifecycle, persistence, CLI, and non-interactive handling. 17 test files / ~6,200 LOC. Score 4 — existing focused permission guide retained in UPDATE mode for ordered-rule and cross-mode contracts.
 
 ## WHERE TO LOOK
 
 | Task | Location |
 |------|----------|
-| Full pipeline scenarios | `integration.test.ts` (1,513 LOC, 15 numbered scenarios + evaluate/expand/merge/parser/non-interactive cases) |
-| Cross-mode UI vs no-UI cascade | `multi-mode.test.ts` (841 LOC) |
-| Request lifecycle + events | `service.test.ts` (515 LOC) — `ask`/`reply`/`list`/`getApproved`, event emission, defensive copies, insertion order |
-| Arity/pattern matching | `arity.test.ts` (566 LOC) |
-| Rule parsing | `parsers.test.ts` — `createBuiltinParserRegistry` |
+| Full pipeline scenarios | `integration.test.ts` — numbered scenarios + evaluate/expand/merge/parser/non-interactive cases |
+| Cross-mode UI vs no-UI cascade | `multi-mode.test.ts` |
+| Request lifecycle + events | `service.test.ts`, `events.test.ts` — `ask`/`reply`/`list`/`getApproved`, defensive copies, insertion order |
+| Arity/pattern matching | `arity.test.ts` |
+| Rule parsing / tool schema drift | `parsers.test.ts`, `parser-contracts.test.ts` — `createBuiltinParserRegistry` |
 | Config shape | `config.test.ts` — `fromConfig`, `merge`, `expand`, `disabled` |
 | Presets | `presets.test.ts` — `rulesForPreset` |
 | Persistence | `storage.test.ts`, `settings.test.ts` — JSONL load/save |
-| Headless behavior | `non-interactive.test.ts` — `handleNoUI` |
+| Headless behavior | `multi-mode.test.ts`, `integration.test.ts` — `handleNoUI` |
 | CLI surface | `cli.test.ts` |
-| External path handling | `external-path.test.ts` |
+| External path handling | `external-dir.test.ts`, `external-dir-resolution.test.ts`, `external-path-presets.test.ts` |
+| Monitor parent authorization | `monitor-parser-parent.test.ts` |
 
 ## CONVENTIONS
 
 - Permission behavior is expressed as **ordered** rules `{permission, pattern, action}` plus a separate `always` pattern list. Tests assert precedence, wildcard/glob matching, session scoping, and JSONL persistence — order is the contract, not a detail.
 - Services are constructed with injected fakes (`createLocalEventEmitter`, fake models/contexts) and isolated `mkdtemp` roots cleaned in `afterEach`; no ambient global state.
 - Both `describe`+`it` and `describe`+`test` appear; hooks and `vi` are imported per file rather than relying on globals.
-- Shared session/auth/resource fixtures come from the parent `../utilities.ts` (`createTestSession`, `createTestResourceLoader`, `createTestExtensionsResult`, `loadAuthStorage`).
+- Request/service/context fixtures are file-local; this subtree does not import `../utilities.ts`. External-path tests use real symlinks and directory modes to exercise filesystem resolution.
 
 ## ANTI-PATTERNS
 
@@ -31,10 +32,11 @@ Permission-system coverage: parsers, evaluation, presets, config merge/expand, s
 - Do not assert permission outcomes by timing; the pipeline is synchronous evaluation plus event-driven reply, so subscribe before asking and await the reply.
 - Do not bypass the parser registry when adding a rule form; new syntax is registered, then evaluated, then persisted, and all three layers have tests.
 - Do not weaken defensive-copy or insertion-order guarantees in `service.test.ts` to accommodate an implementation change.
+- External-path classification must not open path components: Bun realpath can block on automounts or fail on execute-only directories. Preserve the lstat/readlink boundary.
 
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/permission/<file>.test.ts
-bun run --cwd packages/coding-agent test --run test/permission
+bun run --cwd packages/coding-agent test test/permission/<file>.test.ts
+bun run --cwd packages/coding-agent test test/permission
 ```

--- a/packages/coding-agent/test/qa/app-server/AGENTS.md
+++ b/packages/coding-agent/test/qa/app-server/AGENTS.md
@@ -1,13 +1,13 @@
 # test/qa/app-server
 
-Real-surface app-server QA drivers. 47 files + `differential/`. Score 14 — distinct domain: these are **standalone executable scenarios**, not Vitest suites, and they are excluded from the default correctness gate.
+Real-surface app-server QA drivers. 47 direct files + `differential/`. Score 9 — distinct domain: task scenarios are **standalone executables**; `task8-thread-search-support.test.ts` is the Vitest exception.
 
 ## STRUCTURE
 
 ```text
 task<N>-<behavior>.ts      standalone scenario programs, exit via process.exit
 task8-thread-search-support.test.ts   the one Vitest wrapper in this tree
-differential/*.mjs         Node ESM scenarios driven by scripts/qa-app-server/differential/
+differential/*.mjs         Node ESM scenarios using the package's scripts/qa-app-server/ harness
 differential/expected-gaps.json, capability-manifest.json   pinned expectations
 ```
 
@@ -42,8 +42,8 @@ differential/expected-gaps.json, capability-manifest.json   pinned expectations
 
 ```bash
 bunx tsx packages/coding-agent/test/qa/app-server/task<N>-<behavior>.ts
-bun run --cwd packages/coding-agent test --run test/qa/app-server/task8-thread-search-support.test.ts
-bun run qa:app-server        # packaged handshake / multiclient / approval / real-client probes
+bun run --cwd packages/coding-agent test test/qa/app-server/task8-thread-search-support.test.ts
+bun run --cwd packages/coding-agent qa:app-server  # includes real-client-sweep
 ```
 
-Differential scenarios run through the repository's differential harness (`scripts/qa-app-server/differential/driver.mjs`), never as individual node invocations.
+Differential scenarios use `packages/coding-agent/scripts/qa-app-server/`; its `differential/driver.mjs` is a transport library, not a standalone CLI. Preserve harness-owned endpoint setup and teardown.

--- a/packages/coding-agent/test/suite/AGENTS.md
+++ b/packages/coding-agent/test/suite/AGENTS.md
@@ -1,6 +1,6 @@
 # test/suite
 
-Preferred harness-based coverage for `AgentSession` / `AgentSessionRuntime`, builtin extensions, app-server, goals, loops, and compaction lifecycle. 312 flat files + `regressions/` (own file). Score 20 — largest, highest-fan-in test surface in the package.
+Preferred harness-based coverage for `AgentSession` / `AgentSessionRuntime`, builtin extensions, app-server, goals, loops, and compaction lifecycle. 367 direct TypeScript files + `regressions/` and small `fixtures/`. Score 12 — high-fan-in session/extension integration boundary.
 
 ## WHERE TO LOOK
 
@@ -8,6 +8,7 @@ Preferred harness-based coverage for `AgentSession` / `AgentSessionRuntime`, bui
 |------|----------|
 | Shared session/agent fixture | `harness.ts` (`createHarness`, `Harness`, `HarnessOptions`, `getUserTexts`, `getAssistantTexts`, `getMessageText`) |
 | App-server transports/threads | `app-server-mode-harness.ts`, `app-server-mode-socket.ts`, `app-server-thread-handlers-harness.ts`, `app-server-thread-search-support.ts`, `app-server-fuzzy-test-support.ts` |
+| RPC worker lifecycle / backpressure | `rpc-connection-harness.ts`, `rpc-worker-host-support.ts`, `rpc-worker-pressure-support.ts`, `rpc-worker-reservation-support.ts` |
 | Goal subsystem | `goal-*.test.ts`, `goal-monitor-test-harness.ts` (`TestEventBus`, `waitForGoalStatus`) |
 | Loop scheduler/tools | `loop-*.test.ts`, `loop-guard-test-harness.ts` |
 | Hooks lifecycle/safety/trust | `hooks-*.test.ts`, `hooks-command-harness.ts` |
@@ -21,7 +22,7 @@ Local `README.md` carries the same harness/faux-provider rules; keep both in syn
 
 ## CONVENTIONS
 
-- Broad lifecycle and characterization tests go here flat; issue regressions go to `regressions/`. Nothing else nests.
+- Broad lifecycle and characterization tests go here flat; issue regressions go to `regressions/`. Small text/process fixtures live in `fixtures/`.
 - Support modules are `*-harness.ts` / `*-support.ts` / `*-fixtures.ts` siblings (never `.test.ts`) and export their helpers directly rather than hiding behind one fixture API.
 - Harnesses inject clocks, timers, IDs, model registries, extension APIs, and faux providers. Time-dependent tests use `vi.useFakeTimers` / `advanceTimersByTimeAsync` or deferred promises — never elapsed real time.
 - App-server tests assert wire-level JSON-RPC envelopes over real WebSocket/UDS/stdio transports plus fake connections; protocol/parity tests pin generated manifests, hashes, and stable/experimental method lists.
@@ -30,7 +31,7 @@ Local `README.md` carries the same harness/faux-provider rules; keep both in syn
 
 ## ANTI-PATTERNS
 
-- Never extend `test/test-harness.ts` (legacy) when `harness.ts` has the capability.
+- Worker credit/backpressure assertions must observe the real host/worker/socket boundary; replacing the entire transport with a stub cannot catch stalled-peer credit loss.
 - Never introduce sleeps, polling, or real-clock assertions here; the suite's whole value is deterministic scheduling.
 - Do not reuse a captured `pi` / command context after `newSession`, `fork`, `switchSession`, or `reload` — `goal-ticker-stale-context.test.ts` and `stale-extension-context-*` exist because that broke in production.
 - Goal schemas and guidance stay budget-free; legacy budget metadata is migrated away, never resurrected.
@@ -39,12 +40,12 @@ Local `README.md` carries the same harness/faux-provider rules; keep both in syn
 
 ## HOTSPOTS
 
-`agent-session-compaction.test.ts` (2,214 LOC), `config-reload-extension.test.ts` (1,587), `goal-extension.test.ts` (1,081), `goal-store.test.ts` (956), `goal-monitor-continuation.test.ts` (952), `loop-scheduler.test.ts` (930), `gpt-apply-patch-extension.test.ts` (858), `loop-extension.test.ts` (789), `agent-session-queue.test.ts` (778), `retry-fallback-engine.test.ts` (743). `harness.ts` is the convergence point — changes there ripple across ~250 files.
+`agent-session-compaction.test.ts`, `config-reload-extension.test.ts`, `goal-extension.test.ts`, `goal-store.test.ts`, `goal-monitor-continuation.test.ts`, `loop-scheduler.test.ts`, `gpt-apply-patch-extension.test.ts`, `loop-extension.test.ts`, `agent-session-queue.test.ts`, and `retry-fallback-engine.test.ts` concentrate lifecycle orchestration. AST import inspection finds 255 imports of `createHarness` across packages.
 
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/suite/<file>.test.ts
-bun run --cwd packages/coding-agent test --run test/suite   # whole suite dir
-CI=1 bun run --cwd packages/coding-agent test --run test/suite/app-server-mode-ws.test.ts
+bun run --cwd packages/coding-agent test test/suite/<file>.test.ts
+bun run --cwd packages/coding-agent test test/suite   # includes regressions
+CI=1 bun run --cwd packages/coding-agent test test/suite/app-server-mode-ws.test.ts
 ```

--- a/packages/coding-agent/test/suite/regressions/AGENTS.md
+++ b/packages/coding-agent/test/suite/regressions/AGENTS.md
@@ -1,25 +1,27 @@
 # test/suite/regressions
 
-One-concern-per-file regression tests, 162 files / ~22,790 LOC. Score 16 — distinct naming contract and the densest compaction/queue-ownership coverage in the repo.
+One-concern-per-file regression tests: 213 direct test files, a shared image fixture, and a child-process fixture / ~30,100 TypeScript LOC. Score 7 — existing issue-oriented compaction/queue-ownership guide retained in UPDATE mode.
 
 ## WHERE TO LOOK
 
 | Task | Location |
 |------|----------|
-| Compaction admission/rejection | `pre-prompt-compaction-no-continue.test.ts` (915 LOC), `compaction-synchronous-admission.test.ts`, `compaction-rejection-feedback.test.ts` |
+| Compaction admission/rejection | `pre-prompt-compaction-no-continue.test.ts`, `compaction-synchronous-admission.test.ts`, `compaction-rejection-feedback.test.ts` |
+| Oversized-session resume | `1511-resume-oversized-session-compacts.test.ts` — compaction-required admission on resume |
 | Post-compaction queue ownership | `post-compaction-queue-ownership.test.ts`, `post-compaction-queued-input-resume.test.ts`, `post-compaction-tool-continuation-deadlock.test.ts`, `post-compaction-recovery-{bounds,guards}.test.ts` |
 | Stale generation/revision races | `compaction-generation-stale-revision.test.ts`, `stale-extension-context-after-session-replacement.test.ts`, `stale-goal-direct-input.test.ts` |
 | Goal continuation caps | `goal-continuation-*.test.ts`, `issue-447-goal-continuation.test.ts`, `issue-566-goal-repetition-tool-reset.test.ts` |
 | Provider retry/timeout | `provider-idle-{recovery,steering}.test.ts`, `provider-retry-recompaction.test.ts`, `provider-timeout-classification.test.ts` |
 | Codex remote compaction | `issue-296-openai-codex-remote-compaction{,-boundaries}.test.ts` |
-| Image generation arbitration | `imagegen-arbitration.test.ts` (740 LOC, 24-row truth table) |
+| Image generation arbitration | `imagegen-arbitration.test.ts` — 24-row truth table; shared image input in `issue-1455-image-fixture.ts` |
 | Model config/selector | `model-config-controls.test.ts`, `model-selector-favorites-search.test.ts`, `per-model-thinking-memory.test.ts` |
 | Process/inspector/Windows | `inspector-*.test.ts`, `issue-812-windows-taskkill-enoent.test.ts`, `issue-823-mcp-pgrep-pattern.test.ts` |
+| Shutdown rejection boundary | `permission-system-shutdown-unhandled-rejection.test.ts`, `fixtures/permission-system-shutdown-unhandled-rejection.ts` |
 
 ## CONVENTIONS
 
 - Name by behavior, not source module: `issue-<number>-<slug>.test.ts` for tracked issues, `todo-<n>-<slug>.test.ts` for todo tracks, plain behavior slugs otherwise. Do not infer coverage from the filename — several issue-numbered files test broad session/compaction behavior.
-- 85 of 162 files import `../harness.ts`; the rest drive real `AgentSession` / `InteractiveMode` paths directly. Extensions are injected via `extensionFactories` and `pi.on(...)` hooks.
+- Harness-driven cases import `../harness.ts`; direct integration cases drive `AgentSession` / `InteractiveMode`. Extensions are injected via `extensionFactories` and `pi.on(...)` hooks.
 - Compaction regressions deliberately configure tiny context windows / reserve tokens to force the boundary under test. Model IDs, provider IDs, canonical paths, and MCP prefixes are exact-value assertions.
 - Async coordination is deferred promises + captured event arrays + explicit release points; assertions inspect event order, queue ownership, payloads, usage, and persisted state.
 - Windows path tests construct absolute `System32`/`Sysnative` candidates while running on POSIX; that is intentional, not dead code.
@@ -36,6 +38,6 @@ One-concern-per-file regression tests, 162 files / ~22,790 LOC. Score 16 — dis
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/suite/regressions/<name>.test.ts
-bun run --cwd packages/coding-agent test --run test/suite/regressions
+bun run --cwd packages/coding-agent test test/suite/regressions/<name>.test.ts
+bun run --cwd packages/coding-agent test test/suite/regressions
 ```

--- a/packages/coding-agent/test/support/AGENTS.md
+++ b/packages/coding-agent/test/support/AGENTS.md
@@ -1,0 +1,37 @@
+# test/support
+
+## OVERVIEW
+
+Test-environment and provider-wire support, separate from session scenario harnesses. Score 9 - distinct setup/build boundary; `assertWorkspaceBuildPrerequisite` has 29 AST reference nodes.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Ambient override quarantine | `quarantine.ts` - `resolveQuarantineAgentDir`, `scrubAmbientAgentDirEnv`; contract documented in parent |
+| Unique agent/log writer directory | `temp-agent-dir.ts` - `createTempAgentDir` |
+| Child workspace import/build check | `workspace-build-prerequisite.ts` - `assertWorkspaceBuildPrerequisite`, freshness/resolution probes |
+| OpenAI text-tool recovery over SSE | `openai-recovery-wire.ts` - captured requests, fragmented frames, complete/truncated scenarios |
+| Anthropic text-tool recovery wire | `anthropic-recovery-wire.ts` |
+| Claude OAuth test-provider setup | `claude-sdk-oauth-provider.ts` |
+
+## CONVENTIONS
+
+- Build checks are opt-in at the top of dist-dependent test files, not in global `test/setup.ts`.
+- Vitest aliases workspace imports to source; spawned Node/tsx children instead follow package `exports` into `dist`. A passing in-process import does not establish the child prerequisite.
+- Resolution probes use ESM `import.meta.resolve`, then check that the target exists; resolving a URL alone does not prove a build exists.
+- Freshness checks cover ai, agent, tui, pty, protocol, and client. They compare source/dist mtimes, independently of Vitest's aliases.
+- Linked-worktree checks consider both the hoisted workspace symlink's real package root and the checkout-relative package root. Either stale tree can break child imports.
+- `createTempAgentDir` uses `mkdtemp`; its caller-supplied prefix is a label, not the uniqueness mechanism. Returned roots are left for OS cleanup by this helper.
+- Provider-wire recovery fixtures expose real loopback HTTP/SSE boundaries and explicit deferred observations, including fragmented frames and truncated tool calls.
+
+## ANTI-PATTERNS
+
+- Do not make workspace build assertions global: the terminal-tools CI subset intentionally runs without a workspace build.
+- Do not replace ESM resolution probes with `require.resolve`; import-only export maps would produce false missing-package reports.
+- Do not hardcode shared `/tmp` agent/log paths. Compaction loggers still write and rotate real files even when a sink is injected.
+- Do not hide stale-dist failures with a mocked import or skip; the prerequisite error names the missing build and its repair command.
+
+## COMMANDS
+
+From the repository root, `npm run build` satisfies the workspace-build prerequisite. Run the owning test file afterward using the parent guide's package runner; these support modules are not standalone test entries.

--- a/packages/coding-agent/test/ttsr/AGENTS.md
+++ b/packages/coding-agent/test/ttsr/AGENTS.md
@@ -1,6 +1,6 @@
 # test/ttsr
 
-Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/` — own `changes.md`): collapse and control-token-leak detectors, coordinator generation/abort races, rule parsing, repetitive-turns lane, remediation, persistence, and `/ttsr` settings. 18 files, ~3.4k LOC. Score 11 — distinct detector-grammar/evidence domain.
+Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/` — own `changes.md`): collapse and control-token-leak detectors, coordinator generation/abort races, rule parsing, repetitive-turns lane, remediation, persistence, and `/ttsr` settings. 19 TypeScript files (17 tests + 2 helpers), ~3.7k LOC, plus a text fixture. Score 9 — distinct detector-grammar/evidence domain.
 
 ## WHERE TO LOOK
 
@@ -8,7 +8,7 @@ Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/`
 |---|---|
 | Control-leak grammar accept/reject | `detector-control-leak-grammar.test.ts` + `control-leak-helpers.ts` (`ctrl`, `sgml`, `bracket`, `runSplitMatrix`, `expectLeakMatchEverywhere`) |
 | Control-leak evidence / negatives | `detector-control-leak-evidence.test.ts`, `detector-control-leak-negatives.test.ts` |
-| Collapse detection | `detector-collapse.test.ts` + `collapse-test-inputs.ts` |
+| Collapse detection | `detector-collapse.test.ts`, `detector-collapse-paragraphs.test.ts`, `collapse-test-inputs.ts` |
 | Coordinator races / abort semantics | `coordinator.test.ts`, `coordinator-races.test.ts` (`claimAbort`, `createGenerationState`, `markUserCancelled`, `resolveDetection`) |
 | Rule parsing / builtin rules | `rule-parser.test.ts` |
 | Repetitive-turns lane | `repetitive-turns.test.ts` |
@@ -21,7 +21,7 @@ Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/`
 - Detector/grammar tests import production pure modules directly (`detectors/*`, `prompts.ts`, remediation builders) — no session harness needed for detector behavior.
 - Split-matrix discipline: inputs replay split at multiple chunk boundaries (`runSplitMatrix`) so streaming partials behave like complete text.
 - Grammar assertions pin structural facts — token ids, occurrence counts, offsets, contexts — never detector prose.
-- Integration/wiring/persistence tests use `suite/harness.ts` faux-provider sessions.
+- Integration/wiring/persistence tests use `../suite/harness.ts` faux-provider sessions.
 - Negative coverage is first-class: `detector-control-leak-negatives.test.ts` and the `PLAIN_PROSE_PREFIX` guard keep ordinary prose from firing detectors.
 
 ## ANTI-PATTERNS
@@ -33,6 +33,6 @@ Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/`
 ## COMMANDS
 
 ```bash
-bun run --cwd packages/coding-agent test --run test/ttsr/<file>.test.ts
-bun run --cwd packages/coding-agent test --run test/ttsr
+bun run --cwd packages/coding-agent test test/ttsr/<file>.test.ts
+bun run --cwd packages/coding-agent test test/ttsr
 ```

--- a/packages/evals/AGENTS.md
+++ b/packages/evals/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/evals
 
 `@code-yeongyu/senpi-evals` — behavioral, model-backed eval suites over a real
-`AgentSession`, adapted to `vitest-evals`. Earned by distinct domain: the only
-token-spending eval surface in the repo.
+`AgentSession`, adapted to `vitest-evals`. Retained at score 7 for its distinct
+live-model domain; ordinary unit tests here do not spend tokens.
 
 ## WHERE TO LOOK
 
@@ -29,11 +29,21 @@ token-spending eval surface in the repo.
   `expect.soft` is not a scoring mechanism.
 - The harness snapshots native session JSONL before deleting its temp
   workspace; an eval-only `afterEach` registers it against the test task.
+- Session creation uses `createAgentSessionServices` then
+  `createAgentSessionFromServices`; transformed system prompts take effect via reload.
+- Cleanup failures join the original run error in an `AggregateError`; preserve
+  both causes rather than hiding the failed eval behind teardown.
 - Evals run against workspace source via vitest alias config, not built
   artifacts.
 - Each invocation writes an ignored `.eval/<timestamp>_<uuid>/` dir: `runs.jsonl`
   indexing harness runs plus `sessions/` JSONL attachments. Artifacts may
   contain prompts, responses, source, and tool output — treat as sensitive.
+
+## ANTI-PATTERNS
+
+- Never select only a provider or only a model: `resolveModelSelection` requires
+  both, supplied by the harness options or `PI_PROVIDER` + `PI_MODEL`.
+- Do not use comparative score thresholds as hard suite pass/fail assertions.
 
 ## COMMANDS
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/protocol
 
-`@earendil-works/pi-protocol` — transport-neutral CBOR wire protocol for remote pi sessions: TypeBox schemas, message codec, byte-stream framing. Consumed by `packages/server` and `packages/client`. Node `>=22.19.0`; only dependency is `typebox`.
+`@earendil-works/pi-protocol` — transport-neutral CBOR wire protocol for remote pi sessions: TypeBox schemas, message codec, byte-stream framing. Consumed by `packages/server` and `packages/client`. Node `>=22.19.0`; only dependency is `typebox`. Score 9: distinct remote-session wire contract.
 
 ## STRUCTURE
 

--- a/packages/pty/AGENTS.md
+++ b/packages/pty/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/pty
 
-`@earendil-works/pi-pty` is the TypeScript PTY facade: native loader, sessions, detached registry, headless screen, and non-PTY pipe fallback.
+`@earendil-works/pi-pty` is the TypeScript PTY facade: native loader, Bun terminal adapter, sessions, detached registry, headless screen, and non-PTY pipe fallback. Score 14: distinct terminal lifecycle domain; Node `>=24.0.0`.
 
 ## STRUCTURE
 
@@ -9,10 +9,11 @@ src/index.ts                     Public barrel; ".", "./screen", "./registry", "
 src/loader.ts, native-loader.ts  Native prebuild discovery and ABI checks
 src/session.ts                   Public session lifecycle
 src/session-native.ts            Native backend adapter
+src/session-bun.ts               Opt-in Bun.spawn terminal backend
 src/pipe-fallback.ts             child_process fallback when native is absent
 src/session-exit.ts              Exit settlement helpers
 src/registry*.ts                 Session registry and detached ownership
-src/screen.ts                    Headless terminal screen state
+src/screen.ts                    Headless screen; screen-operations.ts queue, screen-text.ts helpers
 src/quarantine.ts                macOS quarantine detection for prebuilds
 native/prebuilds/                Shipped platform binaries
 native/check-prebuild-fresh.mjs  Prebuild freshness gate
@@ -23,7 +24,8 @@ test/fixtures/*.mjs              Native-addon child processes for callback/worke
 
 - The native ABI constant is intentionally independent of package CalVer. Keep it aligned with `crates/senpi-pty` exports.
 - macOS quarantine is probed via `xattr -p` before loading a prebuild. Detection must never clear the attribute; an unreadable attribute is non-rejecting.
-- Unsupported or missing native bindings select the pipe fallback with a diagnostic; fallback behavior must never be presented as a real PTY.
+- Under Bun, `SENPI_BUN_TERMINAL=1` opts into `Bun.spawn` terminal before native selection; it is off by default and ignored under Node.
+- Otherwise unsupported or missing native bindings select the pipe fallback with a diagnostic; fallback behavior must never be presented as a real PTY.
 - Exit notification settles exactly once across native exit, child exit, startup failure, kill, and disposal races.
 - `kill()` is idempotent and detached-child cleanup owns the full process tree.
 - Bound retained raw output/tails; persistent sessions must not grow memory without limit.
@@ -36,6 +38,7 @@ test/fixtures/*.mjs              Native-addon child processes for callback/worke
 | Public API / subpath exports | `src/index.ts` |
 | Native loading/ABI | `src/loader.ts`, `src/native-loader.ts` |
 | Session lifecycle | `src/session.ts`, `src/session-exit.ts` |
+| Bun terminal selection, I/O, resize | `src/session-bun.ts` |
 | Fallback process behavior | `src/pipe-fallback.ts` |
 | Detached sessions | `src/registry.ts`, `src/registry-detached.ts` |
 | Screen parsing | `src/screen.ts` |

--- a/packages/senpi-codemode/AGENTS.md
+++ b/packages/senpi-codemode/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/senpi-codemode
 
 `@code-yeongyu/senpi-codemode` is a source-only Senpi extension that registers
-the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia.
-Deeper guides: `src/tool/AGENTS.md`, `src/kernels/AGENTS.md`, `test/AGENTS.md`.
+the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia. Score 17: extension/runtime integration boundary.
+Deeper guides: `src/{bridge,tool,kernels}/AGENTS.md`, `test/AGENTS.md`, `test/eval/AGENTS.md`.
 
 ## STRUCTURE
 
@@ -11,7 +11,7 @@ src/index.ts                     Extension factory: registers baseline eval, re-
 src/prompt/                      Model-aware eval prompt templates and batching dialect selection
 src/interpreters/                Interpreter availability detection (detect.ts)
 src/config/                      Settings schema, defaults, env overrides
-src/extension/                   Session generations and kernel ownership
+src/extension/                   Session generations, kernel ownership, wake-source/status events, Bun skill discovery
 src/tool/                        Eval schema, cell execution, status events, rendering
 src/kernels/                     Persistent kernels: js (worker), py/rb/jl (subprocess), shared lifecycle
 src/bridge/                      Loopback bearer-auth protocol and server
@@ -19,6 +19,7 @@ src/bridges/                     Host adapters for agent(), output(), structured
 src/output/                      OutputSink, truncation metadata, artifact-path handling
 src/completion/                  Host completion bridge
 src/timeouts/                    Bridge and idle-timeout ownership
+src/skill/bun-1-4/               Bundled Bun skill and references; activated by the JS kernel's runtime
 scripts/qa-*.ts                  Direct kernel, extension, and renderer QA drivers
 test/                            Vitest contracts and the omp parity ledger
 ```
@@ -26,23 +27,24 @@ test/                            Vitest contracts and the omp parity ledger
 ## INVARIANTS
 
 - `eval` registers at extension load and re-registers at `session_start` after settings, interpreter availability, and task-tool names resolve.
-- Eval prompt dialect comes from the active model id; GPT models receive the
-  terse composition-forward dialect that documents detached-cell completion.
+- Eval prompt dialect follows the active model id; GPT gets composition/detached-cell guidance, Kimi uses positive imperative emphasis.
 - Session generations fence old kernels and callbacks; a retired generation
   never emits into a newer session.
 - Kernels persist state per language; per-cell callbacks rebind per execution.
-- Evals require a `summary` in the user's conversational language; detached cells carry it and the old `title` field stays dropped.
+- Evals require a `summary` in the user's conversational language; it is normalized and capped at 80 characters, carried by detached cells; `title` stays dropped.
+- Interactive runs detach at the foreground window (default 60s); print/json and `on_timeout: "error"` use the uncapped timeout deadline.
 - Every cell settles exactly once: success, error, timeout, abort, bridge failure, kernel crash.
 - Timeout and abort cleanup retires child work before ownership is released.
-- The bridge binds loopback only, requires a per-session bearer token, limits
-  request bodies, and aborts work on disconnect.
+- Bridge authentication and disconnect ownership are specified in `src/bridge/AGENTS.md`.
 - `agent()` and `output()` use configured active tool names via `pi.executeTool`; never import an orchestration workspace package here.
 - `local://` resolves under the extension-owned session artifact root; spill notices use plain absolute paths.
 - Status events stay structured from kernel protocol through `EvalToolDetails`
   to render output; preserve agent-progress coalescing.
 - Nested tool-call rendering is bounded and rendering-only: no session messages, no extension events, no toggle.
+- Detached cells publish full `wake_source_state` snapshots on liveness transitions and session start; goal continuation consumes this cross-package contract.
 - Optional interpreters are capability gaps, not installation failures; JavaScript remains available on supported Node versions.
-- Target Node 24+. No Bun-only APIs, `@oh-my-opencode` imports, or `budget`.
+- Keep Node 24+ support; Bun-specific shell capture, sidecar assets, and skill contribution are capability-gated, not required on Node.
+- The Bun skill activates only when the JS kernel runs Bun >=1.4, not because Bun is on PATH. No `@oh-my-opencode` imports or `budget`.
 
 ## WHERE TO LOOK
 
@@ -53,22 +55,20 @@ test/                            Vitest contracts and the omp parity ledger
 | Cell execution, settlement, rendering | `src/tool/` (see `src/tool/AGENTS.md`) |
 | Interpreter detection | `src/interpreters/detect.ts` |
 | Session and kernel ownership | `src/extension/session-manager.ts`, `src/index.ts` |
-| Bridge auth and protocol | `src/bridge/` |
+| Bridge auth and protocol | `src/bridge/` (see `src/bridge/AGENTS.md`) |
 | Agent/output task composition | `src/bridges/` |
 | Kernel runtimes, subprocess lifecycle | `src/kernels/` (see `src/kernels/AGENTS.md`) |
 | Output sink and artifacts | `src/output/`, `src/tool/cell-handler.ts` |
-| Status and TUI/HTML rendering | `src/tool/status-events.ts`, `src/tool/render.ts` |
+| Status, wake state, rendering | `src/extension/{eval-status,eval-status-ticker,wake-source-state}.ts`, `src/tool/{status-events,render}.ts` |
+| Bun skill activation and assets | `src/extension/skill-contribution.ts`, `src/skill/bun-1-4/` |
 | Tests and port coverage | `test/`, `test/PARITY.md` (see `test/AGENTS.md`) |
 | Real-surface QA | `scripts/qa-*.ts` |
 
 ## QUALITY GATES
 
-- Add or update a focused Vitest contract before changing runtime behavior; run
-  it red, then green.
-- Run `bun run test` from this package and `bun run check` from the repository root
-  before committing.
-- Run the relevant `scripts/qa-*.ts` driver for kernel, bridge, extension,
-  output, or renderer changes; capture evidence without secrets.
+- Add or update focused Vitest contracts for runtime behavior; documentation-only edits do not need new tests.
+- Run `bun run test` here and root `bun run check` for code changes; package `build` and `clean` are intentional no-ops.
+- Run the relevant `scripts/qa-*.ts` driver for runtime/renderer changes; capture evidence without secrets.
 - TypeScript stays erasable and strict: no `any`, assertions, non-null
   assertions, ignored diagnostics, or undocumented dynamic imports.
 - Renderer imports stay out of `src/output/` — no renderer dependency cycle.
@@ -77,4 +77,4 @@ test/                            Vitest contracts and the omp parity ledger
   and helper tables with every user-visible surface change.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Updated: 2026-09-10 | Commit `2d0fa41c5`

--- a/packages/senpi-codemode/src/bridge/AGENTS.md
+++ b/packages/senpi-codemode/src/bridge/AGENTS.md
@@ -1,0 +1,40 @@
+# src/bridge
+
+## OVERVIEW
+
+Kernel message schemas and the authenticated loopback HTTP bridge; score 9 for a distinct transport boundary with high protocol import fan-in.
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| Host/kernel messages, decode errors | `protocol.ts` (`HostToKernelMessage`, `KernelToHostMessage`) |
+| JSON-line framing and byte limit | `protocol.ts` (`parseBridgeJsonLine`, `decodeBridgeFrame`) |
+| Token generation and comparison | `protocol.ts` (`generateBridgeToken`, `verifyBridgeToken`) |
+| HTTP routes and disconnect cancellation | `http-server.ts` (`startBridgeServer`) |
+| Reserved operation names | `reserved.ts`; dispatch is in `../bridges/reserved-dispatch.ts` |
+| Transport regressions | `../../test/bridge-protocol.test.ts`, `../../test/bridge-server*.test.ts` |
+
+## CONVENTIONS
+
+- This protocol is not the remote-session CBOR package: kernel frames are JSON
+  records terminated by LF; `BRIDGE_FRAME_MAX_BYTES` is 10 MiB, including the LF.
+- `parseBridgeJsonLine` checks framing/JSON only; `decodeBridgeFrame` also checks
+  TypeBox message schemas. A parsed value alone is not a validated message.
+- The HTTP server binds `127.0.0.1` on an ephemeral port. POST routes are `/call`,
+  `/emit`, and `/completion`; the default request-body cap is 1 MiB, not 10 MiB.
+- Tokens are random base64url strings; verification compares SHA-256 digests
+  with `timingSafeEqual`, allowing different input lengths without throwing.
+- Handler failures use `{ ok: false, error }`; `/emit` success returns HTTP 204.
+  Transport admission errors use HTTP 4xx; call/completion replies use HTTP 200.
+- Response `close` aborts work only if `writableFinished` is false. Server close
+  is idempotent and destroys tracked sockets before awaiting shutdown.
+
+## ANTI-PATTERNS
+
+- Do not use request `close` as a disconnect signal: Node emits it on normal
+  request completion too; cancellation belongs to the unfinished response.
+- Do not collapse frame-size and HTTP-body limits into one setting.
+- Do not replace digest comparison with direct bearer-token string equality.
+- Do not move task-tool implementations into this layer; `../bridges/` owns
+  agent/output/schema adapters, while kernels own execution and recovery.

--- a/packages/senpi-codemode/src/kernels/AGENTS.md
+++ b/packages/senpi-codemode/src/kernels/AGENTS.md
@@ -1,8 +1,8 @@
 # src/kernels
 
 Persistent kernels for four runtimes plus shared subprocess lifecycle. Earned
-by score 13 — distinct multi-runtime domain (31 files, TS hosts plus embedded
-runner/prelude assets).
+by score 9 — distinct multi-runtime domain (38 source files, TS hosts plus
+embedded runner/prelude assets; workspace reference centrality unmeasured).
 
 ## WHERE TO LOOK
 
@@ -11,6 +11,8 @@ runner/prelude assets).
 | JavaScript host API | `js/context-manager.ts` (`JavaScriptKernel`), `js/worker-host.ts` |
 | JS worker runtime, entries | `js/worker-runtime.js`, `js/worker-entry.js`, `js/inline-worker-entry.js`, `js/inline-worker.ts`, `js/worker-core.js` (+ `worker-core.d.ts`) |
 | JS import rewriting, queueing | `js/rewrite-imports.ts`, `js/run-queue.ts`, `js/prelude.ts`, `js/local-module-loader.ts` |
+| JS declaration persistence / last-expression capture | `js/worker-indirect-eval.js` |
+| Shell output capture and child tracking | `js/worker-shell-capture.js`, `js/worker-runtime.js` |
 | Python kernel | `py/kernel.ts`, `py/transport.ts`, `py/process.ts`, `py/prelude.py` |
 | Ruby kernel | `rb/kernel.ts` + `rb/prelude.rb`, `rb/runner.rb` |
 | Julia kernel | `jl/kernel.ts` + `jl/prelude.jl`, `jl/runner.jl` |
@@ -20,12 +22,15 @@ runner/prelude assets).
 ## CONVENTIONS
 
 - Each language dir pairs a typed TS host/controller with an embedded runner or
-  prelude asset; `shared/runtime-asset.ts` ships them.
+  prelude asset; `shared/runtime-asset.ts` resolves local files or the packaged
+  sidecar beside the executable (`node_modules/@code-yeongyu/senpi-codemode/src/`).
 - Transport messages are discriminated by string `type` (`ready`, `result`,
   `tool-call`, `closed`, `init-failed`, ...) exchanged as framed bridge
   messages, one JSON line per frame.
 - JS persistent cell bindings are rewritten onto `globalThis`; imports are
   AST-parsed (Babel) and rewritten to bridge-compatible dynamic imports.
+  `worker-indirect-eval.js` separately scans declarations, literals, comments,
+  and regex tokens to preserve bindings and capture the final expression.
 - JS runs on worker threads with an inline-worker fallback; py/rb/jl run as
   framed subprocesses through `shared/`.
 - Subprocess retirement/restart, worker recovery, timeout, and interrupt
@@ -43,5 +48,7 @@ runner/prelude assets).
   validation.
 - Never rewrite imports by filename/regex — `rewrite-imports.ts` applies
   source-position edits from the parsed program.
-- An optional interpreter being absent (py/rb/jl not installed) is a capability
-  gap, not an installation failure or error path.
+- Do not resolve required runner files to Bun virtual filesystem paths:
+  `requireCodemodeRuntimeAsset` rejects those and requires a readable sidecar.
+- `py/prelude.py` and `js/worker-indirect-eval.js` exceed 500 lines; exercise
+  the language lifecycle/persistence contracts when changing either runtime.

--- a/packages/senpi-codemode/src/tool/AGENTS.md
+++ b/packages/senpi-codemode/src/tool/AGENTS.md
@@ -10,9 +10,9 @@ anchor most suites).
 | Task | Path |
 | --- | --- |
 | Tool registration, options | `eval-tool.ts`, `eval-tool-options.ts`, `eval-request.ts` |
-| Wire contract, TypeBox schemas | `types.ts` (`createEvalInputSchema`, `fullEvalInputSchema`) |
+| Wire contract, enabled-language schemas | `types.ts` (`createEvalInputSchema`, `EVAL_SUMMARY_MAX_LENGTH`; `fullEvalInputSchema` is private) |
 | Cell execution, settlement | `cell-handler.ts`, `cell-execution.ts`, `cell-runtime.ts` |
-| Detached cells | `detached-cell-manager.ts` + `detached-cell-{state,snapshot,notification}.ts`, `detached-notification-queue.ts`, `detached-eval-result.ts` |
+| Detached cells | `detached-cell-manager.ts` + `detached-cell-{contract,state,status,snapshot,notification}.ts`, `detached-notification-queue.ts`, `detached-eval-result.ts` |
 | Call/result rendering | `render.ts`, `runtime-label.ts`, `json-tree.ts`, `image.ts`, `tool-widgets.ts` |
 | Status events, execution events | `status-events.ts`, `eval-execution-event.ts` |
 | Interrupt, capture | `interrupt-note.ts`, `call-capture.ts` |
@@ -21,11 +21,16 @@ anchor most suites).
 
 - Wire/schema fields are snake_case (`cell_id`, `on_timeout`); internal TS
   fields are camelCase. Schemas and shared eval types live only in `types.ts`.
+- `createEvalInputSchema` narrows the advertised language set; `parseEvalRequest`
+  enforces run versus peek/stop requirements. `prepareArguments` clamps summary
+  before schema validation rather than rejecting over-limit labels.
 - Rendering is bounded by explicit line/code-point budgets with an injectable
   render clock; nothing here depends on wall-clock luck.
 - Detached execution is a first-class state machine — snapshot, notification
   queue, spill-file notice, result conversion — never folded into ordinary
   cell execution.
+- Wake-source snapshots originate in the detached manager and use
+  `../extension/wake-source-state.ts`; status text is a separate UI projection.
 - Unicode tree glyphs and status icons are intentional UI conventions.
 
 ## ANTI-PATTERNS
@@ -36,5 +41,5 @@ anchor most suites).
   kernels import `KernelInterruptHandle` from `types.ts`, so discriminants and
   lifecycle state are cross-runtime contracts — change them only with all four
   runtimes and the detached path in mind.
-- `render.ts` (1,030 LOC) is the package's largest file and the highest-risk
-  hotspot for regressions; changes there need render contracts first.
+- `render.ts` exceeds 1,000 lines and is the largest tool-layer file; preserve
+  render contracts around streaming, collapse, errors, and nested widgets.

--- a/packages/senpi-codemode/test/AGENTS.md
+++ b/packages/senpi-codemode/test/AGENTS.md
@@ -1,20 +1,22 @@
 # test
 
 Vitest contracts for the codemode package plus the port-coverage parity ledger.
-Earned by score 15 — contract layer and fixture hub (95 code files, ~12k LOC).
+Earned by score 14 — contract layer and fixture hub (106 direct TypeScript files).
 
 ## WHERE TO LOOK
 
 | Task | Path |
 | --- | --- |
-| Shared fakes, fixtures | `eval/fakes.ts` (`FakeKernel`, `FakeManager`), `eval-render-fixtures.ts` |
+| Shared fakes, fixtures | `eval/AGENTS.md`, `eval/fakes.ts`, `eval-render-fixtures.ts` |
 | Render contracts | `eval-render*.test.ts` family, `json-tree.test.ts`, `tool-widgets.test.ts` |
 | Kernel contracts | `js-kernel*.test.ts`, `py-kernel*.test.ts`, `rb-kernel.test.ts`, `kernels/rb/`, `jl-kernel.test.ts` |
-| Detach, interrupt, timeouts | `eval-detach*.test.ts`, `eval-tool-interrupt.test.ts`, `timeouts.test.ts`, `eval-hard-limit.test.ts` |
+| Detach, interrupt, timeouts | `eval-detach*.test.ts`, `eval-tool-interrupt.test.ts`, `timeouts.test.ts`, `eval-hard-limit.test.ts`, `eval-foreground-window.test.ts` |
 | Bridge protocol, servers | `bridge-protocol.test.ts`, `bridge-server*.test.ts`, `agent-bridge.test.ts`, `schema-bridge.test.ts` |
 | Extension/session lifecycle | `extension.test.ts`, `session-manager*.test.ts`, `factory.test.ts` |
+| Wake-source/status contracts | `eval-wake-source.test.ts`, `eval-status-wiring.test.ts`, `eval-status-ticker.test.ts` |
+| Bun skill and sidecar assets | `bun-skill-contribution.test.ts`, `kernels/shared/runtime-asset.test.ts` |
 | Output sink | `output/` |
-| Prompt snapshots | `prompt.test.ts`, `__snapshots__/` |
+| Existing prompt regression suite | `prompt.test.ts`, `__snapshots__/` (legacy prose snapshots; do not extend for prose-only changes) |
 | Port coverage mapping | `PARITY.md` |
 
 ## CONVENTIONS
@@ -22,12 +24,15 @@ Earned by score 15 — contract layer and fixture hub (95 code files, ~12k LOC).
 - Import `describe`/`it`/`expect`/`vi` explicitly; no ambient globals.
 - Source imports are direct relative `.ts` paths; test-only fixtures live in
   `test/eval/` and `eval-render-fixtures.ts`.
-- Async behavior is asserted via promise resolution/rejection and fake timers
-  (`vi.useFakeTimers`, `advanceTimersByTime`); `setTimeout` appears only in
-  intentional crash/deadline fixtures; `vi.waitFor` stays event/state based.
+- Use the fixture signals in `eval/` to control kernel acquisition, run start,
+  interrupt, and reset. Subscribe before triggering and await with bounded deadlines.
+- Fake timers cover deadline behavior. Existing `vi.waitFor` in wake/status suites
+  and fixed sleeps in `py-prelude-idle-sigint.test.ts` are legacy nondeterminism,
+  not examples to copy; replace with exact state/frame signals when touching them.
 - Titles are behavior-oriented, often Given/When; parity suites compare
   JS/Python/Julia/runtime output and error behavior.
-- `SIZE_OK` allowance marks the intentionally large parity suite.
+- `SIZE_OK` allowances mark intentionally large parity suites.
+- Test parsed fields, sentinel tokens, and shipped-copy equality, not prompt prose.
 
 ## ANTI-PATTERNS
 

--- a/packages/senpi-codemode/test/eval/AGENTS.md
+++ b/packages/senpi-codemode/test/eval/AGENTS.md
@@ -1,0 +1,42 @@
+# test/eval
+
+## OVERVIEW
+
+Shared eval fakes and real JavaScript worker harnesses; score 9 for a distinct test-support boundary imported by dozens of contract suites.
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| Fake kernel/manager, context, result frames | `fakes.ts` |
+| Deferred acquisition, reset, interrupt | `fakes.ts` (`DelayedKernelManager`, `DelayedResetKernel`, `PendingInterruptKernel`) |
+| Real JavaScript runs and captured frames | `js-kernel-harness.ts` |
+| Worker restart counts and blocked readiness | `js-worker-spawn-log.ts` |
+| Bun shell fixture | `fake-bun-shell.ts` |
+| Renderer-specific builders | `../eval-render-fixtures.ts` (outside this helper directory) |
+
+## CONVENTIONS
+
+- `FakeKernel.deferNextRun()` returns the run-start signal; arm it before
+  execution, then settle the held run with `completeDeferredRun`.
+- `FakeManager.getKernel` rebinds the selected kernel's `onMessage` callback.
+  Tests can emit bridge messages separately from the final result frame.
+- `FakeKernel.interrupt` records the reason and settles a deferred active run;
+  `stateRetainedOnInterrupt` controls that interrupt's retained-state outcome.
+- Acquisition, reset, and interrupt fixtures expose separate started/released
+  promises so a race can be held at its actual ownership boundary.
+- `fakeExtensionContext` defaults to print mode with in-memory session settings;
+  interactive detach tests must deliberately select the mode they exercise.
+- `withJavaScriptKernel` closes the real kernel in `finally`; `runJavaScriptCell`
+  collects protocol messages alongside the result, and parsing rejects failed runs.
+- Spawn-log entries run the real `createWorkerCore`; `blockFirstReady` emits a
+  `readiness-blocked` phase and suppresses only the first initialization.
+  Worker-core paths resolve from package cwd; call `removeWorkerEntry` after use.
+
+## ANTI-PATTERNS
+
+- Do not replace worker-core execution with a fake when asserting VM replacement:
+  the spawn log must observe the runtime lifecycle being tested.
+- Do not resolve a held interrupt before the assertion that depends on ownership.
+- Do not use `KernelOwnedTimeoutKernel` as a generic scheduling delay; it exists
+  to exercise a kernel-owned deadline, with timers controlled by that test.

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,14 +1,14 @@
 # packages/server
 
-Commit: `baf15a54d` (2026-08-24)
+Commit: `2d0fa41c5` (2026-09-10)
 
-`@code-yeongyu/senpi-server` is an experimental private package. It is a composable, transport-neutral protocol server built on `@earendil-works/pi-protocol`. The old daemon/IPC/Radius stack under `src/legacy/` and the `server` CLI bin were removed upstream in v0.84.1; applications supply their own `PiServerService`. Node `>=22.19.0`.
+`@code-yeongyu/senpi-server` is an experimental private package. It is a composable, transport-neutral protocol server built on `@earendil-works/pi-protocol`. The old daemon/IPC/Radius stack under `src/legacy/` and the `server` CLI bin were removed upstream in v0.84.1; applications supply their own `PiServerService`. Node `>=22.19.0`. Score 14: distinct protocol-host and transport lifecycle domain.
 
 ## STRUCTURE
 
 ```text
 src/index.ts             Re-exports errors, listener, protocol, server, types
-src/server.ts            PiServer: handshake, auth token hash, message dispatch
+src/server.ts            PiServer: handshake, protocol-version validation, message dispatch
 src/protocol.ts          pi-ai <-> pi-protocol type bridging and transcript mapping
 src/listener.ts          PiServerListener interface (start/close, accept)
 src/connection.ts        ByteConnection, handler, ConnectionState stages
@@ -38,7 +38,7 @@ Package exports: `.` (core), `./testing`, `./unix`.
 
 | Task | Path |
 |---|---|
-| Handshake, auth, dispatch | `src/server.ts` |
+| Handshake, version validation, dispatch | `src/server.ts` |
 | Session runtime lifecycle | `src/sessions.ts`, `src/types.ts` |
 | Server snapshot fanout | `src/snapshots.ts` |
 | Add a transport | `src/listener.ts`, `src/connection.ts`, `src/transports/unix/` as template |
@@ -48,9 +48,10 @@ Package exports: `.` (core), `./testing`, `./unix`.
 
 ## VALIDATION
 
-- `bun run test` (Vitest) from this package; root `bun run check` after code changes.
+- `bun run test` (Vitest), `bun run typecheck` (test config), and `bun run build`
+  (build config) from this package; root `bun run check` after code changes.
 - Add lifecycle tests for handshake timeout, disconnect mid-operation, duplicate close, and stale-socket takeover.
 - Inspect logs and fixtures for secret safety before committing.
 
 ---
-Updated: 2026-08-24 | Commit `baf15a54d` (was `4f26b8282`)
+Updated: 2026-09-10 | Commit `2d0fa41c5`

--- a/packages/session-backends/sqlite-node/AGENTS.md
+++ b/packages/session-backends/sqlite-node/AGENTS.md
@@ -2,17 +2,17 @@
 
 `@earendil-works/pi-storage-sqlite-node` (private). Node `node:sqlite` backend for
 `@earendil-works/pi-agent-core` sessions; vendored from upstream pi. Node `>=22.19.0`.
-Score 16: 50 files, 6 subdirs, dense typed SQL layer with its own migration pipeline.
+Score 14: dense typed SQL layer, six subdirectories, and its own migration pipeline.
 
 ## STRUCTURE
 
 ```text
 src/index.ts              wrapNodeSqliteDatabase / createNodeSqliteFactory + re-exports sqlite/
-src/sqlite/repo.ts        SqliteSessionRepository — repository/storage orchestration (953 LOC hotspot)
+src/sqlite/repo.ts        SqliteSessionRepository — repository/storage orchestration (>900 LOC hotspot)
 src/sqlite/sql.ts         Tagged-template `sql` helper
 src/sqlite/migrations.ts  Migration runner; SQL files in src/sqlite/migrations/
 src/sqlite/storage/       Per-table modules: sessions, entries, records, lanes, facts,
-                          branch-entries, branch-tips, branch-cache, session-sequences,
+                          branch-entries, branch-tips, session-sequences,
                           session-stats, writer-leases
 src/sqlite/search-backend.ts   FTS/search over stored entries
 scripts/prepare-dist.mjs  `copy-sqlite-migrations` build step
@@ -28,7 +28,7 @@ Package exports only `.` (dist/index.js). Migrations are plain `.sql` files copi
 |---|---|
 | New stored field / table | `src/sqlite/storage/` + new `NNN_*.sql` migration |
 | Session lifecycle, decoding, writer leases | `src/sqlite/repo.ts` |
-| Branch resolution / caching | `src/sqlite/branch-cache.ts`, `storage/branch-*.ts` |
+| Branch resolution / caching | `src/sqlite/branch-cache.ts`, `src/sqlite/storage/branch-*.ts` |
 | Search | `src/sqlite/search-backend.ts`, `test/search.test.ts` |
 | node:sqlite adapter quirks | `src/index.ts` |
 
@@ -49,4 +49,4 @@ Package exports only `.` (dist/index.js). Migrations are plain `.sql` files copi
   storage modules directly from outside the package.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Updated: 2026-09-10 | Commit `2d0fa41c5`

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -3,7 +3,8 @@
 `@earendil-works/pi-telemetry` (private). Vendor-neutral telemetry contracts and typed
 schema utilities: explicit context/span types, a NOOP context, an in-memory reference
 adapter, and compile-time schema inference. No exporter, backend, or global state.
-Score 11: distinct domain — dense type-level API with strict lifecycle invariants.
+Retained at score 7: distinct type-level API and adapter lifecycle boundary;
+whole-workspace reference centrality is unmeasured.
 
 ## STRUCTURE
 
@@ -54,4 +55,4 @@ test/               telemetry + conformance Vitest files
 - Repository-wide `bun run check` from root after changes.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Updated: 2026-09-10 | Commit `2d0fa41c5`

--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -1,6 +1,8 @@
 # packages/tui
 
-Commit: `baf15a54d` (2026-08-24)
+Commit: `2d0fa41c5` (2026-09-10)
+
+Score: 13 (package config, code-heavy subtree, dense exports/references); distinct terminal-library boundary.
 
 `@earendil-works/pi-tui` is the standalone terminal renderer/editor library used by Senpi interactive mode. Rendering uses synchronized, differential frames and must preserve terminal ownership boundaries.
 
@@ -13,11 +15,9 @@ src/tui-alt-screen.ts       Alt-screen TUI: layout frames, scroll routing, flash
 src/layout.ts               Layout frame rendering, rects, clipping, scrollbar geometry
 src/layout-node.ts          Per-component layout node attachment
 src/terminal.ts             Terminal capabilities and lifecycle
-src/editor-component.ts     Multiline editor primitive
+src/editor-component.ts     Custom editor interface; implementation in components/editor.ts
 src/components/             Text, markdown, loader, selectors, image components
-src/components/stack.ts     Stack size allocation shared by v-stack/h-stack
-src/components/v-stack.ts   VStack; h-stack.ts HStack; spacer.ts Spacer
-src/components/scroll-view.ts  ScrollView with scrollbar options
+src/components/stack.ts     Shared VStack/HStack sizing; scroll-view.ts owns scrolling
 src/keybindings.ts          Configurable default bindings
 src/keys.ts                 Key parsing and matching
 src/utils.ts                Width, wrapping, ANSI segmentation, output normalization
@@ -27,7 +27,7 @@ src/dollar-invocation-autocomplete.ts  $-invocation suggestions for the editor
 src/changes.md              Fork render behavior
 test/*.test.ts              Node test-runner coverage
 bench/                      frame-cost, editor-layout, markdown-render benchmarks
-native/                     Optional Darwin/Win32 modifier binaries (prebuilt, lazy-loaded)
+native/                     Optional modifiers + Win32 console mode (prebuilt, lazy-loaded)
 ```
 
 ## RENDERING CONTRACT
@@ -45,7 +45,7 @@ native/                     Optional Darwin/Win32 modifier binaries (prebuilt, l
 | Task | File |
 |---|---|
 | Flicker, cursor, viewport (`isViewportTUI`, `VIEWPORT_TUI`) | `src/tui.ts` |
-| Alt-screen rendering, scroll wheel/keys routing | `src/tui-alt-screen.ts` |
+| Alt-screen rendering, scroll routing, transcript search | `src/tui-alt-screen.ts`, `src/alt-screen-search.ts` |
 | Layout rects, clipping, scrollbar geometry | `src/layout.ts`, `src/layout-node.ts` |
 | Stack sizing, scrollable regions | `src/components/stack.ts`, `src/components/scroll-view.ts` |
 | Terminal lifecycle/title, child process terminal | `src/terminal.ts` (`ProcessTerminal`) |
@@ -71,9 +71,10 @@ native/                     Optional Darwin/Win32 modifier binaries (prebuilt, l
 
 ## VALIDATION
 
-- Tests use `node --test --import tsx`, not Vitest; the test script also imports `test/setup-multiplexer-env.mjs`. Run `bun run test` from this package.
+- Package runtime requires Node >=24. Tests use `node --test --import tsx`, not Vitest; `bun run test` also imports `test/setup-multiplexer-env.mjs`.
+- From this package: `bun run build` uses `tsc -p tsconfig.build.json`; `bun run bench:frame-cost -- --n 10000 --stable-components` emits frame-cost JSON.
 - Alt-screen/layout changes: see `test/tui-alt-screen.test.ts`, `test/layout.test.ts`, `test/viewport-render.test.ts`.
 - Rendering changes must include focused headless-terminal assertions and preserve flicker budgets.
 - Runtime changes require root `bun run check`, `senpi-qa` TUI smoke evidence, and visual terminal QA.
 - Read `src/changes.md` before altering renderer or loader behavior.
-- Native modifier binaries: `bun run build:native:darwin`; `bun run build:native:win32` (toolchain via `PI_TUI_WIN32_TOOLCHAIN=msvc|mingw`).
+- Native binaries: `bun run build:native:darwin` needs a macOS SDK/CoreGraphics; `bun run build:native:win32` selects `PI_TUI_WIN32_TOOLCHAIN=msvc|mingw`. Both emit arm64/x64 prebuilds.

--- a/packages/tui/src/AGENTS.md
+++ b/packages/tui/src/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/tui/src
 
-Score: 34 (33 files, barrel at `index.ts`, highest reference centrality in the package).
+Score: 14 (32 direct TypeScript modules, barrel at `index.ts`, dense symbols/exports and >20 import references); distinct renderer/protocol domain.
 
 Rendering engine, input/terminal protocol modules, and the fork-delta ledger. The package-level rendering contract and ownership rules live in `../AGENTS.md`; this file covers module-level operations.
 
@@ -12,14 +12,19 @@ Rendering engine, input/terminal protocol modules, and the fork-delta ledger. Th
 | Key protocol parsing/matching (Kitty keyboard, legacy sequences, modifyOtherKeys) | `keys.ts` |
 | Namespaced default bindings | `keybindings.ts` |
 | Stdin framing, bracketed paste | `stdin-buffer.ts` |
+| Alt-screen search, whitespace-normalized matches and cell spans | `alt-screen-search.ts` |
 | Kitty/iTerm2/tmux image paths | `terminal-image.ts`, `tmux-image-capability.ts`, `tmux-image-probe.ts` |
+| Safe image labels, home-relative image paths | `terminal-text.ts` |
+| Installed/bundled/standalone native-addon discovery | `native-module-path.ts` (`getNativeModuleCandidates`) |
 | Autocomplete provider contracts, `$`/`/` mixing | `autocomplete.ts` (`CombinedAutocompleteProvider`) |
 | Image/paste marker registries, canonicalization | `image-markers.ts`, `paste-markers.ts` |
 | Editor primitives shared with the component `Editor` | `kill-ring.ts`, `undo-stack.ts`, `word-navigation.ts` |
+| Custom editor API and paired marker/attachment state transfer | `editor-component.ts` (`EditorComponent`) |
 | Public API surface | `index.ts` — barrel; the coupling point for `coding-agent` and `senpi-codemode` |
 | Fork render-behavior history | `changes.md` |
 
-Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen`, `TuiMainScreen`, `Container`, `CURSOR_MARKER`, `isViewportTUI`, and `ViewportTUI`.
+Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TUI`, `TuiAltScreen`, `TuiMainScreen`, `Container`, `CURSOR_MARKER`, `isViewportTUI`, and `ViewportTUI`.
+`AltScreenSearchComponent`, `getGraphemeSegmenter`, and `getWordSegmenter` also ship through `index.ts`; `TuiBase` and the low-level layout helpers do not.
 
 Design doc for the alternate-screen layout system (landed 2026-07-31): root `tui-plan.md`.
 
@@ -28,7 +33,7 @@ Design doc for the alternate-screen layout system (landed 2026-07-31): root `tui
 - Keybinding IDs are namespaced (`tui.editor.*`, `tui.input.*`, `tui.select.*`, `tui.altScreen.*`) and centrally managed via `KeybindingsManager`; components consume them, never define them.
 - Markers (paste, image) are atomic, registry-backed, and canonicalized/renumbered on every mutation; they transfer through the paired optional state APIs.
 - Terminal protocols are modeled explicitly: Kitty keyboard, legacy sequences, modifyOtherKeys level detection, tmux focus/passthrough, OSC color queries (`terminal-capabilities.ts`, `native-modifiers.ts`, `tmux-focus.ts`).
-- Native capabilities load lazily and degrade to `undefined`; never a hard dependency.
+- Native lookup tries the resolved package, source/dist or bundled module-relative paths, then executable-adjacent paths; preserve candidate order and deduplication.
 - All width/wrap/segment math goes through `utils.ts` primitives (`visibleWidth`, `wrapTextWithAnsi`, `sliceByColumn`, `extractSegments`) — never hand-rolled string slicing.
 - `utils.ts` uses a bounded/rotating width cache and a pooled ANSI style tracker; `__widthCacheStats()` exposes cache diagnostics for tests.
 

--- a/packages/tui/src/components/AGENTS.md
+++ b/packages/tui/src/components/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/tui/src/components
 
-Score: 21 (18 files, >10 exports, high external reference centrality from `coding-agent` and `senpi-codemode`).
+Score: 9 (18 TypeScript files, >30 symbols, >10 exports, >20 `Editor` constructor uses); distinct component-library domain.
 
 Terminal component library: text, markdown, editor, selectors, stacks, images, loaders. Rendering contract and terminal-ownership rules live in `../../AGENTS.md`; width primitives in `../utils.ts`.
 
@@ -11,7 +11,7 @@ Terminal component library: text, markdown, editor, selectors, stacks, images, l
 | Multiline editor: markers, history, undo, autocomplete, wrapping | `editor.ts` — dominant hotspot (~2.6k LOC) |
 | Markdown rendering, highlighting, tables, LaTeX | `markdown.ts`, `latex.ts` |
 | Single-line input | `input.ts` |
-| Select/settings lists | `select-list.ts`, `settings-list.ts` |
+| Select/settings lists and optional row composition | `select-list.ts` (`SelectListTheme.renderRow`), `settings-list.ts` |
 | Scrollable regions | `scroll-view.ts` |
 | Size allocation shared by both stack directions | `stack.ts` (`allocateStackSizes`) |
 | Layout wrappers | `v-stack.ts`, `h-stack.ts`, `spacer.ts` |
@@ -20,13 +20,15 @@ Terminal component library: text, markdown, editor, selectors, stacks, images, l
 
 ## CONVENTIONS
 
-- Components implement `Component.render(width)`-style text rendering; grapheme/CJK/emoji-aware width comes from `../utils.ts` (`Intl.Segmenter` + East Asian width), not local arithmetic.
+- Components live in individual files with no local barrel; package-facing re-exports are assembled in `../index.ts`.
+- `EditorTheme.selectList` passes its optional `renderRow` composer into autocomplete lists; without it, `SelectList` preserves legacy row bytes.
 - Stack sizing uses basis/grow/shrink/min/max plus `visible` flags; `VStack` and `HStack` share `stack.ts` allocation.
 - `ScrollView` owns scrolling and takes exactly one immutable child; invalid axis or child mutation throws (`scroll-view.ts`).
-- High-frequency components memoize aggressively: `Editor` and `Markdown` hold substantial render/highlight caches — preserve them.
+- `Editor` keeps a wrapped-line cache; `Markdown` keeps bounded render/highlight caches. Preserve these component-specific caches.
+- Editor autocomplete serializes requests, passes abort signals, and checks request identity plus text/cursor snapshots before applying suggestions.
 
 ## ANTI-PATTERNS
 
 - Mutating or removing a `ScrollView` child after construction.
-- Width math bypassing `../utils.ts`.
-- Unbounded caches; the `utils.ts` width cache is bounded/rotating — follow that pattern.
+- Applying stale autocomplete results after the text, cursor, or request has changed.
+- Unbounded Markdown caches or bypassing invalidation when render inputs change.

--- a/packages/tui/test/AGENTS.md
+++ b/packages/tui/test/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/tui/test
 
-Score: 23 (77 files; `VirtualTerminal` imported by 65 of them).
+Score: 12 (80 executable/helper files, dense symbols/exports, >20 `VirtualTerminal` import references); distinct terminal-regression domain.
 
-`node:test` suite asserting rendered escape sequences against a simulated terminal. Test command and multiplexer setup are in `../../AGENTS.md`.
+`node:test` suite asserting rendered escape sequences against a simulated terminal. Package test command is in `../AGENTS.md`; multiplexer bootstrap is local.
 
 ## WHERE TO LOOK
 
@@ -10,9 +10,13 @@ Score: 23 (77 files; `VirtualTerminal` imported by 65 of them).
 |---|---|
 | Terminal simulation helper | `virtual-terminal.ts` — `VirtualTerminal`: `write`/`resize`/`flush`/`getViewport`/`getScrollBuffer`/`waitForRender` |
 | Shared themes | `test-themes.ts` — `defaultSelectListTheme`, `defaultMarkdownTheme`, `defaultEditorTheme` |
-| Editor behavior | `editor.test.ts` (~4.4k LOC, 219 cases: autocomplete, history, Unicode, wrapping, markers, sticky columns) |
+| Editor behavior | `editor.test.ts` (~4.4k LOC: autocomplete, history, Unicode, wrapping, markers, sticky columns) |
 | Core render/diff, alt-screen, overlays | `tui-render.test.ts`, `tui-alt-screen.test.ts`, `overlay-non-capturing.test.ts` |
 | Forbidden-regression guards | `external-stdout-guard.test.ts`, `cursor-write-hygiene.test.ts` |
+| Component disposal vs reusable detach | `component-dispose.test.ts` |
+| Select-row styling threaded through editor autocomplete | `select-list-render-row.test.ts`, `editor-render-row.test.ts` |
+| Terminal detach, native lookup, restricted SIGWINCH, private diagnostic logs | `terminal-detach.test.ts`, `native-module-path.test.ts`, `regression-sigwinch-kill-eacces.test.ts`, `render-diagnostic-permissions.test.ts` |
+| Tabs and public segmenter exports | `tab-width.test.ts`, `segmenter-exports.test.ts` |
 | Perf harness | `perf-trend-local.test.ts`, `render-churn-bench.ts` (inspector profiles), `frame-cost-harness.test.ts` (validates the bench JSON) |
 | Multiplexer environment | `setup-multiplexer-env.mjs` (imported globally by the test script) |
 
@@ -21,10 +25,13 @@ Score: 23 (77 files; `VirtualTerminal` imported by 65 of them).
 - Assert exact ANSI/OSC/APC bytes and viewport/scroll-buffer state via `VirtualTerminal` — never DOM or snapshot abstractions.
 - Naming is behavior-oriented: `regression-*`, `*-characterization`, `*-contract`, `*-repro`.
 - Filesystem autocomplete tests build isolated tmpdir trees and mock `fd` discovery; quoted paths, symlinks, hidden files, and `./` prefixes are explicit seams.
-- Non-`*.test.ts` files are runnable utilities outside the runner glob: `chat-simple.ts`, `image-test.ts`, `key-tester.ts`, `mux-scrollback-harness.ts`, `viewport-overwrite-repro.ts`, `render-churn-bench.ts`.
-- `stdin-buffer.test.ts` deliberately supports both `node:test` and Vitest APIs through a compat wrapper.
+- Non-`*.test.ts` utilities stay outside the runner glob: `chat-simple.ts`, `image-test.ts`, `key-tester.ts`, `viewport-overwrite-repro.ts`, `render-churn-bench.ts`. `mux-scrollback-harness.ts` supplies shared fixtures, not a standalone demo.
+- `stdin-buffer.test.ts` and `terminal-detach.test.ts` retain Node/Vitest compatibility; the package runner remains Node.
+- Bootstrap clears `TMUX`, `TMUX_PANE`, `STY`, and `ZELLIJ`; mux tests opt in via injected detection or scoped environment changes.
+- `flush()` acknowledges queued xterm writes, not a future scheduled TUI render. `waitForRender()` currently adds a fixed 20 ms sleep; it is legacy timing debt, not an event signal.
 
 ## ANTI-PATTERNS
 
-- New tests synchronize on render/event signals (`waitForRender`, flush) — never fixed `setTimeout` sleeps. Legacy sleeps in `loader.test.ts`, `layout.test.ts`, `editor.test.ts`, `chat-simple.ts` must not be extended.
+- For async tests, subscribe to the exact render/event/state signal before triggering work and await it with a bounded timeout, then flush terminal writes as needed.
+- Do not add fixed sleeps or rely on `waitForRender()` as deterministic synchronization. Existing timing debt in helpers and tests is not a pattern to extend.
 - Do not relax byte-exact terminal assertions; characterization contracts pin cursor/clear/SGR/OSC sequences.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,14 +1,13 @@
 # scripts/
 
-Build, validation, release, publish, lockfile, and environment tooling for the senpi monorepo.
+Build, validation, release, publish, lockfile, and environment tooling for the senpi monorepo (score 9: distinct tooling domain).
 
 ## Script anatomy
 
-All `.mjs` files carry `#!/usr/bin/env node` and run as ES modules; `devenv-setup.sh`/
-`.ps1` locate Node and delegate to `devenv-setup.mjs` (they own no logic). Colocated
-`*.test.mjs` run via root `bun run test:scripts` (shared fixtures live in `*.test-support.mjs`,
-outside that glob); root `preinstall` runs `create-bin-stubs.mjs`. `scripts/qa/` render assertions go through `xterm-render.mjs`'s
-cell grid. Prefixes encode role:
+Node ESM helpers and CLIs use `.mjs`; shebangs are not universal. `devenv-setup.sh`/
+`.ps1` locate Node and delegate to `devenv-setup.mjs`. Root `bun run test:scripts` runs
+`node --test scripts/*.test.mjs`; `*.test-support.mjs`, `*.test.ts`, and `qa/` are outside
+that glob. Root `preinstall` runs `create-bin-stubs.mjs`. Prefixes encode role:
 
 | Prefix | Role |
 |--------|------|
@@ -22,67 +21,60 @@ cell grid. Prefixes encode role:
   the `npm_execpath` basename), pnpm-only `npm_config_*` scrubbing, execpath-aware spawning that
   forwards SIGINT/SIGTERM/SIGHUP to the child, and per-manager forwarded-argument shaping.
 - `build-all.mjs`: PM-agnostic build orchestrator in dependency phases, built on `package-manager.mjs`.
-- `run-workspaces.mjs`: root -> workspace script runner
-  (`node scripts/run-workspaces.mjs [--if-present] [--workspace <name|path>]... <script> [-- <args>]`):
-  resolves the root `workspaces` field, runs `<pm> run <script>` per workspace sequentially in path
-  order with the invoking manager, never re-enters the root, and prints a PASS / SKIP / FAIL summary.
-  Every root `package.json` delegation into a workspace goes through it (`root-workspace-scripts.test.mjs`).
-- `release.mjs`: CalVer release composing `calver.mjs` and
-  `release-{packages,artifacts,changelog,git,test-gate}.mjs`. Preflight: on `main`, clean tree
-  (dry-run warns), valid CalVer; `--dry-run` previews every command and file write.
-- `publish.mjs`: publishes seven fork-owned packages (`senpi-ai`, `senpi-agent-core`, `senpi-tui`,
-  `senpi-pty`, `senpi-telemetry`, `senpi-codemode`, `senpi`); sources stay `private`, copied to
-  temporary public manifests under the fork scope (`@code-yeongyu/senpi-server` stays excluded).
-  Provenance requires GitHub Actions (`publish-command.mjs` throws outside it);
-  `local-release.mjs` smoke-tests a release to a temp dir without pushing tags.
-  `build-binaries.sh` mirrors `.github/workflows/build-binaries.yml` locally;
-  `prepare-bun-compile-assets.mjs` + `smoke-standalone-binary.mjs` cover standalone binaries.
-- Lock plumbing: `generate-coding-agent-{shrinkwrap,install-lock}.mjs`,
-  `generate-claude-agent-sdk-platform-lock.mjs`, `hydrate-lock-registry-metadata.mjs`,
-  `materialize-publish-runtime.mjs`, `npm-pack-json.mjs`, helpers in `install-lock-*.mjs`;
-  root `bun run refresh-lock` chains them.
-- Gates/catalog: `check-pr-changelog.mjs`, `check-upstream-release.mjs`, `check-pinned-deps.mjs`,
-  `check-ts-relative-imports.mjs`, `check-browser-smoke.mjs`, `diff-model-catalog.mjs`,
-  `publish-model-catalog.mjs`, `generate-thinking-capabilities.mjs` — `bun run check` chains them.
+- `run-workspaces.mjs`: `node scripts/run-workspaces.mjs [--if-present] [--workspace <name|path>]... <script> [-- <args>]`.
+  Resolves root `workspaces`; runs sequentially in path order with the invoking manager;
+  never re-enters root; prints PASS / SKIP / FAIL (`root-workspace-scripts.test.mjs` guards delegation).
+- `release.mjs`: CalVer release composing `calver.mjs` and `release-{packages,artifacts,changelog,git,test-gate}.mjs`.
+  Preflight: on `main`, clean tree (dry-run warns), valid CalVer; `--dry-run` previews commands and writes.
+- `publish.mjs`: seven fork-owned packages from `registry-packages.mjs`: `senpi-ai`,
+  `senpi-agent-core`, `senpi-tui`, `senpi-pty`, `senpi-telemetry`, `senpi-codemode`, `senpi`.
+  Sources stay private; temporary public manifests use the fork scope; server stays excluded.
+  `publish-command.mjs` requires GitHub Actions provenance; `local-release.mjs` uses a temp release without pushing tags.
+  `build-binaries.sh` mirrors the binary workflow; `prepare-bun-compile-assets.mjs` + `smoke-standalone-binary.mjs` check standalone binaries.
+- Lock plumbing: `bun run refresh-lock` refreshes npm/Bun locks, hydrates registry metadata,
+  then runs `generate-coding-agent-{shrinkwrap,install-lock}.mjs`; the Claude SDK platform
+  lock generator is separate. `materialize-publish-runtime.mjs`, `npm-pack-json.mjs`, `install-lock-*.mjs` support staging/validation.
+- `bun run check`: Biome, pinned-deps, TS imports, publish/install/Claude SDK locks, tsc, browser smoke.
+  `check-pr-changelog.mjs`, `check-upstream-release.mjs`, `diff-model-catalog.mjs`,
+  `publish-model-catalog.mjs`, and `generate-thinking-capabilities.mjs` are separate gates/tools.
+- `qa/xterm-render.mjs`: CLI for render/assert/replay/raw-assert/verify-manifest/self-test;
+  importing it also starts its CLI. Use `node scripts/qa/xterm-render.mjs self-test` for its fixture checks.
+  Visual claims require `.ans`/`.html`/`.json` triplets and parsed-cell assertions; raw-assert checks protocol only.
 
 ## changes.md tracker
 
-`scripts/changes.md` is the hand-written change tracker feeding CHANGELOG gates.
-`changes-md-policy.mjs` owns policy: canonical sections, path classification, coverage audit,
-and the added-line restrictor — a PR only gets credit for tracker bullets its diff added.
-`changes-md-git.mjs` owns git/filesystem collection (skips symlinked trackers, rejects option-like
-`--base` revisions). `audit-changes-md.mjs` audits coverage; `check-pr-changelog.mjs` gates PRs
-via `CHANGELOG_GATE_LABELS` / `CHANGELOG_GATE_BASE` env vars, never shell interpolation; entries
-parse `## YYYY-MM-DD` and `## Title (YYYY-MM-DD)` dialects.
+`scripts/changes.md` feeds CHANGELOG gates. `changes-md-policy.mjs` owns path classification,
+canonical sections, coverage audit, and added-line-only tracker credit. `changes-md-git.mjs`
+collects git/filesystem facts, skips symlinked trackers, and rejects option-like `--base` revisions.
+`audit-changes-md.mjs` audits coverage; `check-pr-changelog.mjs` uses `CHANGELOG_GATE_LABELS` /
+`CHANGELOG_GATE_BASE`, never shell interpolation. Entries accept `## YYYY-MM-DD` and `## Title (YYYY-MM-DD)`.
 
 ## prepare-senpi-bundled-workspaces.mjs
 
-Embeds workspace packages in the published `@code-yeongyu/senpi` tarball. `sourceOnly: false`
-ships `dist/index.js` (build before staging); `sourceOnly: true` ships `src/` (only
-`senpi-codemode`). Every `requiredFiles` entry is validated; `@earendil-works/pi-pty` also
-requires `native/index.js` and a platform prebuild. The tarball is fully self-contained: `copyPublishDependencies` stages the ENTIRE runtime
-closure from `publish-deps.lock.json` into `packages/coding-agent/node_modules`, and
-`stagePublishManifest` rewrites `bundleDependencies` to every platform-portable staged
-package while original `dependencies` keys stay intact, pointing through npm aliases to
-fork-owned `@code-yeongyu/senpi-*` packages (npm packs original import paths; Bun resolves
-the alias; the old partial bundle made arborist abort reify with ERR_MODULE_NOT_FOUND).
-Staging dirties `packages/coding-agent/package.json`; restore with `git checkout --` after it.
+Embeds built workspace `dist/` in the `@code-yeongyu/senpi` tarball; only `senpi-codemode`
+ships `src/`; its Python prelude and nested `node_modules/@babel/parser` must also ship.
+PTY loader files (`dist/index.js`, `native/index.js`) are required; missing native prebuilds warn and allow pipe fallback.
+`copyPublishDependencies` stages the registry runtime closure from `publish-deps.lock.json`.
+Client/protocol are instead copied from their builds into `packages/coding-agent/vendor/pi-{client,protocol}`;
+JS/declaration imports become relative, with no resolver-visible client/protocol package under `node_modules`.
+`stagePublishManifest` lives in `prepare-senpi-publish-manifest.mjs` (re-exported here):
+removes client/protocol dependency edges, bundles portable staged packages, preserves other import keys
+through owned npm aliases, and promotes platform optional families to root optional dependencies.
+Pack gates reject `npm-shrinkwrap.json`, missing runtime bundles, and missing codemode Babel parser.
+Staging changes `packages/coding-agent/package.json` AND emitted imports; use a disposable release checkout,
+or restore the checked manifest and rebuild coding-agent before returning to development.
 
 ## Anti-patterns
 
-- Don't hardcode `npm` as the child process manager. Use the detected PM from `package-manager.mjs`,
-  and reach workspaces from root scripts only through `run-workspaces.mjs` — never
-  `npm run --workspaces`, `npm --workspace=<name> run`, `npm --prefix <dir> run`, or `cd <dir> && npm run`.
-- Never hand-edit `publish-deps.lock.json` or `coding-agent-install-lock.json`; regenerate
-  with the `generate-*` scripts.
-- Never run `bun scripts/publish.mjs` without a prior build; it checks `dist/` exists, not
-  freshness. Never commit `.env` files or print credentials in build logs.
-- Lock generators refuse unreviewed install scripts; the allowlist is keyed by exact
-  `name@version` — bump the allowlist entry together with the dependency.
-- Never bundle packages declaring `os`/`cpu`/`libc` into `bundleDependencies`
-  (`isPlatformConstrainedPackage`): npm republishes the bundled set as required deps, so one
-  cross-platform artifact fails installs with EBADPLATFORM elsewhere; keep them optional
-  registry deps resolved per install target.
+- Use `package-manager.mjs` for manager-neutral child processes and `run-workspaces.mjs` for root delegation;
+  the runner tests reject npm workspace/prefix flags and shell `cd` delegation (see root guide).
+- Regenerate publish/install locks with `generate-*`; never hand-edit them.
+- `publish.mjs` checks `dist/` existence, not freshness: build first. Never commit `.env` or log credentials.
+- Install-script allowlists use exact `name@version`; update the reviewed entry with dependency bumps.
+- Never bundle packages declaring `os`/`cpu`/`libc`: npm republishes bundles as required deps,
+  causing EBADPLATFORM on other hosts. Keep them optional registry deps resolved per target.
+- QA visual assertions never inspect raw escape strings; replay must retain positive scrollback,
+  and clear/replay protocol tokens must belong to one complete DECSET 2026 frame.
 
 ---
-Generated: 2026-08-24 | Commit `baf15a54d`
+Generated: 2026-09-10 | Commit `2d0fa41c5`


### PR DESCRIPTION
## Summary
init-deep update-mode refresh of the AGENTS.md knowledge base against `origin/main` at the commit recorded in `.omo/init-deep.json`. Existing files were edited in place (stale paths, counts, commands and conventions reconciled with the current tree); new AGENTS.md files were added only where a directory now earns one by the init-deep scoring matrix. 72 files updated, 32 created (104 AGENTS.md files); root stays 165 lines with PROTOCOL / DELIVERY STOP INVARIANT / CHANGES.MD TRACKER POLICY sections byte-identical.

Docs-only: no source, config, or test files change.

## QA / evidence
- Every digest-declared AGENTS.md path exists; new files are 30-46 lines, root did not grow.
- only `*AGENTS.md` and `.omo/init-deep.json` are in the diff (`git status` scope check); `.md` is outside the changes.md production scope, so the PR carries `no-changelog`.
- Spot-checked claims against the tree (e.g. MSRV, hotspot LOC) before commit.

## Residual risk
Prose only; a wrong claim misleads an agent but breaks nothing at runtime. Verdict lines from the DAG verify node were re-checked mechanically in the driving session.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `AGENTS.md` knowledge base against current main at `2d0fa41c5`, fixing stale file counts, paths, commands, and conventions across 104 guides.

- Reconciles 72 existing files in place and adds 32 new ones only where directories qualify by the init-deep scoring matrix.
- Root `AGENTS.md` stays at 165 lines with `PROTOCOL`, `DELIVERY STOP INVARIANT`, and `CHANGES.MD TRACKER POLICY` byte-identical.
- Docs-only: no source, config, or test files change; the only other diff is `.omo/init-deep.json` recording the new base commit.
- Carries `no-changelog` since `.md` files are outside the `changes.md` production scope.
- Residual risk is prose-only: a wrong claim misleads an agent but breaks nothing at runtime.

<sup>Written for commit b631cbee6416a8be27d465e4f0819dd0a61fb2e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

