### PR TITLE
fix(compaction): recover an over-window restored session at resume admission

### DIFF
--- a/.agents/skills/senpi-qa/scripts/qa-1524-resume.mjs
+++ b/.agents/skills/senpi-qa/scripts/qa-1524-resume.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	cleanupAll,
+	evidenceDir,
+	installCleanupHooks,
+	makeSandbox,
+	realAuthPath,
+	runCli,
+	stripAnsi,
+} from "./lib/common.mjs";
+import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+
+const CONTEXT_WINDOW = 120_000;
+const MAX_TOKENS = 8_000;
+const FIRST_MARKER = "SENPI-QA-1524-FIRST";
+const RESUME_MARKER = "SENPI-QA-1524-RESUMED";
+const INFLATED_MARKER = "SENPI-QA-1524-INFLATED";
+const INFLATE_ENTRIES = 60;
+const INFLATE_CHUNK = "restored context ".repeat(600);
+
+const results = [];
+function check(label, passed, detail) {
+	results.push({ label, passed, detail });
+	console.log(`${passed ? "PASS" : "FAIL"} ${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+function authFingerprint() {
+	const path = realAuthPath();
+	if (!existsSync(path)) return "absent";
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function findSessionFile(sessionDir) {
+	const found = [];
+	const walk = (dir) => {
+		for (const name of readdirSync(dir)) {
+			const full = join(dir, name);
+			if (statSync(full).isDirectory()) walk(full);
+			else if (name.endsWith(".jsonl")) found.push(full);
+		}
+	};
+	if (existsSync(sessionDir)) walk(sessionDir);
+	if (found.length !== 1) throw new Error(`expected exactly one session file, found ${found.length}`);
+	return found[0];
+}
+
+function readEntries(sessionFile) {
+	return readFileSync(sessionFile, "utf8")
+		.split("\n")
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line));
+}
+
+function inflateSession(sessionFile) {
+	const entries = readEntries(sessionFile);
+	const template = entries.find((entry) => entry.type === "message" && entry.message?.role === "user");
+	if (!template) throw new Error("no user message entry to use as a template");
+	let parentId = entries[entries.length - 1].id;
+	const timestampBase = Date.now();
+	const appended = [];
+	for (let index = 0; index < INFLATE_ENTRIES; index++) {
+		const id = `qa1524-${index}`;
+		appended.push({
+			...template,
+			id,
+			parentId,
+			timestamp: new Date(timestampBase + index).toISOString(),
+			message: {
+				...template.message,
+				role: "user",
+				content: [{ type: "text", text: `${INFLATED_MARKER} ${index} ${INFLATE_CHUNK}` }],
+				timestamp: timestampBase + index,
+			},
+		});
+		parentId = id;
+	}
+	appendFileSync(sessionFile, `${appended.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+	return appended.length;
+}
+
+function estimateTokensFromWire(request) {
+	const payload = request.messages ?? request.body?.messages ?? request.body?.input ?? [];
+	return Math.ceil(JSON.stringify(payload).length / 4);
+}
+
+async function main() {
+	installCleanupHooks();
+	const authBefore = authFingerprint();
+	const box = makeSandbox("senpi-qa-1524");
+	const env = hermeticEnv(box.env);
+	const server = await startFakeModelServer({
+		turns: [{ text: FIRST_MARKER }, { text: RESUME_MARKER }, { text: RESUME_MARKER }],
+	});
+	const cliArgs = ["--print", "--provider", "mock", "--model", "mock-model"];
+	let evidence = "";
+	try {
+		writeMockModelsJson(box.agentDir, server, "openai-completions", {
+			contextWindow: CONTEXT_WINDOW,
+			maxTokens: MAX_TOKENS,
+		});
+
+		const first = await runCli([...cliArgs, "start the session"], { env, cwd: box.cwd });
+		check(
+			"first turn completes",
+			first.code === 0 && stripAnsi(first.stdout).includes(FIRST_MARKER),
+			`exit ${first.code} ${stripAnsi(first.stderr).slice(0, 300)}`,
+		);
+
+		const sessionFile = findSessionFile(box.sessionDir);
+		const inflated = inflateSession(sessionFile);
+		const liveTokens = Math.ceil(
+			JSON.stringify(readEntries(sessionFile).filter((entry) => entry.type === "message")).length / 4,
+		);
+		check(
+			"restored context exceeds the model window",
+			liveTokens > CONTEXT_WINDOW,
+			`live ~${liveTokens} tokens vs window ${CONTEXT_WINDOW}`,
+		);
+
+		const requestsBefore = server.requests.length;
+		const resumed = await runCli([...cliArgs, "--continue", "say the marker"], { env, cwd: box.cwd });
+		const resumedOut = stripAnsi(resumed.stdout);
+		check(
+			"resumed turn completes instead of failing admission",
+			resumed.code === 0 && resumedOut.includes(RESUME_MARKER),
+			`exit ${resumed.code}`,
+		);
+		check(
+			"no model usability budget error surfaced",
+			!resumedOut.includes("ModelUsabilityBudgetError") && !stripAnsi(resumed.stderr).includes("cannot resume"),
+			"",
+		);
+
+		const resumeRequests = server.requests.slice(requestsBefore);
+		check("resumed turn reached the provider", resumeRequests.length > 0, `${resumeRequests.length} request(s)`);
+		const wireTokens = resumeRequests.map(estimateTokensFromWire);
+		const largest = Math.max(0, ...wireTokens);
+		check(
+			"outgoing request fits beside the reserved output budget",
+			largest > 0 && largest <= CONTEXT_WINDOW - MAX_TOKENS,
+			`largest ~${largest} tokens vs budget ${CONTEXT_WINDOW - MAX_TOKENS}`,
+		);
+		check("outgoing request is smaller than the restored context", largest < liveTokens, `${largest} < ${liveTokens}`);
+
+		const afterEntries = readEntries(sessionFile);
+		const preserved = afterEntries.filter(
+			(entry) => entry.type === "message" && JSON.stringify(entry.message?.content ?? "").includes(INFLATED_MARKER),
+		).length;
+		check("recorded transcript is preserved", preserved === inflated, `${preserved}/${inflated} inflated entries on disk`);
+
+		const reopened = await runCli([...cliArgs, "--continue", "say the marker again"], { env, cwd: box.cwd });
+		check(
+			"reopening the reduced session still works",
+			reopened.code === 0 && stripAnsi(reopened.stdout).includes(RESUME_MARKER),
+			`exit ${reopened.code}`,
+		);
+		const reductions = readEntries(sessionFile).filter(
+			(entry) => entry.type === "compaction" && entry.details?.origin === "resume-admission",
+		).length;
+		check("reduction is recorded once, not repeated", reductions === 1, `${reductions} resume-admission entries`);
+
+		evidence = [
+			`window=${CONTEXT_WINDOW} maxTokens=${MAX_TOKENS}`,
+			`restored live tokens ~${liveTokens}`,
+			`outgoing request tokens ${JSON.stringify(wireTokens)}`,
+			`inflated entries preserved ${preserved}/${inflated}`,
+			`resume-admission entries ${reductions}`,
+			"",
+			"first turn stdout:",
+			stripAnsi(first.stdout).trim(),
+			"",
+			"resumed turn stdout:",
+			resumedOut.trim(),
+		].join("\n");
+	} finally {
+		await server.stop();
+		box.cleanup();
+		cleanupAll();
+	}
+
+	const authAfter = authFingerprint();
+	check("real auth file untouched", authBefore === authAfter, "");
+
+	const dir = evidenceDir("issue1524-resume");
+	mkdirSync(dir, { recursive: true });
+	const failed = results.filter((entry) => !entry.passed);
+	writeFileSync(
+		join(dir, "qa-1524-resume.log"),
+		[
+			`# senpi-qa: #1524 oversized resume through the real CLI`,
+			`# date: ${new Date().toISOString()}`,
+			"",
+			...results.map((entry) => `${entry.passed ? "PASS" : "FAIL"} ${entry.label}${entry.detail ? ` — ${entry.detail}` : ""}`),
+			"",
+			evidence,
+			"",
+			"cleanup: fake model server closed; sandbox removed; no tracked child left running",
+		].join("\n"),
+	);
+	console.log(`evidence: ${join(dir, "qa-1524-resume.log")}`);
+	if (failed.length > 0) {
+		console.error(`${failed.length} check(s) failed`);
+		process.exit(1);
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	cleanupAll();
+	process.exit(1);
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Resuming a session whose restored context is larger than the model's context window no longer fails with `ModelUsabilityBudgetError`. Admission now reduces the live context deterministically, without any provider request, before the session opens: it reuses the compaction cut-point selection so a retained tool result keeps its originating tool call, leaves the recorded transcript intact, and accepts a reduction only when the remaining context still leaves room for the system prompt, tool schemas, output reserve, compaction reserve and safety margin, so the first ordinary request cannot overflow. When the fixed overhead alone cannot fit, the original actionable budget error is raised and nothing is written, and sessions with compaction disabled keep the existing refusal. Interactive mode reports the reduction before the first prompt ([#1524](https://github.com/code-yeongyu/senpi/issues/1524)).
+
 - Shared RPC hosts now cut a socket peer that stops reading (a write not accepted within 4 seconds) with an `overflow` record `stalled, resync required` instead of letting it hold the session worker's output credit until the 5-second `session_worker_credit_timeout` quarantined a healthy session mid-turn; a cut or overflowed peer no longer withholds session credit or fails the shared host writer ([#1529](https://github.com/code-yeongyu/senpi/pull/1529)).
 
 ### Removed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -125,6 +125,12 @@ import {
 	createResumeCompactionRequirement,
 	type ResumeCompactionRequirement,
 } from "./extensions/builtin/compaction/resume-admission.ts";
+import {
+	RESUME_SLICE_ORIGIN,
+	RESUME_SLICE_SCHEMA,
+	type ResumeSlicePlan,
+	resumeSliceNotice,
+} from "./extensions/builtin/compaction/resume-slice.ts";
 import { WAKE_SOURCE_STATE_EVENT } from "./extensions/builtin/monitor-state-event.ts";
 import { CODEX_RESPONSES_API, type ServiceTier } from "./extensions/builtin/service-tier.ts";
 import { deriveExtensionRegistrationId } from "./extensions/builtin/tool-search/engine/marker.ts";
@@ -422,6 +428,13 @@ export type AgentSessionEvent =
 	| {
 			type: "resume_compaction_required";
 			projection: ModelUsabilityBudgetProjection;
+			notice: string;
+	  }
+	| {
+			type: "resume_context_reduced";
+			tokensBefore: number;
+			tokensAfter: number;
+			droppedEntries: number;
 			notice: string;
 	  }
 	| { type: "continuation_error"; errorMessage: string }
@@ -1110,6 +1123,7 @@ export class AgentSession {
 	// that AgentSession initiated required-compaction recovery.
 	private _requiredCompactionTurnError: RequiredCompactionError | undefined;
 	private _resumeCompactionRequirement: ResumeCompactionRequirement | undefined;
+	private _resumeSlice: ResumeSlicePlan | undefined;
 	// A retry continuation immediately follows an accepted compaction. Its first
 	// response must not retrigger threshold compaction from stale provider usage.
 	private _skipNextPostRetryCompactionCheck = false;
@@ -2909,6 +2923,9 @@ export class AgentSession {
 				projection: this._resumeCompactionRequirement.projection,
 				notice: this._resumeCompactionRequirement.notice,
 			});
+		}
+		if (this._resumeSlice !== undefined) {
+			listener(this._resumeSliceEvent(this._resumeSlice));
 		}
 		for (const source of this.settingsManager.getSelectedSettingsSources()) {
 			listener({ type: "settings_source_selected", ...source });
@@ -4756,6 +4773,32 @@ export class AgentSession {
 	/** Admit an oversized restored transcript so the normal pre-provider compaction can run. */
 	admitResumeCompactionRequired(projection: ModelUsabilityBudgetProjection): void {
 		this._resumeCompactionRequirement = createResumeCompactionRequirement(projection);
+	}
+
+	/** Reduce an over-window restored context deterministically while the recorded transcript stays intact. */
+	applyResumeSlice(plan: ResumeSlicePlan): void {
+		this.sessionManager.appendCompaction(plan.summary, plan.firstKeptEntryId, plan.tokensBefore, {
+			schema: RESUME_SLICE_SCHEMA,
+			origin: RESUME_SLICE_ORIGIN,
+		});
+		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		this._resumeSlice = plan;
+		this._sessionLogger.info("resume_context_reduced", {
+			count: plan.droppedEntries,
+			tokensBefore: plan.tokensBefore,
+			tokensAfter: plan.tokensAfter,
+		});
+		this._emit(this._resumeSliceEvent(plan));
+	}
+
+	private _resumeSliceEvent(plan: ResumeSlicePlan): AgentSessionEvent {
+		return {
+			type: "resume_context_reduced",
+			tokensBefore: plan.tokensBefore,
+			tokensAfter: plan.tokensAfter,
+			droppedEntries: plan.droppedEntries,
+			notice: resumeSliceNotice(plan),
+		};
 	}
 
 	private _getDownswitchLiveContextTokens(model: Model<Api>): number {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,24 @@
+## Deterministic resume recovery when the restored context exceeds the window (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/core/sdk.ts`: the resume-admission catch still rethrows for fresh starts, non-budget errors and compaction-disabled sessions, and now splits the remaining case. A projection whose live context still fits the raw window keeps taking the existing compaction-required admission; a projection whose live context alone exceeds the window asks `planResumeSlice()` for a deterministic reduction and rethrows the original budget error unchanged when no safe cut fits.
+- `packages/coding-agent/src/core/agent-session.ts`: new `applyResumeSlice()` appends the reduction as a `senpi.compaction.resume-slice.v1` compaction entry that preserves the recorded transcript, rebuilds the live context, writes one `resume_context_reduced` session-log line, and publishes a `resume_context_reduced` event which `subscribe()` replays for listeners that attach after `createAgentSession()` returns.
+- `packages/coding-agent/src/core/session-manager.ts` is deliberately unchanged: `_trimMirrorAfterCompaction()` only trims the in-memory mirror, and `getEntries()`, `getEntry()` and `getBranch()` reload the full history from the session file once `mirrorTrimmed` is set, so the recorded transcript already survives an admission-time reduction.
+
+### Why
+
+- Issue #1524: a `gpt-6-astra` session whose restored transcript alone exceeded the model window (live 965,016 tokens against an 850,000-token window) could never be reopened. The compaction-eligible resume branch only relaxes admission while summarization still fits, and the compaction-required admission only covers a live context within the raw window, so this band had no recovery path and every reopen failed inside `assertModelUsable` before any extension was wired.
+
+### Why an extension could not handle it
+
+- The refusal happens inside `createAgentSession()` before extensions are loaded or bound, and the recovery must append a session entry and rebuild the live context while the session is still being constructed.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/sdk.ts` resume-admission catch block, which is also the merge zone of the earlier compaction-required admission.
+- LOW: `packages/coding-agent/src/core/agent-session.ts` event union, `subscribe()` replay and the method added beside `admitResumeCompactionRequired()`.
+
 ## Editable assistant responses from the session tree (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,23 @@
 # changes.md — builtin compaction policy
 
+## Deterministic resume slice for an over-window restored context (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/compaction/resume-slice.ts` (new, fork-only): `planResumeSlice()` derives the fixed admission overhead from the failed resume projection, then walks `findCutPoint()` from the largest keep budget downwards, measuring each candidate through `buildSessionContext()` with a preview compaction entry, and returns the first cut whose context plus overhead fits the window. It carries the previous checkpoint summary forward under a bounded character budget and returns `undefined` when the fixed overhead alone cannot fit.
+
+### Why
+
+- Issue #1524: resume admission had no recovery for a restored context larger than the window itself, and summarization cannot be the first step there because the summarization request would itself be over the window.
+
+### Why an extension could not handle it
+
+- The plan is consumed inside `createAgentSession()` before extensions are wired, so it cannot live behind an extension hook.
+
+### Expected merge conflict zones
+
+- NONE: the module is fork-only. Its callers in `sdk.ts` and `agent-session.ts` are tracked in `packages/coding-agent/src/core/changes.md`.
+
 ## Resume oversized sessions into required compaction (2026-09-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/resume-slice.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/resume-slice.ts
@@ -1,0 +1,127 @@
+import { estimateTokens, findCutPoint } from "../../../compaction/compaction.ts";
+import { buildSessionContext, type CompactionEntry, type SessionEntry } from "../../../session-manager.ts";
+import type { ModelUsabilityBudgetProjection } from "./model-usability-budget.ts";
+
+export const RESUME_SLICE_SCHEMA = "senpi.compaction.resume-slice.v1";
+export const RESUME_SLICE_ORIGIN = "resume-admission";
+
+const PREVIEW_ENTRY_ID = "__senpi_resume_slice_preview__";
+const MIN_KEEP_TOKENS = 1_024;
+const MAX_CARRIED_SUMMARY_CHARS = 8_000;
+const TRUNCATION_NOTE = "\n[Earlier checkpoint truncated]";
+
+const CHECKPOINT_MARKER = [
+	"[Resume recovery checkpoint]",
+	"The restored conversation was larger than this model's context window, so older context was reduced without any provider request.",
+	"The complete transcript is still recorded in the session file. Continue from the retained messages and treat omitted details as unknown.",
+].join("\n");
+
+export interface ResumeSlicePlan {
+	readonly firstKeptEntryId: string;
+	readonly summary: string;
+	readonly tokensBefore: number;
+	readonly tokensAfter: number;
+	readonly droppedEntries: number;
+}
+
+export interface ResumeSliceInput {
+	readonly entries: readonly SessionEntry[];
+	readonly projection: ModelUsabilityBudgetProjection;
+}
+
+export function resumeSliceNotice(plan: ResumeSlicePlan): string {
+	return `Restored context of ${plan.tokensBefore} tokens exceeded this model's window, so older context was reduced to ${plan.tokensAfter} tokens before the first prompt. The full transcript is preserved in the session file.`;
+}
+
+function fixedOverheadTokens(projection: ModelUsabilityBudgetProjection): number {
+	return (
+		projection.systemPromptTokens +
+		projection.activeToolSchemaTokens +
+		projection.outputReserveTokens +
+		projection.compactionReserveTokens +
+		projection.speculationLeadTokens +
+		projection.safetyMarginTokens
+	);
+}
+
+function latestCompaction(entries: readonly SessionEntry[]): CompactionEntry | undefined {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry?.type === "compaction") return entry;
+	}
+	return undefined;
+}
+
+function resolveBoundaryStart(entries: readonly SessionEntry[]): number {
+	const previous = latestCompaction(entries);
+	if (!previous) return 0;
+	const keptIndex = entries.findIndex((entry) => entry.id === previous.firstKeptEntryId);
+	if (keptIndex >= 0) return keptIndex;
+	return entries.indexOf(previous) + 1;
+}
+
+function buildSliceSummary(entries: readonly SessionEntry[]): string {
+	const carried = latestCompaction(entries)?.summary?.trim();
+	if (!carried) return CHECKPOINT_MARKER;
+	const bounded =
+		carried.length <= MAX_CARRIED_SUMMARY_CHARS
+			? carried
+			: `${carried.slice(0, MAX_CARRIED_SUMMARY_CHARS - TRUNCATION_NOTE.length)}${TRUNCATION_NOTE}`;
+	return `${CHECKPOINT_MARKER}\n\nEarlier checkpoint:\n${bounded}`;
+}
+
+function measureSlicedContext(
+	entries: readonly SessionEntry[],
+	firstKeptEntryId: string,
+	summary: string,
+	tokensBefore: number,
+): number {
+	const preview: CompactionEntry = {
+		type: "compaction",
+		id: PREVIEW_ENTRY_ID,
+		parentId: entries.at(-1)?.id ?? null,
+		timestamp: new Date(0).toISOString(),
+		summary,
+		firstKeptEntryId,
+		tokensBefore,
+		fromHook: false,
+	};
+	return buildSessionContext([...entries, preview], PREVIEW_ENTRY_ID).messages.reduce(
+		(total, message) => total + estimateTokens(message),
+		0,
+	);
+}
+
+/**
+ * Choose the smallest deterministic context reduction that lets an over-window
+ * restored session carry an ordinary request. `findCutPoint` owns boundary
+ * safety, so a retained tool result always keeps its originating tool call.
+ */
+export function planResumeSlice({ entries, projection }: ResumeSliceInput): ResumeSlicePlan | undefined {
+	const overhead = fixedOverheadTokens(projection);
+	const keepBudget = projection.contextWindow - overhead;
+	if (keepBudget < MIN_KEEP_TOKENS) return undefined;
+
+	const entryList = [...entries];
+	const boundaryStart = resolveBoundaryStart(entryList);
+	const summary = buildSliceSummary(entryList);
+	let measuredCutIndex = -1;
+
+	for (let target = keepBudget; target >= MIN_KEEP_TOKENS; target = Math.floor(target / 2)) {
+		const cut = findCutPoint(entryList, boundaryStart, entryList.length, target);
+		if (cut.firstKeptEntryIndex === measuredCutIndex) continue;
+		measuredCutIndex = cut.firstKeptEntryIndex;
+		const firstKeptEntryId = entryList[cut.firstKeptEntryIndex]?.id;
+		if (!firstKeptEntryId) continue;
+		const tokensAfter = measureSlicedContext(entryList, firstKeptEntryId, summary, projection.liveContextTokens);
+		if (tokensAfter + overhead > projection.contextWindow) continue;
+		return {
+			firstKeptEntryId,
+			summary,
+			tokensBefore: projection.liveContextTokens,
+			tokensAfter,
+			droppedEntries: Math.max(0, cut.firstKeptEntryIndex - boundaryStart),
+		};
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -11,6 +11,7 @@ import { estimateTokens } from "./compaction/compaction.ts";
 import { createSessionCursorExecBridge } from "./cursor-exec-bridge-session.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { ModelUsabilityBudgetError } from "./extensions/builtin/compaction/model-usability-budget.ts";
+import { planResumeSlice } from "./extensions/builtin/compaction/resume-slice.ts";
 import { type ServiceTier, supportsServiceTier } from "./extensions/builtin/service-tier.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlmForTransport, TRANSPORT_IMAGE_BUDGET_BYTES } from "./messages.ts";
@@ -552,12 +553,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (
 			!hasExistingSession ||
 			!(error instanceof ModelUsabilityBudgetError) ||
-			!session.settingsManager.getCompactionEnabled() ||
-			error.projection.liveContextTokens > error.projection.contextWindow
+			!session.settingsManager.getCompactionEnabled()
 		) {
 			throw error;
 		}
-		session.admitResumeCompactionRequired(error.projection);
+		if (error.projection.liveContextTokens > error.projection.contextWindow) {
+			const plan = planResumeSlice({
+				entries: session.sessionManager.getBranch(),
+				projection: error.projection,
+			});
+			if (!plan) throw error;
+			session.applyResumeSlice(plan);
+		} else {
+			session.admitResumeCompactionRequired(error.projection);
+		}
 	}
 	sessionRef.current = session;
 	const extensionsResult = resourceLoader.getExtensions();

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-10 - Report a reduced restored context on resume
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: renders the new `resume_context_reduced` session event as a warning, next to the existing required-compaction notice, so a user whose restored context was reduced at admission sees it before the first prompt.
+
+### Why
+
+- Issue #1524: an over-window restored session now opens with a deterministically reduced context. Silently opening it would hide that older turns are no longer in context even though the transcript is still on disk.
+
+### Why an extension could not handle it
+
+- The event is published while the session is being constructed, before extensions are loaded, and the notice must render through interactive mode's own warning surface.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/interactive/interactive-mode.ts` session-event switch, adjacent to the `resume_compaction_required` case.
+
 ## 2026-09-10 - Edit assistant responses from /tree
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4531,6 +4531,10 @@ export class InteractiveMode {
 				this.showWarning(event.notice);
 				break;
 
+			case "resume_context_reduced":
+				this.showWarning(event.notice);
+				break;
+
 			case "settings_source_selected":
 				this.showSettingsSourceSelected(event);
 				break;

--- a/packages/coding-agent/test/suite/regressions/1524-resume-live-over-window.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1524-resume-live-over-window.test.ts
@@ -1,0 +1,218 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { estimateTokens } from "../../../src/core/compaction/compaction.ts";
+import {
+	ModelUsabilityBudgetError,
+	projectModelUsabilityBudget,
+} from "../../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
+import type { AgentSession } from "../../../src/core/agent-session.ts";
+import { createAgentSession } from "../../../src/core/sdk.ts";
+import type { CompactionEntry, SessionEntry } from "../../../src/core/session-manager.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * #1524: a restored transcript whose live context alone exceeds the model
+ * context window was refused at resume admission, so the session could never be
+ * opened again. #1517 admits oversized resumes only while `live <= window`.
+ */
+const CONTEXT_WINDOW = 850_000;
+const MAX_TOKENS = 128_000;
+const ORDINARY_REQUEST_CONTEXT_BUDGET = CONTEXT_WINDOW - MAX_TOKENS;
+const TURN_TEXT = "restored context ".repeat(4_800);
+
+interface SeedResult {
+	messageEntries: number;
+	liveTokens: number;
+}
+
+function seedOversizedTranscript(harness: Harness, turns: number): SeedResult {
+	const model = harness.getModel();
+	let timestamp = 1;
+	for (let turn = 0; turn < turns; turn++) {
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: `${TURN_TEXT} turn ${turn}` }],
+			timestamp: timestamp++,
+		});
+		if (turn % 6 === 5) {
+			const toolCallId = `call-${turn}`;
+			harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("running a tool", { timestamp: timestamp++ }),
+				content: [
+					{ type: "text", text: "running a tool" },
+					{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "echo hi" } },
+				],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+			});
+			harness.sessionManager.appendMessage({
+				role: "toolResult",
+				toolCallId,
+				toolName: "bash",
+				content: [{ type: "text", text: `${TURN_TEXT} tool output ${turn}` }],
+				isError: false,
+				timestamp: timestamp++,
+			});
+			continue;
+		}
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage(`${TURN_TEXT} answer ${turn}`, { timestamp: timestamp++ }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+		});
+	}
+	const entries = harness.sessionManager.getEntries();
+	const messages = harness.sessionManager.buildSessionContext().messages;
+	return {
+		messageEntries: entries.filter((entry) => entry.type === "message").length,
+		liveTokens: messages.reduce((total, message) => total + estimateTokens(message), 0),
+	};
+}
+
+function compactionEntries(entries: SessionEntry[]): CompactionEntry[] {
+	return entries.filter((entry): entry is CompactionEntry => entry.type === "compaction");
+}
+
+function messageEntryCount(harness: Harness): number {
+	return harness.sessionManager.getEntries().filter((entry) => entry.type === "message").length;
+}
+
+function persistedMessageEntryCount(harness: Harness): number {
+	const sessionFile = harness.sessionManager.getSessionFile();
+	if (!sessionFile) throw new Error("expected a persisted session file");
+	return readFileSync(sessionFile, "utf8")
+		.split("\n")
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as { type?: string })
+		.filter((entry) => entry.type === "message").length;
+}
+
+function orphanToolResultIds(messages: readonly { role: string; [key: string]: unknown }[]): string[] {
+	const callIds = new Set<string>();
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of (message.content ?? []) as Array<{ type: string; id?: string }>) {
+			if (block.type === "toolCall" && block.id) callIds.add(block.id);
+		}
+	}
+	return messages
+		.filter((message) => message.role === "toolResult")
+		.map((message) => String(message.toolCallId))
+		.filter((id) => !callIds.has(id));
+}
+
+function uncompactedRequirement(harness: Harness, session: AgentSession, liveContextTokens: number): number {
+	const projection = projectModelUsabilityBudget({
+		model: harness.getModel(),
+		systemPrompt: session.agent.state.systemPrompt,
+		tools: session.agent.state.tools,
+		liveContextTokens,
+		compaction: harness.settingsManager.getCompactionSettings(),
+		includeSpeculationLead: false,
+		admission: "resume",
+	});
+	return (
+		projection.liveContextTokens +
+		projection.systemPromptTokens +
+		projection.activeToolSchemaTokens +
+		projection.outputReserveTokens +
+		projection.compactionReserveTokens +
+		projection.speculationLeadTokens +
+		projection.safetyMarginTokens
+	);
+}
+
+async function resume(harness: Harness, dirName: string) {
+	return createAgentSession({
+		cwd: harness.tempDir,
+		agentDir: join(harness.tempDir, dirName),
+		model: harness.getModel(),
+		sessionManager: harness.sessionManager,
+	});
+}
+
+describe("#1524 resume when live context exceeds the context window", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	async function oversizedHarness(): Promise<{ harness: Harness; seed: SeedResult }> {
+		const harness = await createHarness({
+			models: [{ id: "resume", contextWindow: CONTEXT_WINDOW, maxTokens: MAX_TOKENS }],
+			persistSession: true,
+		});
+		harnesses.push(harness);
+		const seed = seedOversizedTranscript(harness, 24);
+		expect(seed.liveTokens).toBeGreaterThan(CONTEXT_WINDOW);
+		return { harness, seed };
+	}
+
+	it("opens the session, keeps the transcript, and leaves room for an ordinary request", async () => {
+		const { harness, seed } = await oversizedHarness();
+
+		const resumed = await resume(harness, "resume-agent");
+		const messages = resumed.session.agent.state.messages;
+		const contextTokens = messages.reduce((total: number, message) => total + estimateTokens(message), 0);
+
+		expect(contextTokens).toBeLessThanOrEqual(ORDINARY_REQUEST_CONTEXT_BUDGET);
+		expect(uncompactedRequirement(harness, resumed.session, contextTokens)).toBeLessThanOrEqual(CONTEXT_WINDOW);
+		expect(persistedMessageEntryCount(harness)).toBe(seed.messageEntries);
+		const entries = harness.sessionManager.getEntries();
+		expect(entries.filter((entry) => entry.type === "message")).toHaveLength(seed.messageEntries);
+		const compactions = compactionEntries(entries);
+		expect(compactions).toHaveLength(1);
+		expect(compactions[0]?.details).toMatchObject({ origin: "resume-admission" });
+		expect(orphanToolResultIds(messages as never)).toEqual([]);
+		resumed.session.dispose();
+	});
+
+	it("reopening an already reduced session does not add another reduction", async () => {
+		const { harness } = await oversizedHarness();
+
+		const first = await resume(harness, "resume-agent");
+		first.session.dispose();
+		const afterFirst = compactionEntries(harness.sessionManager.getEntries()).length;
+		const second = await resume(harness, "resume-agent-2");
+		second.session.dispose();
+
+		expect(compactionEntries(harness.sessionManager.getEntries())).toHaveLength(afterFirst);
+	});
+
+	it("refuses without touching history when the fixed overhead cannot fit", async () => {
+		const harness = await createHarness({
+			models: [{ id: "tiny", contextWindow: 12_000, maxTokens: 10_000 }],
+			persistSession: true,
+		});
+		harnesses.push(harness);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "overflowing ".repeat(20_000) }],
+			timestamp: 1,
+		});
+		const before = messageEntryCount(harness);
+
+		await expect(resume(harness, "tiny-agent")).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		expect(messageEntryCount(harness)).toBe(before);
+		expect(compactionEntries(harness.sessionManager.getEntries())).toHaveLength(0);
+	});
+
+	it("keeps refusing when the user disabled compaction", async () => {
+		const { harness } = await oversizedHarness();
+		const agentDir = join(harness.tempDir, "disabled-agent");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ compaction: { enabled: false } }));
+		const before = messageEntryCount(harness);
+
+		await expect(resume(harness, "disabled-agent")).rejects.toBeInstanceOf(ModelUsabilityBudgetError);
+
+		expect(messageEntryCount(harness)).toBe(before);
+		expect(compactionEntries(harness.sessionManager.getEntries())).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

A session whose restored transcript is larger than the model's context window could not be reopened at all: resume admission threw `ModelUsabilityBudgetError` inside `createAgentSession` before any extension was wired, so neither compaction nor its recovery paths could run (#1524, reported with live 965,016 tokens against an 850,000-token window). The compaction-eligible resume branch only relaxes admission while summarization still fits, and the compaction-required admission from #1517 deliberately excluded exactly this band.

Resume now reduces the live context deterministically, without any provider request, before the session opens. The reduction reuses the existing compaction cut-point selection, keeps the recorded transcript intact, and is accepted only when the remaining context still leaves room for the whole request overhead, so the first ordinary request cannot overflow. When the fixed overhead alone cannot fit, the original actionable budget error is raised and nothing is written; sessions with compaction disabled keep refusing as before.

## Changes

- **Reduction planner** (`resume-slice.ts`, new, fork-only): derives the fixed admission overhead from the failed projection, walks `findCutPoint()` from the largest keep budget downwards, measures each candidate through a preview compaction entry, and returns the first cut whose context plus overhead fits the window. Carries the previous checkpoint summary forward under a bounded budget; returns nothing when the overhead alone cannot fit.
- **Admission** (`sdk.ts`): unchanged refusals for fresh starts, non-budget errors and compaction-disabled sessions; the over-window case now asks for a plan and rethrows the original error when there is none, while the in-window case keeps the existing compaction-required admission.
- **Session** (`agent-session.ts`): `applyResumeSlice()` appends the reduction as a `senpi.compaction.resume-slice.v1` entry, rebuilds the live context, logs one line, and publishes a `resume_context_reduced` event that `subscribe()` replays for listeners attached after construction.
- **Interactive** (`interactive-mode.ts`): renders that event as a warning next to the existing required-compaction notice.
- `session-manager.ts` is deliberately untouched — see Risks.

## QA & Evidence

Remote host `gorky` (linux/x86_64, node 24.20.0, vitest 4.1.11). Evidence under `local-ignore/qa-evidence/20260910-issue1524/`.

- **What was tested:** failing-first proof, before any production edit — new regression against unmodified `main`.
  **Observed result:** vitest exit 1; `ModelUsabilityBudgetError` at `sdk.ts:546` with measured live 979,364 / window 850,000 / required 1,158,762, the same band as the report.
  **Artifact:** `c001-red-before-production-edit.log`
  **Why sufficient:** reproduces the reported failure through the real admission path, not a stub.

- **What was tested:** the same regression after the change.
  **Observed result:** 4 passed — session opens, uncompacted requirement fits the window, transcript preserved on disk and in memory, no orphaned tool result, reopening adds no second reduction, impossible overhead still refuses without writing, compaction-disabled still refuses.
  **Artifact:** `c001-green-after-fix.log`
  **Why sufficient:** RED to GREEN through the identical scenario.

- **What was tested:** whether the new assertions can actually fail (mutation pass).
  **Observed result:** removing the compaction-disabled guard, removing the post-reduction budget check, stopping the trimmed mirror from reloading the file, and making the trim truncate the session file each fail their owning assertion; the restored tree returns 4 passed.
  **Artifact:** `c002-mutation-matrix.md`
  **Why sufficient:** this pass caught two of my own assertions being unfalsifiable and one unnecessary API change; all three were corrected before this PR.

- **What was tested:** adjacent behavior — resume admission, model usability budget, session persistence, compaction mechanics.
  **Observed result:** 92 files / 731 tests passed.
  **Artifact:** `c003-adjacent-regressions.log`
  **Why sufficient:** covers the neighbours of every touched seam, including `#1511` and start/switch admission.

- **What was tested:** `npm run check` and `npm run build --workspace @code-yeongyu/senpi`.
  **Observed result:** both exit 0.
  **Artifacts:** `c003-static-check.log`, `c003-build.log`
  **Why sufficient:** matches the repository's static gate. An earlier red run was a stale hybrid test tree, not this change; it is green on a clean tree.

- **What was tested:** real CLI, `node .agents/skills/senpi-qa/scripts/qa-1524-resume.mjs` — start a sandboxed session against a scripted local provider, inflate the persisted transcript past the window, resume with `--continue`.
  **Observed result:** 11/11 PASS. Restored context ~156,380 tokens against a 120,000-token window; resumed turn exits 0 with no budget error; the outgoing provider request measured on the wire is ~45,423 tokens inside the 112,000 budget; all 60 inflated records remain on disk; a second resume works with exactly one recorded reduction; the real credential file is untouched.
  **Artifact:** `c004-real-cli-resume-qa.log`
  **Why sufficient:** proves the user-visible behavior end to end on the real surface, measuring the actual request bytes rather than in-process state.

## Risks & Residuals

- **Context loss on recovery:** accepted and reported. This band requires dropping context by definition; the reduction keeps as much recent context as fits, records a checkpoint summary, preserves the transcript, and the user is warned before the first prompt.
- **Persistence API:** mitigated by dropping my first approach. I initially added a `preserveTranscript` flag to `SessionManager.appendCompaction`, assuming compaction truncates the session file. It does not — `_trimMirrorAfterCompaction` only trims the in-memory mirror and entry reads reload the full history from the file once trimmed. The flag protected nothing and was reverted, so persistence is unchanged and the transcript guarantee is pinned by tests that fail if it regresses.
- **Compaction disabled:** unchanged by design; those sessions still refuse with the actionable budget error rather than silently losing context.
- **Fixture fidelity:** the unit fixture reproduces the reported band (live > window) at measured 979,364 tokens rather than the exact 965,016 from the report; the arithmetic and code path are identical.

## Related Issues

Fixes #1524. Follows #1509 (compaction-eligible resume admission) and #1517 (compaction-required resume admission); supersedes the approach in the still-open #1430, which conflicts with current `main` and reduces context without the post-reduction budget check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resuming a session whose restored transcript is larger than the model's context window no longer fails with `ModelUsabilityBudgetError` — admission now reduces the live context without a provider request before the session opens.

- The reduction reuses compaction cut-point selection, preserves the transcript on disk, and only applies when the remaining context still leaves room for the full request overhead.
- If no safe cut fits, or compaction is disabled, the original budget error is raised and nothing is written.
- Interactive mode warns before the first prompt, and reopening an already reduced session does not reduce again.

<sup>Written for commit da117f6f502f978fb9ab88279f8156d89c7a8a24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

