### PR TITLE
fix(notice): wrap notice lines and put the update command on its own line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- The update-available notice no longer clips a long update command into an unrunnable fragment. The command is shown on its own line and the notice box wraps to the terminal width ([#1539](https://github.com/code-yeongyu/senpi/issues/1539)).
+
 - The published package is Bun-compile-safe on its own: publish staging inlines css-tree's `data/patch.json`, mdn-data dictionaries and version, which css-tree otherwise resolves through `createRequire(import.meta.url)` at module scope. A binary compiled from the tarball previously died on the first `webfetch` markdown or text conversion with `Cannot find module '../data/patch.json'`; jsdom's binary-only worker rewrite deliberately stays out of the tarball so a plain Bun consumer keeps jsdom's own lookup ([#1540](https://github.com/code-yeongyu/senpi/pull/1540)).
 
 - Resuming a session whose restored context is larger than the model's context window no longer fails with `ModelUsabilityBudgetError`. Admission now reduces the live context deterministically, without any provider request, before the session opens: it reuses the compaction cut-point selection so a retained tool result keeps its originating tool call, leaves the recorded transcript intact, and accepts a reduction only when the remaining context still leaves room for the system prompt, tool schemas, output reserve, compaction reserve and safety margin, so the first ordinary request cannot overflow. When the fixed overhead alone cannot fit, the original actionable budget error is raised and nothing is written, and sessions with compaction disabled keep the existing refusal. Interactive mode reports the reduction before the first prompt ([#1524](https://github.com/code-yeongyu/senpi/issues/1524)).

--- a/packages/coding-agent/src/core/extensions/notice/box.ts
+++ b/packages/coding-agent/src/core/extensions/notice/box.ts
@@ -1,20 +1,29 @@
-import { Box, type Component, Text } from "@earendil-works/pi-tui";
+import { Box, type Component, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { Theme } from "../../../modes/interactive/theme/theme.ts";
 import type { NoticeSpec } from "./spec.ts";
 
 const BOLD = "[1m";
 const BOLD_OFF = "[22m";
 
+function noticeText(text: string): Component {
+	return {
+		render(width: number): string[] {
+			return wrapTextWithAnsi(text, Math.max(1, width));
+		},
+		invalidate(): void {},
+	};
+}
+
 /** Render a NoticeSpec as the shared transcript notice box (loop-guard visual family). */
 export function buildNoticeBox(spec: NoticeSpec, options: { readonly expanded: boolean }, theme: Theme): Component {
 	const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
-	box.addChild(new Text(theme.fg(spec.tone ?? "accent", `${BOLD}${spec.title}${BOLD_OFF}`), 0, 0));
-	box.addChild(new Text(theme.fg("dim", spec.why), 0, 0));
+	box.addChild(noticeText(theme.fg(spec.tone ?? "accent", `${BOLD}${spec.title}${BOLD_OFF}`)));
+	box.addChild(noticeText(theme.fg("dim", spec.why)));
 	for (const line of spec.extra ?? []) {
-		box.addChild(new Text(theme.fg(line.tone ?? "dim", line.text), 0, 0));
+		box.addChild(noticeText(theme.fg(line.tone ?? "dim", line.text)));
 	}
 	if (options.expanded && spec.expandedLine !== undefined) {
-		box.addChild(new Text(theme.fg("dim", spec.expandedLine), 0, 0));
+		box.addChild(noticeText(theme.fg("dim", spec.expandedLine)));
 	}
 	return box;
 }

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-10 - Keep the update command fully visible in the notice box
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `showNewVersionNotification` now emits the update command on its own notice `extra` line instead of appending it to the why sentence, so a long Bun global install command is not glued to prose.
+
+### Why
+
+- Issue #1539: at 80 columns the update-available notice showed `Run bun add --cwd` and nothing runnable. The command must sit on its own line so it can wrap as one copyable unit.
+
+### Why an extension could not handle it
+
+- The update notice is assembled by interactive mode after the version check; there is no extension hook for that surface.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/interactive/interactive-mode.ts` `showNewVersionNotification`.
+
 ## 2026-09-10 - Report a reduced restored context on resume
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6228,8 +6228,8 @@ export class InteractiveMode {
 		this.showNoticeBox({
 			title: "Update Available",
 			tone: "warning",
-			why: `New version ${newVersion} is available. Run ${action}`,
-			extra: [{ text: `Changelog: ${changelogLink}`, tone: "accent" }],
+			why: `New version ${newVersion} is available.`,
+			extra: [{ text: action }, { text: `Changelog: ${changelogLink}`, tone: "accent" }],
 		});
 	}
 

--- a/packages/coding-agent/test/divergent-notice-rendering.test.ts
+++ b/packages/coding-agent/test/divergent-notice-rendering.test.ts
@@ -1,8 +1,10 @@
 import type { Model } from "@earendil-works/pi-ai";
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
+import { APP_NAME, BRAND } from "../src/config.ts";
 import promptUrlWidgetExtension from "../src/core/extensions/builtin/prompt-url-widget.ts";
 import { renderBannerLines } from "../src/core/extensions/builtin/rules/ui/rules-banner.ts";
+import type { NoticeSpec } from "../src/core/extensions/notice/spec.ts";
 import type { ExtensionAPI, ExtensionContext } from "../src/core/extensions/types.ts";
 import { buildNoticeBox, noticeEntryRenderer, noticeMessageRenderer } from "../src/index.ts";
 import { EarendilAnnouncementComponent } from "../src/modes/interactive/components/earendil-announcement.ts";
@@ -88,6 +90,23 @@ describe("divergent notice rendering", () => {
 		const fakeThis = createInteractiveThis();
 		interactiveMethod(methodName).call(fakeThis, ...args);
 		expectNoticeContract(renderChildren(fakeThis.chatContainer));
+	});
+
+	test("showNewVersionNotification emits the update command on its own extra line", () => {
+		const fakeThis = createInteractiveThis();
+		let captured: NoticeSpec | undefined;
+		fakeThis.showNoticeBox = (spec: unknown): void => {
+			captured = spec as NoticeSpec;
+			interactiveMethod("showNoticeBox").call(fakeThis, spec);
+		};
+
+		interactiveMethod("showNewVersionNotification").call(fakeThis, "5.0.0-0.beta.51");
+
+		expect(captured).toBeDefined();
+		const action = BRAND?.update?.command ?? `${APP_NAME} update`;
+		expect(captured?.why).toBe("New version 5.0.0-0.beta.51 is available.");
+		expect(captured?.why).not.toContain(action);
+		expect(captured?.extra?.some((line) => line.text === action)).toBe(true);
 	});
 
 	test("renders loaded-resource conflict diagnostics through the notice background", () => {

--- a/packages/coding-agent/test/suite/notice-kit.test.ts
+++ b/packages/coding-agent/test/suite/notice-kit.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
 	buildNoticeBox,
@@ -83,6 +84,21 @@ describe("buildNoticeBox", () => {
 		const titleText = "[1mtoned[22m";
 		expect(rawRender({ title: "toned", tone: "warning", why: "w" })).toContain(theme.fg("warning", titleText));
 		expect(rawRender({ title: "toned", why: "w" })).toContain(theme.fg("accent", titleText));
+	});
+
+	it("wraps a 134-char why at width 80 so every visible row fits and the full text is present", () => {
+		const why =
+			"New version 5.0.0-0.beta.51 is available. Run bun add --cwd '/Users/bitcosgo/.bun/install/global/node_modules/omo-ai' -g omo-ai@beta x";
+		expect(why.length).toBe(134);
+
+		const rows = buildNoticeBox({ title: "Update Available", why }, { expanded: false }, theme).render(80);
+		expect(rows.length).toBeGreaterThan(0);
+		for (const row of rows) {
+			expect(visibleWidth(row)).toBeLessThanOrEqual(80);
+		}
+
+		const present = rows.map((row) => row.replace(ANSI_PATTERN, "").trim()).join(" ");
+		expect(present.replace(/\s+/g, " ")).toContain(why);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes #1539. The update-available notice assembled a long Bun global install command into the same `why` sentence as the version prose, then rendered that sentence as a single notice line. At 80 columns the user saw `Run bun add --cwd` and nothing they could actually run.

The command now lives on its own extra line, and `buildNoticeBox` wraps every line to the available width with the existing ANSI-aware wrap helper so no notice can clip content.

## Root cause

- `packages/coding-agent/src/modes/interactive/interactive-mode.ts:6224-6233` built `why = "New version <v> is available. Run <cmd>"` as one string, so an 88-character Bun command shared the line with prose (about 134 characters total).
- `packages/coding-agent/src/core/extensions/notice/box.ts:11-13` put `spec.why` into one child with no wrap call on the notice path. A long command then either wrapped mid-prose (`Run bun add --cwd` on the first row) or was clipped by the terminal.

The install-method detection itself was not the bug: `updateTarget()` already returns the correct Bun command.

## Changes

- `showNewVersionNotification` emits the update command on its own `extra` line instead of appending it to `why`. The changelog extra line is unchanged.
- `buildNoticeBox` wraps title, why, extra, and expanded lines with `wrapTextWithAnsi` at render width. Box padding, `customMessageBg`, and `theme.fg` calls are unchanged.

## Verification

Failing-first, then green, scoped to the notice files (no full `bun test` on this machine):

```
cd packages/coding-agent && npx vitest --run test/suite/notice-kit.test.ts test/divergent-notice-rendering.test.ts
```

RED (before the production change; extra-line test):

```
FAIL  test/divergent-notice-rendering.test.ts > divergent notice rendering > showNewVersionNotification emits the update command on its own extra line
AssertionError: expected 'New version 5.0.0-0.beta.51 is availa…' to be 'New version 5.0.0-0.beta.51 is availa…'

Expected: "New version 5.0.0-0.beta.51 is available."
Received: "New version 5.0.0-0.beta.51 is available. Run senpi update"
```

The 80-column wrap contract already held via `Text.render` on old code; it is now pinned and implemented on the notice path with `wrapTextWithAnsi`.

GREEN (after the production change):

```
Test Files  2 passed (2)
Tests  20 passed (20)
```

Related notice tests also passed:

```
cd packages/coding-agent && npx vitest --run test/suite/notice-kit.test.ts test/divergent-notice-rendering.test.ts test/notice-public-api.test.ts test/risky-main-model-warning-tui.test.ts test/high-reasoning-warning-tui.test.ts
```

```
Test Files  5 passed (5)
Tests  32 passed (32)
```

`npx biome check --write` on the four touched files: clean. LSP diagnostics on those files: none.

`script/qa/web-terminal-visual-qa.mjs` is not in this repo, so no 80-column screenshot was captured.

## Ideal-state checklist

1. The update command is emitted on its own line (use the notice spec's extra lines) rather than appended to prose. — `showNewVersionNotification` sets `why` to `New version <v> is available.` and puts the command in `extra[0]`. Covered by the extra-line test.
2. `buildNoticeBox` wraps any line that exceeds the available width (repo ANSI-aware wrap utility, no hand-roll), preserving the box visual family and theme calls. — each notice line is rendered through `wrapTextWithAnsi` inside the existing `Box(1, 1, theme.bg("customMessageBg"))`. Covered by the 134-char why at width 80 test.
3. The wrapped command stays copyable as one logical unit (wrap at whitespace, never mid-token where avoidable). — `wrapTextWithAnsi` word-wraps; the command is a dedicated extra line so it is not glued to prose.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1539: the update-available notice folded a long Bun global update command into the why prose, so at 80-column terminals the command was clipped into an unrunnable fragment. The command now sits on its own line and every notice line wraps to the terminal width.

- `buildNoticeBox` wraps every notice line with `wrapTextWithAnsi` at the available width.
- `showNewVersionNotification` moves the update command to its own `extra` line instead of appending it to the `why` prose.
- Adds tests pinning the 80-column wrap contract and the standalone update command.

<sup>Written for commit a0d6ad6e20b4eb4fd1ada1e726068a2d05ea4a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

