### PR TITLE
fix(agent): honor an inline isError on returned tool results

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- A tool result returned with `isError: true` is now treated as a tool error: `tool_execution_end.isError` and the `toolResult` message carry the flag while `content` and `details` stay intact, so structured failures (team, memory, terminal tools) render and report as failures instead of successes. `AgentToolResult` declares the optional `isError` field.
+
 ### Removed
 
 ## [2026.9.9-2] - 2026-09-09

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1198,7 +1198,7 @@ async function executePreparedToolCall(
 		}
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);
-		return { result: settled, isError: false };
+		return { result: settled, isError: settled.isError === true };
 	} catch (error) {
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,3 +1,22 @@
+## 2026-09-10 - Honor an inline isError on returned tool results
+
+### What changed
+
+- packages/agent/src/types.ts: `AgentToolResult` declares `isError?: boolean` so a tool can report a failure without throwing while keeping `content` and `details` intact.
+- packages/agent/src/agent-loop.ts: `executePreparedToolCall` carries `settled.isError === true` into the executed outcome instead of hardcoding `isError: false`, so `tool_execution_end` and the `toolResult` message flag the failure.
+
+### Why
+
+- Structured-failure tools (omo's team and memory tools, the terminal tool) return `isError: true` with typed `details` for the model to branch on. The loop dropped that flag, so the TUI painted the row as success, the RPC `tool_execution_end.isError` the desktop GUI maps to "failed" stayed false, and `tool_result` hooks saw a success.
+
+### Why this lives in the fork
+
+- The error flag is decided inside the loop's execution outcome before any hook runs; extensions can only rewrite it per tool through `tool_result`, not restore the contract for every tool.
+
+### Expected merge conflict zones
+
+- `executePreparedToolCall` return in packages/agent/src/agent-loop.ts and the `AgentToolResult` interface in packages/agent/src/types.ts.
+
 ## 2026-09-10 - Use native TypeScript builds for omob performance
 
 ### What changed

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -443,6 +443,11 @@ export interface AgentToolResult<T> {
 	 * Early termination only happens when every finalized tool result in the batch sets this to true.
 	 */
 	terminate?: boolean;
+	/**
+	 * Report a failure without throwing: `true` marks this result as a tool error while keeping
+	 * `content` and `details` intact for the model and renderers. Omitted or `false` means success.
+	 */
+	isError?: boolean;
 }
 
 /**

--- a/packages/agent/test/tool-inline-is-error.test.ts
+++ b/packages/agent/test/tool-inline-is-error.test.ts
@@ -1,0 +1,168 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+
+/**
+ * A tool may report a failure WITHOUT throwing by setting `isError: true` on the
+ * result it returns, keeping its structured `details` intact for the model to
+ * branch on (omo's team/memory tools and the terminal tool do this). The loop
+ * must carry that flag into `tool_execution_end` and the `toolResult` message,
+ * because every downstream error surface keys on it: the TUI's tool-row
+ * background, the RPC `isError` field the desktop GUI maps to "failed", and
+ * `tool_result` extension hooks.
+ */
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function createUserMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function isLlmMessage(message: AgentMessage): message is Message {
+	return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+type ToolExecutionEndEvent = Extract<AgentEvent, { type: "tool_execution_end" }>;
+type ToolResultStartEvent = Extract<AgentEvent, { type: "message_start" }> & {
+	message: { role: "toolResult"; isError: boolean };
+};
+
+async function runSingleToolCall(tool: AgentTool<ReturnType<typeof Type.Object>, unknown>) {
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+	const config: AgentLoopConfig = { model: createModel(), convertToLlm: (messages) => messages.filter(isLlmMessage) };
+	let llmCalls = 0;
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([createUserMessage("go")], context, config, undefined, () => {
+		llmCalls++;
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			mockStream.push({
+				type: "done",
+				reason: llmCalls === 1 ? "toolUse" : "stop",
+				message:
+					llmCalls === 1
+						? createAssistantMessage(
+								[{ type: "toolCall", id: "tool-1", name: tool.name, arguments: {} }],
+								"toolUse",
+							)
+						: createAssistantMessage([{ type: "text", text: "done" }], "stop"),
+			});
+		});
+		return mockStream;
+	});
+	for await (const event of stream) events.push(event);
+
+	const end = events.find((event): event is ToolExecutionEndEvent => event.type === "tool_execution_end");
+	const toolResult = events.find(
+		(event): event is ToolResultStartEvent => event.type === "message_start" && event.message.role === "toolResult",
+	);
+	if (!end || !toolResult) throw new Error("tool call did not complete");
+	return { end, toolResult };
+}
+
+function createTool(name: string, result: Record<string, unknown>): AgentTool<ReturnType<typeof Type.Object>, unknown> {
+	return {
+		name,
+		label: name,
+		description: `returns ${JSON.stringify(result)}`,
+		parameters: Type.Object({}),
+		async execute() {
+			return result as never;
+		},
+	};
+}
+
+describe("inline tool result isError", () => {
+	it("marks a result returned with isError: true as a tool error without discarding its details", async () => {
+		const { end, toolResult } = await runSingleToolCall(
+			createTool("inline_fail", {
+				content: [{ type: "text", text: "member 'x' failed to start" }],
+				details: { kind: "runtime_error" },
+				isError: true,
+			}),
+		);
+
+		expect(end.isError).toBe(true);
+		expect(end.result.details).toEqual({ kind: "runtime_error" });
+		expect(toolResult.message.isError).toBe(true);
+	});
+
+	it("keeps a result without an isError flag as a successful tool result", async () => {
+		const { end, toolResult } = await runSingleToolCall(
+			createTool("plain_ok", { content: [{ type: "text", text: "ok" }], details: { kind: "created" } }),
+		);
+
+		expect(end.isError).toBe(false);
+		expect(toolResult.message.isError).toBe(false);
+	});
+
+	it("treats an explicit isError: false as success", async () => {
+		const { end } = await runSingleToolCall(
+			createTool("explicit_ok", { content: [{ type: "text", text: "ok" }], details: {}, isError: false }),
+		);
+
+		expect(end.isError).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,7 +23,10 @@
 - Goal continuation prompts now treat asking through `request_user_input` / `ask_user_question` as a legal ending, audit user-only blockers before marking a goal blocked, and count materially different attempts rather than automatic wake-ups for recurrence.
 - Prompt presets route a user question through `request_user_input` (GPT-6 Astra, GPT-5.6) or `ask_user_question` (Claude Fable/Opus, Kimi K3, GLM 5.x) when the tool is available, instead of ending the turn on a bare question.
 
+- Extension tools can report a failure without throwing: a result returned with `isError: true` is now delivered as a tool error on both the agent-loop path and `pi.executeTool`, so the TUI paints the row with the error background, RPC `tool_execution_end.isError` is `true`, and `tool_result` hooks observe the failure while the tool's `content` and `details` stay intact.
+
 - `generate_image` defaults to `gpt-image-2.5-sunburst`, the most capable image model (Flare stays selectable when speed matters), prices requests from the builtin image catalog instead of zero, and the native `image_generation` server tool is injected with that same model so official OpenAI Responses sessions no longer fall back to the API default `gpt-image-1`.
+
 ### Fixed
 
 - An unanswered-yet question asked with wait-for-answer off now delivers its answer - and its idle-timeout notice - as exactly one framed user message on every surface (interactive TUI, RPC clients, app-server clients); previously only the TUI delivered it and answers given over RPC or app-server were dropped. A TUI attached to a shared host also advertises the `question` capability, so it renders the full question overlay instead of falling back to sequential prompts.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3245,6 +3245,7 @@ export class AgentSession {
 				options?.signal,
 				options?.onUpdate as AgentToolUpdateCallback<unknown> | undefined,
 			);
+			isError = result.isError === true;
 		} catch (err) {
 			result = {
 				content: [

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,20 @@
+## Honor an inline isError on executeTool results (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: the direct `executeTool` path sets `isError = result.isError === true` after a tool settles, so `tool_result` hooks observe the same error flag the agent loop now derives from a returned `isError: true`.
+
+### Why
+
+- A tool that reports a structured failure without throwing was delivered to `tool_result` hooks as a success on the `pi.executeTool` path, diverging from the agent-loop path fixed in `packages/agent/src/agent-loop.ts`.
+
+### Why an extension could not handle it
+
+- The flag is computed inside `AgentSession` before hooks run; a hook can only override it after the fact and per tool.
+
+### Expected merge conflict zones
+
+- LOW: the `executeTool` try block in `packages/coding-agent/src/core/agent-session.ts`.
 ## askUser settings and --no-ask-user session override (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/test/execute-tool-hooks.test.ts
+++ b/packages/coding-agent/test/execute-tool-hooks.test.ts
@@ -168,4 +168,48 @@ describe("pi.executeTool hook dispatch", () => {
 			harness.cleanup();
 		}
 	});
+
+	it("reports a returned isError: true to tool_result hooks without discarding details", async () => {
+		const observed: Array<{ isError: boolean; details: unknown }> = [];
+		const harness = await createExecuteToolHarness((pi) => {
+			pi.registerTool({
+				name: "inline_fail_ext",
+				label: "Inline fail",
+				description: "Returns a structured failure without throwing",
+				parameters: Type.Object({}),
+				execute: async () => ({
+					content: [{ type: "text", text: "member 'x' failed to start" }],
+					details: { kind: "runtime_error" },
+					isError: true,
+				}),
+			});
+			pi.registerTool({
+				name: "inline_ok_ext",
+				label: "Inline ok",
+				description: "Returns a success without an isError flag",
+				parameters: Type.Object({}),
+				execute: async () => ({
+					content: [{ type: "text", text: "created" }],
+					details: { kind: "created" },
+				}),
+			});
+			pi.on("tool_result", (event) => {
+				observed.push({ isError: event.isError, details: event.details });
+				return undefined;
+			});
+		});
+
+		try {
+			const failed = await harness.api.executeTool("inline_fail_ext", {});
+			await harness.api.executeTool("inline_ok_ext", {});
+
+			expect(observed).toEqual([
+				{ isError: true, details: { kind: "runtime_error" } },
+				{ isError: false, details: { kind: "created" } },
+			]);
+			expect(failed.details).toEqual({ kind: "runtime_error" });
+		} finally {
+			harness.cleanup();
+		}
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/1524-resume-live-over-window.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1524-resume-live-over-window.test.ts
@@ -2,12 +2,12 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../../../src/core/agent-session.ts";
 import { estimateTokens } from "../../../src/core/compaction/compaction.ts";
 import {
 	ModelUsabilityBudgetError,
 	projectModelUsabilityBudget,
 } from "../../../src/core/extensions/builtin/compaction/model-usability-budget.ts";
-import type { AgentSession } from "../../../src/core/agent-session.ts";
 import { createAgentSession } from "../../../src/core/sdk.ts";
 import type { CompactionEntry, SessionEntry } from "../../../src/core/session-manager.ts";
 import { createHarness, type Harness } from "../harness.ts";


### PR DESCRIPTION
## What changed

- `packages/agent/src/types.ts`: `AgentToolResult` declares `isError?: boolean` — report a failure without throwing while keeping `content` and `details`.
- `packages/agent/src/agent-loop.ts`: `executePreparedToolCall` returns `isError: settled.isError === true` instead of a hardcoded `false`, so `tool_execution_end.isError` and the `toolResult` message carry the flag.
- `packages/coding-agent/src/core/agent-session.ts`: the `pi.executeTool` path derives `isError` the same way, so `tool_result` hooks observe it.
- Tests: `packages/agent/test/tool-inline-is-error.test.ts` (inline true -> flagged; missing / explicit false -> success), `packages/coding-agent/test/execute-tool-hooks.test.ts` (hook observes `isError: true` with original details on `executeTool`).
- Trackers + changelogs: `packages/agent/src/changes.md`, `packages/coding-agent/src/core/changes.md`, both package `CHANGELOG.md` files.
- Unrelated one-line biome import-sort drift in `test/suite/regressions/1524-resume-live-over-window.test.ts` committed separately so `npm run check` leaves the tree clean.

## Why

Structured-failure tools (omo's team and memory tools, the builtin `terminal` tool) return `isError: true` with typed `details` for the model to branch on. The loop dropped the flag, so every error surface painted the failure as success at once: TUI `toolSuccessBg`, RPC `tool_execution_end.isError=false` (desktop GUI shows "completed"), and `tool_result` hooks. User-visible instance: `team_create` reporting `member '<name>' failed to start: No available model for category "deep"` as a green row.

fixes #1548

## Observed behavior

RED (before, `main@97a00393b`): `tool_execution_end.isError = false | toolResult.isError = false` for a tool returning `isError: true`.
GREEN (after): both `true`; `details` preserved; no-flag and `isError: false` results stay `false`.

## QA / evidence

- `packages/agent`: `npx vitest run test/tool-inline-is-error.test.ts` RED then GREEN (3/3); full package suite 44 files / 559 passed / 1 pre-existing skip.
- `packages/coding-agent`: `npx vitest run test/execute-tool-hooks.test.ts test/execute-tool.test.ts` RED then GREEN (12/12).
- `npm run check` exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk platform lock, `tsc --noEmit`, browser smoke).
- TUI real-surface (xterm.js screenshot of an inline-`isError` tool row in `toolErrorBg`): attached in a follow-up comment.

## Residual risk

- Tools that already returned `isError: true` (terminal tool, omo memory/team tools) now render and report as errors — that is the intended contract; no tool in this repo returned the flag for a success.
- Consumer follow-up: https://github.com/code-yeongyu/oh-my-openagent/issues/8063.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tools that report failures by returning `isError: true` were previously delivered as successes: the agent loop hardcoded `isError: false` and `executeTool` never read the flag. The flag now flows through `tool_execution_end`, the `toolResult` message, and `tool_result` hooks, so structured failures render and report as errors while `content` and `details` stay intact. Fixes #1548.

**Bug Fixes**
- `AgentToolResult` now declares optional `isError`; both execution paths derive the flag from it instead of hardcoding `false`.
- Tools already returning the flag (terminal, memory, team tools) now render as errors — the intended contract.
- Tests cover `isError: true`, missing flag, and explicit `false`.

<sup>Written for commit 5cd7d2bc53240d0e6f1c105a8ce46cce2a621140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

