### PR TITLE
docs(extensions): document returning isError: true as a tool failure signal

### DIFF
--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -12,6 +12,7 @@
 ### Why this lives in the fork
 
 - The error flag is decided inside the loop's execution outcome before any hook runs; extensions can only rewrite it per tool through `tool_result`, not restore the contract for every tool.
+- This deliberately diverges from upstream pi-mono, which documents "returning a value never sets the error flag"; `packages/coding-agent/docs/extensions.md` now documents both signaling paths.
 
 ### Expected merge conflict zones
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2322,17 +2322,33 @@ pi.registerTool({
 
 **Usage accounting:** If a tool makes nested LLM calls, return their combined `Usage` as `usage`. Senpi persists it on the tool result and includes it in footer, `/session`, and RPC session totals. `tool_result` handlers can inspect or replace this value.
 
-**Signaling errors:** To mark a tool execution as failed (sets `isError: true` on the result and reports it to the LLM), throw an error from `execute`. Returning a value never sets the error flag regardless of what properties you include in the return object.
+**Signaling errors:** There are two ways to mark a tool execution as failed (sets `isError: true` on the result, the `tool_execution_end` event, and the `toolResult` message the LLM sees):
+
+- Throw an error from `execute`. The thrown message becomes the result text and `details` is empty.
+- Return a normal result with `isError: true`. `content` and `details` are delivered unchanged, so the LLM can still branch on your typed `details` while every error surface (TUI row background, RPC `isError`, `tool_result` handlers) treats the call as a failure. Omitting `isError` or setting it to `false` is a success.
 
 **Early termination:** Return `terminate: true` from `execute()` to hint that the automatic follow-up LLM call should be skipped after the current tool batch. This only takes effect when every finalized tool result in that batch is terminating. See [examples/extensions/structured-output.ts](../examples/extensions/structured-output.ts) for a minimal example where the agent ends on a final structured-output tool call.
 
 ```typescript
-// Correct: throw to signal an error
+// Throw when there is nothing structured to report
 async execute(toolCallId, params) {
   if (!isValid(params.input)) {
     throw new Error(`Invalid input: ${params.input}`);
   }
   return { content: [{ type: "text", text: "OK" }], details: {} };
+}
+
+// Return isError: true when the LLM should still see typed details
+async execute(toolCallId, params) {
+  const outcome = await createTeam(params);
+  if (outcome.kind === "member_start_rejected") {
+    return {
+      content: [{ type: "text", text: outcome.reason }],
+      details: { kind: "runtime_error", code: outcome.kind },
+      isError: true,
+    };
+  }
+  return { content: [{ type: "text", text: "Created" }], details: { kind: "created" } };
 }
 ```
 
@@ -3252,7 +3268,7 @@ const highlighted = highlightCode(code, lang, theme);
 
 - Extension errors are logged, agent continues
 - `tool_call` errors block the tool (fail-safe)
-- Tool `execute` errors must be signaled by throwing; the thrown error is caught, reported to the LLM with `isError: true`, and execution continues
+- Tool `execute` errors are signaled by throwing or by returning a result with `isError: true`; either way the result reaches the LLM with `isError: true` and execution continues (a returned result keeps its `content` and `details`)
 
 ## Mode Behavior
 


### PR DESCRIPTION
## What changed

- `packages/coding-agent/docs/extensions.md`: the "Signaling errors" paragraph, its example, and the Error Handling bullet now document both ways to fail a tool — throwing, or returning a result with `isError: true` (which keeps `content`/`details` for the LLM). The old sentence "Returning a value never sets the error flag regardless of what properties you include in the return object" is gone.
- `packages/agent/src/changes.md`: one line on the inline-isError entry recording that the fork deliberately diverges from upstream here and where it is documented.

## Why

#1549 made the agent loop honor an inline `isError`; the docs still taught the reversed contract to extension authors (flagged by the gate review of #1549). Refs #1548.

## QA / evidence

Docs-only; no runtime change. Verified the three edited locations read correctly and that no other "never sets the error flag" wording remains (`grep -n 'never sets the error flag' docs/extensions.md` → none).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the extension docs to reflect that tool failures can now be signaled by returning a result with `isError: true`, not just by throwing. This aligns the documentation with the behavior added in #1549, and adds a note in `packages/agent/src/changes.md` explaining the deliberate divergence from upstream.

<sup>Written for commit a2cb1edb052db14f6dfbf43d716d7327229aa027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

