### PR TITLE
fix(claude-sdk-oauth): detach completed resume abort listeners

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Fixed
 
+- Claude SDK OAuth reattach no longer closes a healthy resumed query when
+  normal completed-request cleanup aborts the request controller; the
+  initialization cancellation listener is detached once initialization settles,
+  while pending cancellation still rejects and closes the query.
+
 ### Removed
 
 ## [2026.9.10] - 2026-09-10

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,30 @@
 # claude-sdk-oauth
 
+## 2026-09-10 - Detach completed resume initialization abort listeners
+
+### What changed
+
+- `session-reattach.ts`: the abort listener that bounds `initializationResult`
+  is now removed in a `finally` block after initialization settles.
+- `test/claude-sdk-oauth-reattach.test.ts`: cover both successful initialization
+  followed by normal request cleanup and genuine abort during pending
+  initialization.
+
+### Why
+
+- The request controller is also aborted during normal completed-request
+  cleanup. Leaving the initialization listener attached closed a healthy
+  resumed query after initialization, forcing the next turn through another
+  resume and eventually a full-history cache write.
+- Pending and pre-aborted initialization still closes the query and rejects, so
+  cancellation remains fail-closed while completed initialization no longer
+  has a stale listener.
+
+### Expected merge conflict zones
+
+- LOW: `session-reattach.ts` initialization helper and the adjacent reattach
+  regression test; no public API or generated bundle changes.
+
 ## 2026-09-10 - Validate the Claude Code executable before the SDK spawns it, fall back to PATH
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
@@ -132,15 +132,24 @@ async function awaitInitialization(entry: ClaudeSdkOauthSessionEntry, signal?: A
 		await initialize.call(entry.query);
 		return;
 	}
-	const aborted = new Promise<never>((_resolve, reject) => {
-		const onAbort = (): void => {
-			closeSession(entry.senpiSessionId, "resume_initialization_aborted");
-			reject(new Error("Claude SDK OAuth reattach aborted"));
-		};
-		if (signal.aborted) onAbort();
-		else signal.addEventListener("abort", onAbort, { once: true });
+	let rejectAborted: (reason?: unknown) => void = () => {};
+	const aborted = new Promise<never>((_, reject) => {
+		rejectAborted = reject;
 	});
-	await Promise.race([initialize.call(entry.query), aborted]);
+	const onAbort = (): void => {
+		closeSession(entry.senpiSessionId, "resume_initialization_aborted");
+		rejectAborted(new Error("Claude SDK OAuth reattach aborted"));
+	};
+	if (signal.aborted) {
+		onAbort();
+	} else {
+		signal.addEventListener("abort", onAbort, { once: true });
+	}
+	try {
+		await Promise.race([initialize.call(entry.query), aborted]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
 }
 
 /**

--- a/packages/coding-agent/test/claude-sdk-oauth-reattach.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-reattach.test.ts
@@ -166,4 +166,38 @@ describe("claude-sdk-oauth session reattach", () => {
 		await expect(reattachSession({ binding: binding(), options: options() })).rejects.toThrow("resume rejected");
 		expect(getSession(SESSION_ID)).toBeUndefined();
 	});
+
+	it("keeps a successfully initialized query after request cleanup aborts", async () => {
+		const controller = new AbortController();
+		overrideSessionRegistryBoundary({ queryFactory: () => fakeQuery() });
+
+		await reattachSession({ binding: binding(), options: options(), signal: controller.signal });
+		controller.abort();
+		await Promise.resolve();
+
+		expect(getSession(SESSION_ID)).toBeDefined();
+	});
+
+	it("closes a query when initialization is still pending and the request aborts", async () => {
+		const controller = new AbortController();
+		let resolveInitialization: ((value: { session_id: string }) => void) | undefined;
+		overrideSessionRegistryBoundary({
+			queryFactory: () => ({
+				async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage> {},
+				async interrupt() {},
+				close() {},
+				initializationResult: () =>
+					new Promise((resolve) => {
+						resolveInitialization = resolve;
+					}),
+			}),
+		});
+
+		const reattach = reattachSession({ binding: binding(), options: options(), signal: controller.signal });
+		controller.abort();
+
+		await expect(reattach).rejects.toThrow("reattach aborted");
+		expect(getSession(SESSION_ID)).toBeUndefined();
+		resolveInitialization?.({ session_id: SDK_SESSION_ID });
+	});
 });


### PR DESCRIPTION
Fixes #1563

## Summary

Detach the awaitInitialization abort listener once resume initialization settles. Normal completed-request cleanup aborts the request controller, and the stale listener previously closed a healthy resumed Claude SDK query, forcing the next turn through unnecessary reattach/full-history cache writes.

## Evidence

- RED before production edit: claude-sdk-oauth-reattach.test.ts failed 1 test / passed 7; successful initialization followed by controller abort left no resident session.
- GREEN after fix: focused reattach test 9/9, including pending-abort close/reject control.
- Adjacent stream test: 17/17.
- Repository check: bun run check exit 0.
- Real CLI surface: isolated senpi --help and senpi --list-models succeeded without live provider credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1563. Detaches the resume initialization abort listener once initialization settles, so normal request cleanup no longer closes a healthy resumed Claude SDK query.

- The stale listener previously closed a successfully resumed query during normal completed-request cleanup, forcing the next turn through unnecessary reattach and full-history cache writes.
- Pending or pre-aborted initialization still closes the query and rejects, so cancellation remains fail-closed.
- Adds regression tests for successful initialization followed by request cleanup abort, and for abort during pending initialization.
- Documents the fix in the `claude-sdk-oauth` changes file and package changelog.

<sup>Written for commit 4ca5d6533aebc2bbc5eaf68793d1a28399a40677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

