### PR TITLE
fix(coding-agent): warn for Astra only at max reasoning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,15 +15,8 @@
   initialization cancellation listener is detached once initialization settles,
   while pending cancellation still rejects and closes the query.
 - GPT-6 Astra high-reasoning warnings now appear only at `max`; GPT-5.6 Sol
-<<<<<<< HEAD
-  continues to warn at both `xhigh` and `max`.
-||||||| parent of 99a9650e5 (docs(coding-agent): clarify Sol warning levels)
-  continues to warn at `xhigh` and `max`.
-
-=======
   continues to warn at both `xhigh` and `max`.
 
->>>>>>> 99a9650e5 (docs(coding-agent): clarify Sol warning levels)
 ### Removed
 
 ## [2026.9.10] - 2026-09-10

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,7 +15,15 @@
   initialization cancellation listener is detached once initialization settles,
   while pending cancellation still rejects and closes the query.
 - GPT-6 Astra high-reasoning warnings now appear only at `max`; GPT-5.6 Sol
+<<<<<<< HEAD
   continues to warn at both `xhigh` and `max`.
+||||||| parent of 99a9650e5 (docs(coding-agent): clarify Sol warning levels)
+  continues to warn at `xhigh` and `max`.
+
+=======
+  continues to warn at both `xhigh` and `max`.
+
+>>>>>>> 99a9650e5 (docs(coding-agent): clarify Sol warning levels)
 ### Removed
 
 ## [2026.9.10] - 2026-09-10

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,8 @@
   normal completed-request cleanup aborts the request controller; the
   initialization cancellation listener is detached once initialization settles,
   while pending cancellation still rejects and closes the query.
-
+- GPT-6 Astra high-reasoning warnings now appear only at `max`; GPT-5.6 Sol
+  continues to warn at both `xhigh` and `max`.
 ### Removed
 
 ## [2026.9.10] - 2026-09-10

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -15,6 +15,11 @@
 - Astra's warning policy is specific to its highest reasoning level, so showing it
   at `xhigh` was overly broad.
 
+### Why an extension could not handle it
+
+- The warning predicate is core session policy evaluated before warning events are
+  emitted.
+
 ### Expected merge conflict zones
 
 - LOW: the high-reasoning warning predicate and its focused test.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-10 - Restrict GPT-6 Astra high-reasoning warning to max
+
+### What changed
+
+- `packages/coding-agent/src/core/high-reasoning-warning.ts`: GPT-6 Astra now emits
+  the high-reasoning warning only at `max`; GPT-5.6 Sol retains its `xhigh`/`max`
+  warning behavior.
+- `packages/coding-agent/test/high-reasoning-warning.test.ts`: added coverage for
+  Astra variants at both reasoning levels.
+
+### Why
+
+- Astra's warning policy is specific to its highest reasoning level, so showing it
+  at `xhigh` was overly broad.
+
+### Expected merge conflict zones
+
+- LOW: the high-reasoning warning predicate and its focused test.
+
 ## 2026-09-10 - Print mode binds editAssistantMessage for extensions
 
 ### What changed

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -4,13 +4,17 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 // Matches GPT-5.x Sol and GPT-6 Astra variants, including provider-prefixed
 // forms. The trailing lookahead excludes unrelated ids that continue with letters.
 const SENSITIVE_MODEL_ID_PATTERN = /(?:gpt-5(?:\.\d+)?-sol|gpt-6-astra)(?![a-z])/i;
+const ASTRA_MODEL_ID_PATTERN = /gpt-6-astra(?![a-z])/i;
 
 export function isSensitiveHighReasoningModel(model: Pick<Model<Api>, "id">): boolean {
 	return SENSITIVE_MODEL_ID_PATTERN.test(model.id);
 }
 
 export function shouldWarnHighReasoning(model: Pick<Model<Api>, "id">, thinkingLevel: ThinkingLevel): boolean {
-	return (thinkingLevel === "xhigh" || thinkingLevel === "max") && isSensitiveHighReasoningModel(model);
+	const isWarningLevel = ASTRA_MODEL_ID_PATTERN.test(model.id)
+		? thinkingLevel === "max"
+		: thinkingLevel === "xhigh" || thinkingLevel === "max";
+	return isWarningLevel && isSensitiveHighReasoningModel(model);
 }
 
 export interface HighReasoningWarningContent {

--- a/packages/coding-agent/test/high-reasoning-warning.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning.test.ts
@@ -38,6 +38,8 @@ const NON_SOL_MODEL_IDS = [
 	"deepseek-v4-flash",
 ];
 
+const ASTRA_MODEL_IDS = ["gpt-6-astra", "gpt-6-astra-fast", "openai/gpt-6-astra"];
+
 describe("high-reasoning-warning", () => {
 	describe("isSensitiveHighReasoningModel", () => {
 		it.each(SOL_MODEL_IDS)("flags the gpt-5.6-sol variant %s", (id) => {
@@ -58,6 +60,11 @@ describe("high-reasoning-warning", () => {
 			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "xhigh")).toBe(true);
 			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "max")).toBe(true);
 			expect(shouldWarnHighReasoning(mkModel("openai/gpt-5.6-sol-pro"), "xhigh")).toBe(true);
+		});
+
+		it.each(ASTRA_MODEL_IDS)("warns for GPT-6 Astra only at max: %s", (id) => {
+			expect(shouldWarnHighReasoning(mkModel(id), "xhigh")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel(id), "max")).toBe(true);
 		});
 
 		it("does NOT warn for claude-fable-5 at xhigh or max (reported bug)", () => {

--- a/packages/coding-agent/test/suite/astra-high-reasoning-warning.test.ts
+++ b/packages/coding-agent/test/suite/astra-high-reasoning-warning.test.ts
@@ -13,14 +13,14 @@ const ASTRA_MODEL_IDS = [
 
 const EFFORTS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
-describe.each(ASTRA_MODEL_IDS)("Astra warning parity for %s", (id) => {
-	it.each(EFFORTS)("warns only above high when effort is %s", (effort) => {
+describe.each(ASTRA_MODEL_IDS)("Astra warning policy for %s", (id) => {
+	it.each(EFFORTS)("warns only at max when effort is %s", (effort) => {
 		// Given an Astra model variant and a selected effort.
 		const model = { id };
 		// When the existing warning policy is evaluated.
 		const warns = shouldWarnHighReasoning(model, effort);
-		// Then Astra uses the same effort threshold as Sol.
-		expect(warns).toBe(effort === "xhigh" || effort === "max");
+		// Then Astra warns only at its highest reasoning level.
+		expect(warns).toBe(effort === "max");
 	});
 });
 


### PR DESCRIPTION
## Summary
GPT-6 Astra emitted the high-reasoning warning at both `xhigh` and `max`. Astra now warns only at `max`, its highest reasoning level, while GPT-5.6 Sol keeps warning at both `xhigh` and `max`. Capability metadata and warning content are unchanged.

## Changes
- Warning policy: `packages/coding-agent/src/core/high-reasoning-warning.ts` gates Astra ids on `max` only; every other sensitive id keeps the `xhigh`/`max` threshold.
- Regression coverage: `test/high-reasoning-warning.test.ts` adds Astra variants at both levels; `test/suite/astra-high-reasoning-warning.test.ts` now pins the max-only policy across the seven Astra id shapes and all seven efforts.
- Records: `packages/coding-agent/CHANGELOG.md` and `src/changes.md`.

## QA & Evidence
- **What was tested:** the four warning suites (`high-reasoning-warning`, `suite/astra-high-reasoning-warning`, `high-reasoning-warning-event`, `high-reasoning-warning-rpc`) on a permitted remote macOS host.
  **Observed result:** 4 files / 122 tests passed.
  **Why sufficient:** covers the predicate, the session event, and the RPC serialization for both Astra and Sol.
- **What was tested:** the real CLI over `--mode rpc` in an isolated sandbox, driving `set_model` + `set_thinking_level` and capturing `high_reasoning_warning` events.
  **Observed result:** Astra at `xhigh` produced no warning; Astra at `max` produced `{modelId: gpt-6-astra, thinkingLevel: max}`; Sol warned at `xhigh` and `max`. Real credential file verified unchanged.
  **Why sufficient:** proves the user-visible behavior on the surface that emits the warning, not just the predicate.
- **Artifact:** evidence held locally (`local-ignore/qa-evidence/20260910-astra-max-warning/`).

## Risks & Residuals
- Sol regression risk: mitigated by the control rows in both the unit suites and the live RPC probes.
- Cubic: skipped by the bot on this PR; CI is green on the merge head.

Fixes #1564