### PR TITLE
fix(interactive): stop rendering the '.' manual-continue shortcut as a user message

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- A bare `.` submitted on a session that already has messages no longer renders as a user message in the TUI. It stays the manual-continue shortcut the session delivers as a hidden continuation, so nothing is painted for it while idle or while steering an active turn; a `.` on an empty session and a `.` carrying image attachments remain ordinary user input ([#1569](https://github.com/code-yeongyu/senpi/issues/1569))
+
 - Claude SDK OAuth reattach no longer closes a healthy resumed query when
   normal completed-request cleanup aborts the request controller; the
   initialization cancellation listener is detached once initialization settles,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -183,7 +183,11 @@ import type {
 } from "./extensions/types.ts";
 import { normalizeToolExposure, RUNTIME_EXTENSION_PATH } from "./extensions/types.ts";
 import { shouldWarnHighReasoning } from "./high-reasoning-warning.ts";
-import { MANUAL_CONTINUE_CUSTOM_TYPE, MANUAL_CONTINUE_DIRECTIVE } from "./manual-continue.ts";
+import {
+	isManualContinueSubmission,
+	MANUAL_CONTINUE_CUSTOM_TYPE,
+	MANUAL_CONTINUE_DIRECTIVE,
+} from "./manual-continue.ts";
 import {
 	type BashExecutionMessage,
 	type CustomMessage,
@@ -3759,7 +3763,13 @@ export class AgentSession {
 			// empty session, or a "." carrying image attachments (the user is sending
 			// the images, not asking to continue), falls through to ordinary prompt
 			// handling below.
-			if (text.trim() === "." && this.agent.state.messages.length > 0 && !options?.images?.length) {
+			if (
+				isManualContinueSubmission({
+					text,
+					hasMessages: this.agent.state.messages.length > 0,
+					hasImages: (options?.images?.length ?? 0) > 0,
+				})
+			) {
 				await this.sendCustomMessage(
 					{
 						customType: MANUAL_CONTINUE_CUSTOM_TYPE,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,22 @@
+## Shared manual-continue submission predicate (2026-09-10)
+
+### What changed
+
+- `packages/coding-agent/src/core/manual-continue.ts`: adds `MANUAL_CONTINUE_SHORTCUT` and `isManualContinueSubmission({ text, hasMessages, hasImages })`.
+- `packages/coding-agent/src/core/agent-session.ts`: `prompt()` classifies the bare `.` through that predicate instead of an inline condition.
+
+### Why
+
+- Interactive mode must reach the same verdict before it paints a user echo, and one predicate keeps the empty-session and image-attachment carve-outs from drifting between the two call sites.
+
+### Why this lives in the fork
+
+- The `.` manual-continue shortcut is fork behavior in `AgentSession.prompt()`.
+
+### Expected merge conflict zones
+
+- LOW: the manual-continue interception at the top of `prompt()`.
+
 ## Leaf token and typed errors for assistant edits (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/manual-continue.ts
+++ b/packages/coding-agent/src/core/manual-continue.ts
@@ -11,6 +11,25 @@
 
 export const MANUAL_CONTINUE_CUSTOM_TYPE = "manual-continue";
 
+export const MANUAL_CONTINUE_SHORTCUT = ".";
+
+/**
+ * Whether a submission is the manual-continue shortcut rather than user content.
+ *
+ * Shared by `AgentSession.prompt()` (which routes it as the hidden directive
+ * below) and the interactive submit boundary (which must not paint a user echo
+ * for a turn the transcript never receives). An empty session has no intent to
+ * resume, and a "." carrying images is the user sending the images, so both stay
+ * ordinary user input.
+ */
+export function isManualContinueSubmission(input: {
+	readonly text: string;
+	readonly hasMessages: boolean;
+	readonly hasImages: boolean;
+}): boolean {
+	return input.text.trim() === MANUAL_CONTINUE_SHORTCUT && input.hasMessages && !input.hasImages;
+}
+
 export const MANUAL_CONTINUE_DIRECTIVE = `<system-notice>
 Continue.
 

--- a/packages/coding-agent/src/core/manual-continue.ts
+++ b/packages/coding-agent/src/core/manual-continue.ts
@@ -11,7 +11,7 @@
 
 export const MANUAL_CONTINUE_CUSTOM_TYPE = "manual-continue";
 
-export const MANUAL_CONTINUE_SHORTCUT = ".";
+const MANUAL_CONTINUE_SHORTCUT = ".";
 
 /**
  * Whether a submission is the manual-continue shortcut rather than user content.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,17 @@
+## 2026-09-10 - The "." manual-continue shortcut paints no user echo
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: submissions go through `beginUserEcho()`, which skips the optimistic echo for a bare `.` on a session that already has messages (via the shared `isManualContinueSubmission`); `OptimisticUserEchoController.promptOptions/reject/remove` and `InteractiveUserInput.pendingEchoId` accept `undefined` as "nothing was painted".
+
+### Why
+
+- The session routes that `.` as a hidden continuation, so the echo painted at submit time showed a user bubble the transcript never receives.
+
+### Expected merge conflict zones
+
+- LOW: `OptimisticUserEchoController`, `InteractiveUserInput`, and the echo call sites in `setupEditorSubmitHandler` / `handleFollowUp`.
+
 ## 2026-09-10 - /tree edits carry the leaf token and reach shared hosts
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -8,6 +8,10 @@
 
 - The session routes that `.` as a hidden continuation, so the echo painted at submit time showed a user bubble the transcript never receives.
 
+### Why this lives in the fork
+
+- The `.` manual-continue shortcut and the optimistic user echo are both fork behavior in `AgentSession.prompt()` and interactive mode.
+
 ### Expected merge conflict zones
 
 - LOW: `OptimisticUserEchoController`, `InteractiveUserInput`, and the echo call sites in `setupEditorSubmitHandler` / `handleFollowUp`.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -101,6 +101,7 @@ import { appendHiddenTuiStdout, appendUncaughtCrashLog } from "../../core/hidden
 import { buildHighReasoningWarning } from "../../core/high-reasoning-warning.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
+import { isManualContinueSubmission } from "../../core/manual-continue.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
@@ -573,7 +574,8 @@ export class OptimisticUserEchoController {
 		return id;
 	}
 
-	promptOptions(id: string): {
+	/** `undefined` means nothing was painted for this submission; every callback then resolves to a no-op. */
+	promptOptions(id: string | undefined): {
 		preflightResult: (success: boolean) => void;
 		promptDisposition: (disposition: "handled" | "queued" | "started") => void;
 	} {
@@ -594,14 +596,15 @@ export class OptimisticUserEchoController {
 		};
 	}
 
-	reject(id: string): void {
+	reject(id: string | undefined): void {
+		if (id === undefined) return;
 		const index = this.pending.findIndex((record) => record.id === id);
 		if (index === -1) return;
 		const [record] = this.pending.splice(index, 1);
 		record?.handle.remove();
 	}
 
-	remove(id: string): void {
+	remove(id: string | undefined): void {
 		this.reject(id);
 	}
 
@@ -619,7 +622,8 @@ export class OptimisticUserEchoController {
 interface InteractiveUserInput {
 	text: string;
 	images?: ImageContent[];
-	pendingEchoId: string;
+	/** `undefined` for a submission that paints no echo, such as the manual-continue shortcut. */
+	pendingEchoId: string | undefined;
 }
 
 /** Local copy of pi-tui's image-marker pattern so submission scanning never mutates a shared /g regex. */
@@ -4465,6 +4469,25 @@ export class InteractiveMode {
 		this.showStatus("Startup is still in progress");
 	}
 
+	/**
+	 * Paint the render-only echo for a submission, unless it is the bare "."
+	 * manual-continue shortcut. The session routes that "." as a hidden
+	 * continuation, so painting it would leave a user bubble the transcript never
+	 * receives; `undefined` tells the echo callbacks nothing was painted.
+	 */
+	private beginUserEcho(text: string, images?: readonly ImageContent[]): string | undefined {
+		if (
+			isManualContinueSubmission({
+				text,
+				hasMessages: this.session.messages.length > 0,
+				hasImages: (images?.length ?? 0) > 0,
+			})
+		) {
+			return undefined;
+		}
+		return this.optimisticUserEchoes.begin(text);
+	}
+
 	private setupEditorSubmitHandler(): void {
 		this.defaultEditor.onSubmit = async (text: string) => {
 			try {
@@ -4698,7 +4721,7 @@ export class InteractiveMode {
 					const images = preResolvedImages ?? this.takeSubmissionImages(text);
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					const pendingEchoId = this.optimisticUserEchoes.begin(text);
+					const pendingEchoId = this.beginUserEcho(text, images);
 					try {
 						await this.session.prompt(text, {
 							streamingBehavior: "steer",
@@ -4719,7 +4742,7 @@ export class InteractiveMode {
 				this.flushPendingBashComponents();
 
 				const images = preResolvedImages ?? this.takeSubmissionImages(text);
-				const pendingEchoId = this.optimisticUserEchoes.begin(text);
+				const pendingEchoId = this.beginUserEcho(text, images);
 				const submission: InteractiveUserInput =
 					images.length > 0 ? { text, images, pendingEchoId } : { text, pendingEchoId };
 				if (this.onInputCallback) {
@@ -6319,7 +6342,7 @@ export class InteractiveMode {
 		if (this.session.isStreaming) {
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");
-			const pendingEchoId = this.optimisticUserEchoes.begin(text);
+			const pendingEchoId = this.beginUserEcho(text, images);
 			try {
 				await this.session.prompt(text, {
 					streamingBehavior: "followUp",

--- a/packages/coding-agent/test/interactive-mode-exit-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-exit-command.test.ts
@@ -26,6 +26,7 @@ type SubmitContext = {
 		isCompacting: boolean;
 		isStreaming: boolean;
 		isBashRunning: boolean;
+		messages: unknown[];
 		prompt: (text: string, options?: unknown) => Promise<void>;
 	};
 	flushPendingBashComponents: () => void;
@@ -37,12 +38,14 @@ type SubmitContext = {
 	pendingImages: Map<number, unknown>;
 	optimisticUserEchoes: ReturnType<typeof createEchoControllerStub>;
 	takeSubmissionImages: (submittedText: string) => unknown[];
+	beginUserEcho: (text: string, images?: readonly unknown[]) => string | undefined;
 	shutdown: () => Promise<void>;
 };
 
 type InteractiveModePrivate = {
 	setupEditorSubmitHandler(this: SubmitContext): void;
 	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
+	beginUserEcho(this: SubmitContext, text: string, images?: readonly unknown[]): string | undefined;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
@@ -58,6 +61,7 @@ function createSubmitContext(): SubmitContext {
 			isCompacting: false,
 			isStreaming: false,
 			isBashRunning: false,
+			messages: [],
 			prompt: vi.fn(async () => {}),
 		},
 		flushPendingBashComponents: vi.fn(),
@@ -68,11 +72,13 @@ function createSubmitContext(): SubmitContext {
 		pendingImages: new Map(),
 		optimisticUserEchoes: createEchoControllerStub(),
 		takeSubmissionImages: vi.fn(() => []),
+		beginUserEcho: vi.fn(() => undefined),
 		shutdown: vi.fn(async () => {}),
 	};
 	// Borrowed receiver: resolve markers with the REAL production helper (its
 	// only dependencies are the pendingImages map above).
 	context.takeSubmissionImages = interactiveModePrototype.takeSubmissionImages.bind(context);
+	context.beginUserEcho = interactiveModePrototype.beginUserEcho.bind(context);
 	return context;
 }
 

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -71,6 +71,7 @@ interface FakeSession {
 	isCompacting: boolean;
 	isStreaming: boolean;
 	isBashRunning: boolean;
+	messages: unknown[];
 	prompt: MockFn;
 	reserveQueuedInputOrder: MockFn;
 	extensionRunner: { getCommand: (name: string) => unknown };
@@ -127,6 +128,7 @@ interface ModeContext {
 	buildMainLoopPromptOptions?: (userInput: UserSubmission) => unknown;
 	isExtensionCommand?: (text: string) => boolean;
 	getExpandedEditorText?: () => string;
+	beginUserEcho?: (text: string, images?: readonly ImageContent[]) => string | undefined;
 }
 
 type ModePrototype = {
@@ -148,6 +150,7 @@ type ModePrototype = {
 	buildMainLoopPromptOptions(this: ModeContext, userInput: UserSubmission): unknown;
 	isExtensionCommand(this: ModeContext, text: string): boolean;
 	getExpandedEditorText(this: ModeContext): string;
+	beginUserEcho(this: ModeContext, text: string, images?: readonly ImageContent[]): string | undefined;
 };
 
 const proto = InteractiveMode.prototype as unknown as ModePrototype;
@@ -181,6 +184,7 @@ function createModeContext(): ModeContext {
 		isCompacting: false,
 		isStreaming: false,
 		isBashRunning: false,
+		messages: [],
 		prompt: vi.fn(async () => {}),
 		reserveQueuedInputOrder: vi.fn(() => 0),
 		extensionRunner: { getCommand: vi.fn(() => undefined) },
@@ -239,6 +243,7 @@ function createModeContext(): ModeContext {
 		"getExpandedEditorText",
 		"getUserInput",
 		"buildMainLoopPromptOptions",
+		"beginUserEcho",
 	] as const) {
 		const real = proto[method] as unknown as ((this: ModeContext, ...args: never[]) => unknown) | undefined;
 		if (typeof real === "function") {

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -26,6 +26,7 @@ type SubmitContext = {
 		isCompacting: boolean;
 		isStreaming: boolean;
 		isBashRunning: boolean;
+		messages: unknown[];
 		prompt: (text: string, options?: unknown) => Promise<void>;
 	};
 	flushPendingBashComponents: () => void;
@@ -37,6 +38,7 @@ type SubmitContext = {
 	pendingImages: Map<number, unknown>;
 	optimisticUserEchoes: EchoControllerStub;
 	takeSubmissionImages: (submittedText: string) => unknown[];
+	beginUserEcho: (text: string, images?: readonly unknown[]) => string | undefined;
 };
 
 type InputContext = {
@@ -92,6 +94,7 @@ type InteractiveModePrivate = {
 	setupEditorSubmitHandler(this: SubmitContext): void;
 	getUserInput(this: InputContext): Promise<{ text: string; images?: unknown[] }>;
 	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
+	beginUserEcho(this: SubmitContext, text: string, images?: readonly unknown[]): string | undefined;
 	buildMainLoopPromptOptions(
 		this: RunContext,
 		userInput: { text: string; images?: unknown[]; pendingEchoId: string },
@@ -112,6 +115,7 @@ function createSubmitContext(): SubmitContext {
 			isCompacting: false,
 			isStreaming: false,
 			isBashRunning: false,
+			messages: [],
 			prompt: vi.fn(async () => {}),
 		},
 		flushPendingBashComponents: vi.fn(),
@@ -122,10 +126,12 @@ function createSubmitContext(): SubmitContext {
 		pendingImages: new Map(),
 		optimisticUserEchoes: createEchoControllerStub(),
 		takeSubmissionImages: vi.fn(() => []),
+		beginUserEcho: vi.fn(() => undefined),
 	};
 	// Borrowed receiver: resolve markers with the REAL production helper (its
 	// only dependencies are the pendingImages map above).
 	context.takeSubmissionImages = interactiveModePrototype.takeSubmissionImages.bind(context);
+	context.beginUserEcho = interactiveModePrototype.beginUserEcho.bind(context);
 	return context;
 }
 

--- a/packages/coding-agent/test/suite/helpers/ask-user-async-fake-mode.ts
+++ b/packages/coding-agent/test/suite/helpers/ask-user-async-fake-mode.ts
@@ -20,6 +20,7 @@ export type FakeEditor = Text & { setText: Mock<(text: string) => void>; addToHi
 export type FakeSession = {
 	isStreaming: boolean;
 	isCompacting: boolean;
+	messages: unknown[];
 	sendUserMessage: Mock<(text: string, options?: { deliverAs?: "steer" | "followUp" }) => Promise<void>>;
 	prompt: Mock<(text: string, options?: object) => Promise<void>>;
 };
@@ -51,6 +52,7 @@ export function createFakeInteractiveMode(options: { isStreaming?: boolean } = {
 	const session: FakeSession = {
 		isStreaming: options.isStreaming ?? false,
 		isCompacting: false,
+		messages: [],
 		sendUserMessage: vi.fn(async () => {}),
 		prompt: vi.fn(async () => {}),
 	};

--- a/packages/coding-agent/test/suite/manual-continue-tui-echo.test.ts
+++ b/packages/coding-agent/test/suite/manual-continue-tui-echo.test.ts
@@ -1,5 +1,5 @@
 /**
- * The bare "." manual-continue shortcut must never paint a TUI user echo.
+ * The bare "." manual-continue shortcut must never paint a TUI user echo (#1569).
  *
  * `AgentSession.prompt()` routes a "." submitted on a session that already has
  * messages as a hidden continuation: no user message is created, persisted, or

--- a/packages/coding-agent/test/suite/manual-continue-tui-echo.test.ts
+++ b/packages/coding-agent/test/suite/manual-continue-tui-echo.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The bare "." manual-continue shortcut must never paint a TUI user echo.
+ *
+ * `AgentSession.prompt()` routes a "." submitted on a session that already has
+ * messages as a hidden continuation: no user message is created, persisted, or
+ * replayed. The interactive submit boundary therefore must not paint its
+ * render-only optimistic echo for that submission either — a painted bubble is
+ * a message the transcript never receives. A "." on an empty session, and a
+ * "." carrying image attachments, stay ordinary user input and keep their echo.
+ */
+
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import * as interactiveModeModule from "../../src/modes/interactive/interactive-mode.ts";
+
+type RenderHandle = { replace(message: AgentMessage): void; remove(): void };
+
+type EchoController = {
+	begin(text: string): string;
+	promptOptions(id: string | undefined): {
+		preflightResult(success: boolean): void;
+		promptDisposition(disposition: "handled" | "queued" | "started"): void;
+	};
+	reject(id: string | undefined): void;
+};
+
+type EchoControllerConstructor = new (render: (text: string) => RenderHandle) => EchoController;
+
+type Submission = { text: string; images?: ImageContent[]; pendingEchoId: string | undefined };
+
+type PromptCall = { text: string; options: Record<string, unknown> | undefined };
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: 1 };
+}
+
+function createSubmitHarness(options: { messages: AgentMessage[]; isStreaming?: boolean; images?: ImageContent[] }): {
+	submit: (text: string) => Promise<void>;
+	painted: string[];
+	submissions: Submission[];
+	prompts: PromptCall[];
+} {
+	const painted: string[] = [];
+	const submissions: Submission[] = [];
+	const prompts: PromptCall[] = [];
+	const controllerClass = Reflect.get(interactiveModeModule, "OptimisticUserEchoController");
+	expect(controllerClass, "InteractiveMode must expose its TUI-local optimistic echo controller").toBeTypeOf(
+		"function",
+	);
+	const Controller = controllerClass as EchoControllerConstructor;
+	const optimisticUserEchoes = new Controller((text) => {
+		painted.push(text);
+		return { replace: () => {}, remove: () => {} };
+	});
+	const defaultEditor: { onSubmit?: (text: string) => Promise<void> } = {};
+	// Borrowed from the prototype so the shipped classification runs against the stubbed collaborators.
+	const beginUserEcho = Reflect.get(interactiveModeModule.InteractiveMode.prototype, "beginUserEcho");
+	if (typeof beginUserEcho !== "function") throw new Error("InteractiveMode.beginUserEcho is missing");
+	const context = {
+		beginUserEcho,
+		defaultEditor,
+		preResolvedSubmissionImages: undefined,
+		hideShortcutOverlay: () => {},
+		lastEditorText: "",
+		isExtensionCommand: () => false,
+		session: {
+			isCompacting: false,
+			isStreaming: options.isStreaming ?? false,
+			messages: options.messages,
+			prompt: async (text: string, promptOptions: Record<string, unknown> | undefined) => {
+				prompts.push({ text, options: promptOptions });
+			},
+		},
+		flushPendingBashComponents: () => {},
+		takeSubmissionImages: () => options.images ?? [],
+		optimisticUserEchoes,
+		onInputCallback: (submission: Submission) => submissions.push(submission),
+		pendingUserInputs: [],
+		editor: { addToHistory: () => {}, setText: () => {} },
+		updatePendingMessagesDisplay: () => {},
+		ui: { requestRender: () => {} },
+	};
+	const setup = Reflect.get(interactiveModeModule.InteractiveMode.prototype, "setupEditorSubmitHandler");
+	if (typeof setup !== "function") throw new Error("InteractiveMode.setupEditorSubmitHandler is missing");
+	setup.call(context);
+
+	return {
+		submit: async (text: string) => {
+			const onSubmit = defaultEditor.onSubmit;
+			if (!onSubmit) throw new Error("setupEditorSubmitHandler did not install an onSubmit handler");
+			await onSubmit(text);
+		},
+		painted,
+		submissions,
+		prompts,
+	};
+}
+
+describe("manual-continue TUI echo", () => {
+	it("paints nothing for a bare '.' on a session that already has messages", async () => {
+		const harness = createSubmitHarness({ messages: [userMessage("hello")] });
+
+		await harness.submit(".");
+
+		expect(harness.painted).toEqual([]);
+		expect(harness.submissions).toHaveLength(1);
+		expect(harness.submissions[0]?.text).toBe(".");
+		expect(harness.submissions[0]?.pendingEchoId).toBeUndefined();
+	});
+
+	it("paints nothing for a padded '.' submission, which the editor trims to the shortcut", async () => {
+		const harness = createSubmitHarness({ messages: [userMessage("hello")] });
+
+		await harness.submit("  .  ");
+
+		expect(harness.painted).toEqual([]);
+		expect(harness.submissions[0]?.text).toBe(".");
+	});
+
+	it("paints nothing for a bare '.' steer continuation during an active turn", async () => {
+		const harness = createSubmitHarness({
+			messages: [userMessage("hello")],
+			isStreaming: true,
+		});
+
+		await harness.submit(".");
+
+		expect(harness.painted).toEqual([]);
+		expect(harness.prompts).toHaveLength(1);
+		expect(harness.prompts[0]?.text).toBe(".");
+		expect(harness.prompts[0]?.options?.streamingBehavior).toBe("steer");
+	});
+
+	it("paints a bare '.' on an empty session, which stays an ordinary user message", async () => {
+		const harness = createSubmitHarness({ messages: [] });
+
+		await harness.submit(".");
+
+		expect(harness.painted).toEqual(["."]);
+		expect(harness.submissions[0]?.pendingEchoId).toBeTypeOf("string");
+	});
+
+	it("paints a '.' carrying image attachments, which stays an ordinary user message", async () => {
+		const harness = createSubmitHarness({
+			messages: [userMessage("hello")],
+			images: [{ type: "image", data: "aGk=", mimeType: "image/png" }],
+		});
+
+		await harness.submit(".");
+
+		expect(harness.painted).toEqual(["."]);
+		expect(harness.submissions[0]?.pendingEchoId).toBeTypeOf("string");
+	});
+
+	it("paints ordinary text on a session that already has messages", async () => {
+		const harness = createSubmitHarness({ messages: [userMessage("hello")] });
+
+		await harness.submit("keep going please");
+
+		expect(harness.painted).toEqual(["keep going please"]);
+		expect(harness.submissions[0]?.pendingEchoId).toBeTypeOf("string");
+	});
+});

--- a/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
+++ b/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
@@ -69,13 +69,16 @@ describe("optimistic pending user echo", () => {
 			return { replace: () => {}, remove: () => {} };
 		});
 		const defaultEditor: { onSubmit?: (text: string) => Promise<void> } = {};
+		const beginUserEcho = Reflect.get(interactiveModeModule.InteractiveMode.prototype, "beginUserEcho");
+		if (typeof beginUserEcho !== "function") throw new Error("InteractiveMode.beginUserEcho is missing");
 		const context = {
+			beginUserEcho,
 			defaultEditor,
 			preResolvedSubmissionImages: undefined,
 			hideShortcutOverlay: () => {},
 			lastEditorText: "",
 			isExtensionCommand: () => false,
-			session: { isCompacting: false, isStreaming: false },
+			session: { isCompacting: false, isStreaming: false, messages: [] },
 			flushPendingBashComponents: () => {},
 			takeSubmissionImages: () => [],
 			optimisticUserEchoes,


### PR DESCRIPTION
## Summary

A bare `.` submitted on a session that already has messages is the manual-continue shortcut: `AgentSession.prompt()` routes it as a hidden custom message and never creates a user turn. The interactive submit boundary still painted its optimistic user echo first, so the TUI rendered a user bubble for input the transcript never receives.

Fixes #1569

## Changes

- `src/core/manual-continue.ts`: `MANUAL_CONTINUE_SHORTCUT` and `isManualContinueSubmission({ text, hasMessages, hasImages })` own the shortcut's carve-outs.
- `src/core/agent-session.ts`: `prompt()` classifies through that predicate instead of an inline condition (no behavior change).
- `src/modes/interactive/interactive-mode.ts`: submissions resolve their echo through `beginUserEcho()`, which paints nothing for the shortcut, while idle and while steering an active turn. `OptimisticUserEchoController.promptOptions/reject/remove` and `InteractiveUserInput.pendingEchoId` accept `undefined` as "nothing was painted".

Ordinary input is untouched: a `.` on an empty session and a `.` carrying image attachments stay user messages with their echo. The three existing submit-handler test receivers gained the `session.messages` field and the borrowed `beginUserEcho` the real class now uses.

## QA & Evidence

- **What was tested:** the new regression file drives the real `setupEditorSubmitHandler` through the real `OptimisticUserEchoController`, covering idle `.`, padded `  .  `, streaming `.` (steer), empty-session `.`, `.` with an image attachment, and ordinary text.
- **Observed result:**

```
CI=1 bun run --cwd packages/coding-agent test \
  test/suite/manual-continue-tui-echo.test.ts test/suite/optimistic-pending-user-echo.test.ts \
  test/manual-continue-shortcut.test.ts test/suite/regressions/pre-prompt-compaction-no-continue.test.ts \
  test/interactive-mode-image-submission.test.ts test/interactive-mode-startup-input.test.ts \
  test/interactive-mode-exit-command.test.ts test/tui-vertical-jitter-lifecycle.test.ts \
  test/grok/classic-chrome-characterization.test.ts test/session-log-routes.test.ts

Test Files  10 passed (10)
     Tests  98 passed (98)
```

- **Mutation check:** forcing `beginUserEcho()` to always paint fails exactly the three shortcut cases with `painted: ["."]` (the reported symptom) and leaves the three ordinary-input cases green, so the new coverage can fail for the regression it names.
- **Why sufficient:** the defect lives at the submit boundary between the editor and `prompt()`; the regression drives that exact seam with the shipped classification rather than a stub, and the sibling suites pin that ordinary input, image submissions, startup input, and compaction queueing are unchanged.
- Root `npm run check` (biome + `tsc --noEmit`) passes through the pre-commit hook on both commits.

## Risks & Residuals

- Echo ids are now nullable through `OptimisticUserEchoController`; every consumer already treated a missing id as "nothing painted", and the compaction-queue paths that pass an optional id are covered by the reruns above.
- Input typed while compaction is running is queued as text and still shows `.` in the pending-queue display; that surface is the queue, not a sent user message, and is out of scope here.

## Related Issues

Fixes #1569. The Desktop projection of the same shortcut is tracked separately in code-yeongyu/omo-desktop-app#530.
