### PR TITLE
fix(ai): identify senpi as a Kimi client on the subscription path

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Kimi For Coding sessions now identify themselves as a Kimi client. `api.kimi.com/coding` recognizes its clients by a product `User-Agent` plus a six-header `X-Msh-*` device set (platform, version, device name, device model, OS version, per-install device id), which the official Kimi Code client sends on device authorization, token poll, token refresh, and every managed request; senpi sent none of them, so a subscription session presented itself as an anonymous Anthropic-protocol client holding a Kimi bearer token. The OAuth subscription path now sends the full set on all four request paths. Header values are printable-ASCII sanitized (the endpoint answers 520 on raw non-ASCII bytes) and the device id persists under the agent dir, falling back to a per-process id when that directory is unwritable instead of throwing. The api-key path is unchanged and stays header-free, because it authenticates with a platform key rather than a client session ([#1504](https://github.com/code-yeongyu/senpi/issues/1504))
+
 ### Removed
 
 ## [2026.9.10] - 2026-09-10

--- a/packages/ai/src/auth/oauth/kimi-coding.ts
+++ b/packages/ai/src/auth/oauth/kimi-coding.ts
@@ -10,6 +10,7 @@ import { getProviderEnvValue } from "../../utils/provider-env.ts";
 import { sleep } from "../../utils/sleep.ts";
 import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
 import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
+import { kimiCodeIdentityHeaders } from "./kimi-identity.ts";
 
 const CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
 const DEFAULT_OAUTH_HOST = "https://auth.kimi.com";
@@ -71,6 +72,7 @@ async function startDeviceAuthorization(oauthHost: string, signal: AbortSignal):
 	const response = await fetch(`${oauthHost}/api/oauth/device_authorization`, {
 		method: "POST",
 		headers: {
+			...kimiCodeIdentityHeaders(),
 			"Content-Type": "application/x-www-form-urlencoded",
 			Accept: "application/json",
 		},
@@ -153,6 +155,7 @@ async function pollForToken(
 			const response = await fetch(`${oauthHost}/api/oauth/token`, {
 				method: "POST",
 				headers: {
+					...kimiCodeIdentityHeaders(),
 					"Content-Type": "application/x-www-form-urlencoded",
 					Accept: "application/json",
 				},
@@ -226,6 +229,7 @@ async function refreshToken(oauthHost: string, refreshTokenValue: string, signal
 			response = await fetch(`${oauthHost}/api/oauth/token`, {
 				method: "POST",
 				headers: {
+					...kimiCodeIdentityHeaders(),
 					"Content-Type": "application/x-www-form-urlencoded",
 					Accept: "application/json",
 				},
@@ -291,6 +295,6 @@ export const kimiCodingOAuth: OAuthAuth = {
 	},
 
 	async toAuth(credential) {
-		return { headers: { Authorization: `Bearer ${credential.access}` } };
+		return { headers: { ...kimiCodeIdentityHeaders(), Authorization: `Bearer ${credential.access}` } };
 	},
 };

--- a/packages/ai/src/auth/oauth/kimi-identity.ts
+++ b/packages/ai/src/auth/oauth/kimi-identity.ts
@@ -1,0 +1,93 @@
+/**
+ * Kimi Code client identity headers.
+ *
+ * `api.kimi.com/coding` identifies its clients by a product `User-Agent` plus
+ * an `X-Msh-*` device header set, and the official Kimi Code client sends that
+ * set on every OAuth and managed-API request (MoonshotAI/kimi-code
+ * `packages/oauth/src/identity.ts`). senpi sent none of them, so a
+ * subscription session never identified itself as a Kimi client at all.
+ *
+ * Three contract details that are not visible from the code: values must be
+ * printable ASCII (the endpoint sits behind a CDN that answers 520 on raw
+ * non-ASCII header bytes), the device id is expected to be stable per install,
+ * and the platform string names a client family rather than the host product.
+ * Device-id persistence is deliberately best-effort — an unwritable agent dir
+ * must degrade to a per-process id, never throw, because these headers are
+ * built for every request.
+ *
+ * Subscription (OAuth) path only: the api-key path authenticates with a
+ * platform key rather than a client session and stays header-free.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { arch, hostname, platform, release } from "node:os";
+import { join } from "node:path";
+import { getProviderEnvValue } from "../../utils/provider-env.ts";
+
+const KIMI_CLIENT_PLATFORM = "kimi_cli";
+const KIMI_CLIENT_VERSION = "1.0";
+const DEVICE_ID_FILENAME = "kimi-device-id";
+
+function sanitizeHeaderValue(value: string, fallback = "unknown"): string {
+	const sanitized = value.replace(/[^\x20-\x7E]/g, "").trim();
+	return sanitized || fallback;
+}
+
+function agentDir(): string {
+	const configured = getProviderEnvValue("SENPI_CODING_AGENT_DIR") ?? getProviderEnvValue("CODING_AGENT_DIR");
+	if (configured) return configured.replace(/\/$/, "");
+	const home = getProviderEnvValue("HOME") ?? ".";
+	return `${home.replace(/\/$/, "")}/.senpi/agent`;
+}
+
+function deviceModel(): string {
+	const current = platform();
+	const label =
+		current === "darwin" ? "macOS" : current === "win32" ? "Windows" : current === "linux" ? "Linux" : current;
+	return [label, release(), arch()].filter(Boolean).join(" ").trim();
+}
+
+function readOrMintDeviceId(): string {
+	const directory = agentDir();
+	const path = join(directory, DEVICE_ID_FILENAME);
+	try {
+		const existing = readFileSync(path, "utf-8").trim();
+		if (existing) return existing;
+	} catch {
+		// Absent or unreadable: fall through and mint a replacement.
+	}
+
+	const minted = randomUUID().replace(/-/g, "");
+	try {
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(path, `${minted}\n`, { mode: 0o600 });
+	} catch {
+		// Unwritable agent dir: this id lives for the current process only.
+	}
+	return minted;
+}
+
+let cachedDeviceId: string | undefined;
+
+function deviceId(): string {
+	cachedDeviceId ??= readOrMintDeviceId();
+	return cachedDeviceId;
+}
+
+/** Test seam: forget the memoized id so a fresh agent dir is re-read. */
+export function resetKimiDeviceIdForTests(): void {
+	cachedDeviceId = undefined;
+}
+
+export function kimiCodeIdentityHeaders(): Record<string, string> {
+	return {
+		"User-Agent": `KimiCLI/${KIMI_CLIENT_VERSION}`,
+		"X-Msh-Platform": KIMI_CLIENT_PLATFORM,
+		"X-Msh-Version": KIMI_CLIENT_VERSION,
+		"X-Msh-Device-Name": sanitizeHeaderValue(hostname()),
+		"X-Msh-Device-Model": sanitizeHeaderValue(deviceModel()),
+		"X-Msh-Os-Version": sanitizeHeaderValue(release()),
+		"X-Msh-Device-Id": sanitizeHeaderValue(deviceId()),
+	};
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,25 @@
+## 2026-09-10 - Kimi Code client identity headers on the subscription path (#1504)
+
+### What changed
+
+- `packages/ai/src/auth/oauth/kimi-identity.ts` (new): `kimiCodeIdentityHeaders()` returns `User-Agent: KimiCLI/<version>` plus `X-Msh-Platform`, `X-Msh-Version`, `X-Msh-Device-Name`, `X-Msh-Device-Model`, `X-Msh-Os-Version`, and `X-Msh-Device-Id`. Every value is printable-ASCII sanitized. The device id is read from (or minted into) `<agent dir>/kimi-device-id` (`SENPI_CODING_AGENT_DIR` / `CODING_AGENT_DIR`, else `~/.senpi/agent`), memoized per process, and degrades to an ephemeral id when that directory cannot be written; `resetKimiDeviceIdForTests()` clears the memo.
+- `packages/ai/src/auth/oauth/kimi-coding.ts`: sends that header set on device authorization, device-code token polling, and token refresh, and returns it from `toAuth` so `resolveProviderAuth` merges it into every chat request the model runtime issues for the provider. The api-key auth path is untouched and stays header-free.
+
+### Why
+
+- `api.kimi.com/coding` recognizes its clients by a product `User-Agent` plus the six-header `X-Msh-*` device set; the official Kimi Code client attaches it to every OAuth and managed-API call. `X-Msh` existed nowhere in this package, so a Kimi For Coding subscription session presented itself as an anonymous Anthropic-protocol client holding a Kimi bearer token (#1504).
+- It is the only divergence from the reference clients that fits the timeline: the kimi-coding request shape had not changed when the endpoint began rejecting fresh sessions, so a server-side tightening around client identification explains it where a payload regression does not.
+- ASCII sanitization and best-effort device-id persistence are ported deliberately: raw non-ASCII header bytes draw a CDN 520 on this host, and an `ENOENT` on a fresh install must not break header construction for every request.
+
+### Why an extension could not handle it
+
+- The headers must ride the provider's own OAuth requests (device authorization, polling, refresh) inside `kimi-coding.ts` and the credential-derived request auth that `resolveProviderAuth` produces from `toAuth`. Both run below any extension hook, and an extension cannot see the device-code exchange at all.
+
+### Expected merge conflict zones
+
+- LOW: new file `packages/ai/src/auth/oauth/kimi-identity.ts`.
+- LOW: the three `fetch` call sites and `toAuth` in `packages/ai/src/auth/oauth/kimi-coding.ts`.
+
 ## 2026-09-10 - Map ask_user_question to Claude Code's AskUserQuestion wire name
 
 ### What changed

--- a/packages/ai/test/kimi-coding-identity-headers.test.ts
+++ b/packages/ai/test/kimi-coding-identity-headers.test.ts
@@ -1,0 +1,177 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { kimiCodingOAuth } from "../src/auth/oauth/kimi-coding.ts";
+import { resetKimiDeviceIdForTests } from "../src/auth/oauth/kimi-identity.ts";
+import type { ProviderAuthInteraction } from "../src/auth/types.ts";
+import { kimiCodingProvider } from "../src/providers/kimi-coding.ts";
+
+const OAUTH_HOST = "https://auth.kimi.com";
+const IDENTITY_HEADER_NAMES = [
+	"X-Msh-Platform",
+	"X-Msh-Version",
+	"X-Msh-Device-Name",
+	"X-Msh-Device-Model",
+	"X-Msh-Os-Version",
+	"X-Msh-Device-Id",
+] as const;
+
+const credential = {
+	type: "oauth",
+	access: "access-token",
+	refresh: "refresh-token",
+	expires: Date.now() + 3_600_000,
+} as const;
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function headerRecord(init: RequestInit | undefined): Record<string, string> {
+	const raw = (init?.headers ?? {}) as Record<string, string>;
+	const normalized: Record<string, string> = {};
+	for (const [name, value] of Object.entries(raw)) normalized[name.toLowerCase()] = value;
+	return normalized;
+}
+
+function interaction(): ProviderAuthInteraction {
+	return {
+		signal: new AbortController().signal,
+		prompt: async () => {
+			throw new Error("Kimi Code login should not prompt");
+		},
+		notify: () => {},
+	};
+}
+
+describe("Kimi Code client identity headers", () => {
+	let agentDir: string;
+
+	beforeEach(() => {
+		agentDir = mkdtempSync(join(tmpdir(), "senpi-kimi-identity-"));
+		vi.stubEnv("SENPI_CODING_AGENT_DIR", agentDir);
+		resetKimiDeviceIdForTests();
+	});
+
+	afterEach(() => {
+		resetKimiDeviceIdForTests();
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.useRealTimers();
+	});
+
+	it("derives request auth carrying the bearer token and every identity header", async () => {
+		const auth = await kimiCodingOAuth.toAuth(credential);
+		const headers = auth.headers ?? {};
+
+		expect(headers.Authorization).toBe("Bearer access-token");
+		expect(String(headers["User-Agent"] ?? "")).toMatch(/^KimiCLI\//);
+		for (const name of IDENTITY_HEADER_NAMES) {
+			expect(String(headers[name] ?? ""), `missing ${name}`).not.toHaveLength(0);
+		}
+	});
+
+	it("keeps every header value printable ASCII", async () => {
+		const auth = await kimiCodingOAuth.toAuth(credential);
+
+		for (const [name, value] of Object.entries(auth.headers ?? {})) {
+			expect(String(value), `non-ascii in ${name}`).toMatch(/^[\x20-\x7E]*$/);
+		}
+	});
+
+	it("persists one device id under the agent dir and reuses it", async () => {
+		const first = await kimiCodingOAuth.toAuth(credential);
+		const deviceId = String(first.headers?.["X-Msh-Device-Id"] ?? "");
+		const storePath = join(agentDir, "kimi-device-id");
+
+		expect(deviceId).not.toHaveLength(0);
+		expect(existsSync(storePath)).toBe(true);
+		expect(readFileSync(storePath, "utf-8").trim()).toBe(deviceId);
+
+		resetKimiDeviceIdForTests();
+		const second = await kimiCodingOAuth.toAuth(credential);
+		expect(second.headers?.["X-Msh-Device-Id"]).toBe(deviceId);
+	});
+
+	it("falls back to an ephemeral device id when the agent dir cannot be written", async () => {
+		vi.stubEnv("SENPI_CODING_AGENT_DIR", join("/dev/null", "unwritable-agent-dir"));
+		resetKimiDeviceIdForTests();
+
+		const auth = await kimiCodingOAuth.toAuth(credential);
+
+		expect(String(auth.headers?.["X-Msh-Device-Id"] ?? "")).not.toHaveLength(0);
+	});
+
+	it("sends the identity headers on device authorization and token polling", async () => {
+		vi.useFakeTimers();
+		const seen: Record<string, string>[] = [];
+		const pollResponses = [
+			jsonResponse({ error: "authorization_pending" }, 400),
+			jsonResponse({ access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600 }),
+		];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				seen.push(headerRecord(init));
+				if (String(input) === `${OAUTH_HOST}/api/oauth/device_authorization`) {
+					return jsonResponse({
+						user_code: "ABCD-1234",
+						device_code: "device-code-123",
+						verification_uri: "https://www.kimi.com/code",
+						verification_uri_complete: "https://www.kimi.com/code?user_code=ABCD-1234",
+						interval: 5,
+						expires_in: 600,
+					});
+				}
+				const response = pollResponses.shift();
+				if (!response) throw new Error("Unexpected extra token poll");
+				return response;
+			}),
+		);
+
+		const login = kimiCodingOAuth.login(interaction());
+		await vi.advanceTimersByTimeAsync(10_000);
+		await expect(login).resolves.toMatchObject({ access: "access-token" });
+
+		expect(seen.length).toBeGreaterThanOrEqual(2);
+		for (const headers of seen) {
+			for (const name of IDENTITY_HEADER_NAMES) {
+				expect(headers, `missing ${name}`).toHaveProperty(name.toLowerCase());
+			}
+		}
+	});
+
+	it("sends the identity headers on token refresh", async () => {
+		const seen: Record<string, string>[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: unknown, init?: RequestInit): Promise<Response> => {
+				seen.push(headerRecord(init));
+				return jsonResponse({ access_token: "a", refresh_token: "r", expires_in: 3600 });
+			}),
+		);
+
+		await kimiCodingOAuth.refresh(
+			{ type: "oauth", access: "old", refresh: "old-refresh", expires: 0 },
+			new AbortController().signal,
+		);
+
+		expect(seen).toHaveLength(1);
+		for (const name of IDENTITY_HEADER_NAMES) {
+			expect(seen[0], `missing ${name}`).toHaveProperty(name.toLowerCase());
+		}
+	});
+
+	it("leaves the api-key path free of identity headers", async () => {
+		const resolved = await kimiCodingProvider().auth.apiKey?.resolve({
+			ctx: { env: async () => undefined } as never,
+			credential: { type: "api_key", key: "platform-key" },
+			signal: new AbortController().signal,
+		});
+
+		expect(resolved?.auth.apiKey).toBe("platform-key");
+		expect(resolved?.auth.headers).toBeUndefined();
+	});
+});

--- a/packages/ai/test/kimi-coding-oauth.test.ts
+++ b/packages/ai/test/kimi-coding-oauth.test.ts
@@ -223,9 +223,8 @@ describe("Kimi Code OAuth", () => {
 		});
 		expect(credential.expires).toBeGreaterThanOrEqual(before + 3600 * 1000);
 
-		await expect(kimiCodingOAuth.toAuth(credential)).resolves.toEqual({
-			headers: { Authorization: "Bearer new-access" },
-		});
+		const auth = await kimiCodingOAuth.toAuth(credential);
+		expect(auth.headers).toMatchObject({ Authorization: "Bearer new-access" });
 	});
 
 	it("retries refresh on 429 and fails unauthorized on invalid_grant", async () => {


### PR DESCRIPTION
## What breaks

`api.kimi.com/coding` recognizes its clients by a product `User-Agent` plus a six-header `X-Msh-*` device set — platform, version, device name, device model, OS version, and a per-install device id. The official Kimi Code client builds that set in `packages/oauth/src/identity.ts` and attaches it to device authorization, token polling, token refresh, and every managed request. A second, independently written integration sends the same set on chat requests too.

`X-Msh` appeared nowhere in `packages/ai/src`. A Kimi For Coding subscription session therefore presented itself as an anonymous Anthropic-protocol client that happened to hold a Kimi bearer token.

This is also the only divergence from both reference clients that fits #1504's timeline: senpi's kimi-coding request shape had not changed when the endpoint started rejecting fresh sessions, so a server-side tightening around client identification explains it where a payload regression does not.

## What this changes

- **New** `packages/ai/src/auth/oauth/kimi-identity.ts` builds the header set. Values are printable-ASCII sanitized; the device id is read from (or minted into) `<agent dir>/kimi-device-id`, memoized per process, and degrades to an ephemeral id when that directory cannot be written.
- `packages/ai/src/auth/oauth/kimi-coding.ts` sends the set on device authorization, device-code polling, token refresh, and — through `toAuth` — every chat request the model runtime issues for the provider.
- The api-key path is untouched and stays header-free: it authenticates with a platform key rather than a client session, and both reference integrations keep it clean.

Two details are ported deliberately rather than invented: ASCII sanitization exists because raw non-ASCII header bytes draw a CDN 520 on this host, and best-effort device-id persistence exists because an `ENOENT` on a fresh install must not break header construction for every request. Both are lessons visible in the reference integration's history.

## Evidence

Wire capture through the real CLI in RPC mode against a local interceptor (agent-dir `models.json` baseUrl override + a stored `kimi-coding` credential), so this is the actual transport path rather than a mock.

| | before | after |
|---|---|---|
| `User-Agent` | `pi (<os> <release>; <arch>)` | `KimiCLI/1.0` |
| `X-Msh-*` | none | all six present |
| device id across two processes | n/a | identical (persisted, mode 0600) |
| api-key credential | no `X-Msh-*` | no `X-Msh-*` (unchanged) |

`packages/ai/test/kimi-coding-identity-headers.test.ts` covers all four request paths, the persisted-then-reused device id, the unwritable-dir fallback, printable-ASCII values, and the api-key path staying clean. Reverting only `kimi-coding.ts` while keeping the suite turns it red on the missing `User-Agent` and `X-Msh-Platform` (`expected '' to match /^KimiCLI\//`, `missing X-Msh-Platform`), and restoring it goes green together with the pre-existing `kimi-coding-oauth.test.ts`. Run on Bun 1.4.

## Deliberately not changed

- **Beta Messages endpoint.** The official client routes anthropic-protocol Kimi models through `client.beta.messages.create`. `anthropic-messages` already does, and the capture confirms `POST /v1/messages?beta=true` on the wire. No change needed.
- **`tools[].eager_input_streaming`.** The official client never sends it and the other integration withholds it from non-official Anthropic hosts, but senpi has sent it since June — including while kimi-coding worked — so it is not this regression. Flipping its default would also strip the field from the gateway-hosted models that proxy to Anthropic and accept it. Worth an alignment pass on its own.

## Verification limit

No Kimi For Coding subscription credential is available to me, so I cannot show a live 200 from the service. What is proven is that senpi now emits the request an official Kimi client emits instead of one no Kimi client would send. **`Refs #1504` rather than `Fixes`, on purpose**: the issue should stay open until someone with a subscription confirms the 500 is gone. The route itself is healthy and discriminating — unauthenticated answers 401 `Invalid Authentication`, a malformed bearer answers a different 401.

Refs #1504

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the Kimi client identity header set on the Kimi For Coding OAuth subscription path, so `api.kimi.com/coding` no longer sees a subscribed session as an anonymous Anthropic-protocol client holding a Kimi bearer token. The api-key path is unchanged and stays header-free.

- Applies `User-Agent: KimiCLI/1.0` plus the six `X-Msh-*` headers to device authorization, token polling, token refresh, and every chat request via `toAuth`.
- Header values are printable-ASCII sanitized; the device id persists under the agent dir and degrades to a per-process id when the dir is unwritable.
- Refs #1504 rather than Fixes — no subscription credential was available to confirm the live 500 is gone.

<sup>Written for commit b695cb056d8c577b285f675c49b831cd20661742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

