### PR TITLE
fix(coding-agent): make file reload detection deterministic

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### Fixed
 
+- Auth and cached provider-settings reload detection now uses file content revisions instead of filesystem mtimes, so rapid same-tick rewrites are observed deterministically.
+
 - A provider-agnostic "Provider is not configured" style refusal no longer ends a goal as a Codex policy rejection. The gate now requires the Codex responses api id, so another provider or gateway emitting the same sentence keeps provider and system recovery instead of blocking the goal; the api id is pinned against the shipped model catalog so renaming it there cannot silently disarm the guard ([#1520](https://github.com/code-yeongyu/senpi/issues/1520))
 
 - A bare `.` submitted on a session that already has messages no longer renders as a user message in the TUI. It stays the manual-continue shortcut the session delivers as a hidden continuation, so nothing is painted for it while idle or while steering an active turn; a `.` on an empty session and a `.` carrying image attachments remain ordinary user input ([#1569](https://github.com/code-yeongyu/senpi/issues/1569))

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,26 @@
 # Local fork changes
 
+## 2026-09-11 - Make file reload detection independent of mtime granularity
+
+### What changed
+
+- `src/utils/paths.ts` adds a SHA-256 file-content revision helper.
+- `src/core/auth-storage.ts` uses content revisions for shared auth reload coalescing.
+- The Cursor CLI OAuth and Claude SDK OAuth settings caches use content revisions instead of `mtimeMs:size`.
+- The package changelog records the runtime fix.
+
+### Why
+
+- Two rapid rewrites can share an mtime on Linux, causing auth readers or cached provider settings to retain stale data. Content revisions preserve the cache optimization while making change detection deterministic.
+
+### Why this lives in the fork
+
+- These are Senpi's auth and provider settings runtime paths and their fork-specific reload behavior.
+
+### Expected merge conflict zones
+
+- MEDIUM: `src/utils/paths.ts`, `src/core/auth-storage.ts`, and the two provider settings loaders.
+
 ## 2026-09-10 - Use native TypeScript builds for omob performance
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -20,6 +20,25 @@
 
 - LOW: brand profile parsing, changelog settings accessors, and the config-reload routine settings key list.
 
+## 2026-09-11 - Make file reload detection independent of mtime granularity
+
+### What changed
+
+- `core/auth-storage.ts` now compares SHA-256 file-content revisions when deciding whether a shared auth snapshot is current.
+- Cursor CLI OAuth and Claude SDK OAuth settings caches use the same content revision helper instead of `mtimeMs:size`.
+
+### Why
+
+- Linux can retain one mtime for rapid rewrites, so mtime-based cache keys returned stale credentials or provider settings.
+
+### Why an extension could not handle it
+
+- Auth reload state is core-owned; provider settings cache invalidation is owned by the provider loaders.
+
+### Expected merge conflict zones
+
+- LOW: `core/auth-storage.ts`, `utils/paths.ts`, and provider `settings.ts` cache keys.
+
 ## 2026-09-10 - Restrict GPT-6 Astra high-reasoning warning to max
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -24,7 +24,8 @@
 
 ### What changed
 
-- `core/auth-storage.ts` now compares SHA-256 file-content revisions when deciding whether a shared auth snapshot is current.
+- `src/core/auth-storage.ts` now compares SHA-256 file-content revisions when deciding whether a shared auth snapshot is current.
+- `src/utils/paths.ts` owns the shared SHA-256 file-content revision helper used by the reload and settings caches.
 - Cursor CLI OAuth and Claude SDK OAuth settings caches use the same content revision helper instead of `mtimeMs:size`.
 
 ### Why

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -32,7 +32,7 @@ import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.ts";
 import { raceWithAbortSignal } from "../utils/abort.ts";
-import { getFileRevision, normalizePath } from "../utils/paths.ts";
+import { getFileContentRevision, normalizePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import {
 	CredentialStoreBusyError,
@@ -401,7 +401,7 @@ export class AuthStorage implements CredentialStore {
 			sharedAuthFileReadState = { authPath, readState: this.readState };
 		}
 		if (authPath) {
-			const revision = getFileRevision(authPath);
+			const revision = getFileContentRevision(authPath);
 			if (revision !== undefined && revision === this.readState.revision) return;
 		}
 		this.reload();
@@ -460,7 +460,7 @@ export class AuthStorage implements CredentialStore {
 				data = parsed.data;
 				// A written repair invalidates the revision read before it; leaving it
 				// unset makes the next reader re-read instead of trusting a stale stamp.
-				revision = parsed.repaired || !this.authPath ? undefined : getFileRevision(this.authPath);
+				revision = parsed.repaired || !this.authPath ? undefined : getFileContentRevision(this.authPath);
 				return parsed.repaired
 					? { result: undefined, next: JSON.stringify(parsed.data, null, 2) }
 					: { result: undefined };
@@ -564,7 +564,7 @@ export class AuthStorage implements CredentialStore {
 	private async reloadFromStorageAsync(options?: AuthOperationOptions): Promise<AuthStorageData> {
 		return this.storage.withLockAsync(async (content) => {
 			const parsed = this.parseStorageContent(content);
-			const revision = parsed.repaired || !this.authPath ? undefined : getFileRevision(this.authPath);
+			const revision = parsed.repaired || !this.authPath ? undefined : getFileContentRevision(this.authPath);
 			this.updateReadState(parsed.data, revision);
 			return parsed.repaired
 				? { result: parsed.data, next: JSON.stringify(parsed.data, null, 2) }
@@ -583,7 +583,7 @@ export class AuthStorage implements CredentialStore {
 				return this.readState.data;
 			}
 		}
-		const revision = getFileRevision(this.authPath);
+		const revision = getFileContentRevision(this.authPath);
 		if (revision !== undefined && revision === this.readState.revision) return this.readState.data;
 		if (!this.readState.reload) {
 			const controller = new AbortController();
@@ -645,7 +645,7 @@ export class AuthStorage implements CredentialStore {
 			const next = await fn(currentData[provider]);
 			if (next === undefined) {
 				latestData = currentData;
-				revision = this.authPath ? getFileRevision(this.authPath) : undefined;
+				revision = this.authPath ? getFileContentRevision(this.authPath) : undefined;
 				return { result: currentData[provider] };
 			}
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -61,6 +61,24 @@
 - MEDIUM: `packages/coding-agent/src/core/remote-catalog-provider.ts` refresh publication and provider wrapper.
 - LOW: new `packages/coding-agent/src/core/remote-catalog-merge.ts` and the colocated remote catalog regression tests.
 
+## 2026-09-11 - Detect auth changes by content rather than mtime
+
+### What changed
+
+- `packages/coding-agent/src/core/auth-storage.ts` uses SHA-256 file-content revisions for shared reload detection and coalescing.
+
+### Why
+
+- Rapid rewrites may retain the same filesystem mtime and size, so metadata-only revisions can return stale credentials.
+
+### Why an extension could not handle it
+
+- The shared auth snapshot and reload-coalescing state are owned by core storage before provider extensions read them.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/auth-storage.ts` revision reads around reload and cache adoption.
+
 ## 2026-09-10 - Atomic account display-name metadata with shape-keyed sentinel guard (senpi#1495)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,24 @@
 # claude-sdk-oauth
 
+## 2026-09-11 - Detect same-tick settings rewrites
+
+### What changed
+
+- `settings.ts`: the cached provider-settings loader now keys its manager cache on a SHA-256 content revision rather than `mtimeMs:size`, so a rewrite made within one filesystem mtime tick is observed.
+
+### Why
+
+- Linux filesystems can preserve the same mtime for two rapid writes, leaving the loader with stale provider settings despite its re-read contract.
+
+### Why an extension could not handle it
+
+- The cache and its invalidation key are owned by this provider extension's settings loader.
+
+### Expected merge conflict zones
+
+- LOW: `settings.ts` around `settingsFingerprint`.
+
+
 ## 2026-09-10 - Optional Claude account display names (senpi#1495)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/settings.ts
@@ -1,5 +1,5 @@
-import { statSync } from "node:fs";
 import { getAgentDir } from "../../../../config.ts";
+import { getFileContentRevision } from "../../../../utils/paths.ts";
 import { getSettingsPath, type Settings, SettingsManager } from "../../../settings-manager.ts";
 import type { SettingSource } from "./sdk-boundary.ts";
 
@@ -167,12 +167,7 @@ export function loadClaudeSdkOauthProviderSettings(
 }
 
 function settingsFingerprint(path: string): string {
-	try {
-		const stat = statSync(path);
-		return `${stat.mtimeMs}:${stat.size}`;
-	} catch {
-		return "missing";
-	}
+	return getFileContentRevision(path) ?? "missing";
 }
 
 let cachedClaudeSdkOauthManager: { cwd: string; key: string; manager: SettingsManager } | undefined;
@@ -180,7 +175,7 @@ let cachedClaudeSdkOauthManager: { cwd: string; key: string; manager: SettingsMa
 /** Load settings from Senpi's configured global and project settings.json paths. */
 export function loadClaudeSdkOauthProviderSettingsFromDisk(cwd: string): ClaudeSdkOauthProviderSettings {
 	// fallbackEligible() calls this per candidate probe; cache the manager by
-	// (cwd, settings mtime+size) and re-apply env live to avoid locked disk reads.
+	// (cwd, settings content revision) and re-apply env live to avoid locked disk reads.
 	const agentDir = getAgentDir();
 	const key = `${cwd}|${settingsFingerprint(getSettingsPath(cwd, agentDir, "global"))}|${settingsFingerprint(
 		getSettingsPath(cwd, agentDir, "project"),

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
@@ -19,6 +19,24 @@
 
 - LOW: slot shape in `accounts.ts`; the three rendering sites in `showAccounts` in `account-command.ts`.
 
+## 2026-09-11 - Detect same-tick settings rewrites
+
+### What changed
+
+- `settings.ts`: the cached provider-settings loader now keys its manager cache on a SHA-256 content revision rather than `mtimeMs:size`, so a rewrite made within one filesystem mtime tick is observed.
+
+### Why
+
+- Linux filesystems can preserve the same mtime for two rapid writes, leaving the loader with stale provider settings despite its re-read contract.
+
+### Why an extension could not handle it
+
+- The cache and its invalidation key are owned by this provider extension's settings loader.
+
+### Expected merge conflict zones
+
+- LOW: `settings.ts` around `settingsFingerprint`.
+
 ## 2026-08-24 - Keep provider tool protocol out of assistant text
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
@@ -1,5 +1,5 @@
-import { statSync } from "node:fs";
 import { getAgentDir } from "../../../../config.ts";
+import { getFileContentRevision } from "../../../../utils/paths.ts";
 import {
 	FileSettingsStorage,
 	getSettingsPath,
@@ -221,12 +221,7 @@ export function createCursorCliOauthSandboxModeValidator(
 }
 
 function settingsFingerprint(path: string): string {
-	try {
-		const stat = statSync(path);
-		return `${stat.mtimeMs}:${stat.size}`;
-	} catch {
-		return "missing";
-	}
+	return getFileContentRevision(path) ?? "missing";
 }
 
 let cachedCursorCliOauthManager: { cwd: string; key: string; manager: SettingsManager } | undefined;
@@ -235,7 +230,7 @@ let cachedCursorCliOauthManager: { cwd: string; key: string; manager: SettingsMa
 export function loadCursorCliOauthProviderSettingsFromDisk(cwd: string): CursorCliOauthProviderSettings {
 	// fallbackEligible() calls this per candidate probe during retry-fallback; a fresh
 	// SettingsManager per call drove locked disk reads hundreds of times per provider
-	// error. Cache the manager by (cwd, settings mtime+size) and re-apply env live.
+	// error. Cache the manager by (cwd, settings content revision) and re-apply env live.
 	const agentDir = getAgentDir();
 	const key = `${cwd}|${settingsFingerprint(getSettingsPath(cwd, agentDir, "global"))}|${settingsFingerprint(
 		getSettingsPath(cwd, agentDir, "project"),

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -18,6 +18,24 @@
 
 - LOW: changelog header parsing and version comparison helpers.
 
+## 2026-09-11 - Add content revisions for file-backed caches
+
+### What changed
+
+- `packages/coding-agent/src/utils/paths.ts` adds a SHA-256 file-content revision helper for auth and provider-settings caches.
+
+### Why
+
+- A content change must invalidate a cache even when the filesystem reports unchanged mtime and size.
+
+### Why an extension could not handle it
+
+- The revision primitive is shared by core auth storage and provider settings loaders.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/utils/paths.ts` file-revision helpers.
+
 ## Canonical identity resolves through the native realpath (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/src/utils/paths.ts
+++ b/packages/coding-agent/src/utils/paths.ts
@@ -1,4 +1,5 @@
-import { lstatSync, readlinkSync, realpathSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readlinkSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve as nodeResolvePath, parse, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -152,6 +153,18 @@ export function getFileRevision(path: string): string | undefined {
 	try {
 		const stats = statSync(path, { bigint: true });
 		return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeNs}:${stats.ctimeNs}`;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Returns a revision derived from file contents rather than filesystem timestamps.
+ * Use this when a same-tick rewrite must invalidate an in-memory snapshot.
+ */
+export function getFileContentRevision(path: string): string | undefined {
+	try {
+		return createHash("sha256").update(readFileSync(path)).digest("hex");
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/test/cursor-cli-oauth/settings-cache.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/settings-cache.test.ts
@@ -50,7 +50,7 @@ describe("Cursor CLI OAuth provider settings cache", () => {
 		for (let i = 0; i < N; i++) loadCursorCliOauthProviderSettingsFromDisk(cwd);
 
 		expect(createSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-		// The loader caches by (cwd, mtime, size); unchanged files must not create
+		// The loader caches by (cwd, file content revision); unchanged files must not create
 		// a fresh SettingsManager + locked disk reads on every call. Current code
 		// has no cache => N creates.
 		expect(createSpy.mock.calls.length).toBeLessThan(N);


### PR DESCRIPTION
## Symptom
On Linux, these tests intermittently retained the previous file contents after a rapid rewrite:

- `packages/coding-agent/test/auth-storage.test.ts:137`: `expected { type: 'api_key', key: 'old' } to deeply equal { type: 'api_key', key: 'new' }`
- `packages/coding-agent/test/cursor-cli-oauth/settings.test.ts:249`: expected `enabled: true, pinnedAccount: "second"`, received `enabled: false, pinnedAccount: "first"`

## Root cause
Both paths used filesystem timestamps as cache/reload change signals. Auth reloads compared `getFileRevision()` in `packages/coding-agent/src/core/auth-storage.ts:404,463,567,586,648`; the revision included mtime metadata. The Cursor and Claude settings caches used `mtimeMs:size` in their `settingsFingerprint()` functions. On the reported Linux filesystem, two same-tick rewrites produced the same change key, so stale snapshots were treated as current.

The tests write the file twice in one test without advancing mtime explicitly and assert that the second contents are observed. That is valid for the documented "reload on changed file" behavior, but bare mtime equality made it timing-dependent.

## Fix
- Add `getFileContentRevision()` in `packages/coding-agent/src/utils/paths.ts`, using SHA-256 of file contents.
- Use that revision for auth snapshot reload/coalescing.
- Use it for both Cursor CLI OAuth and Claude SDK OAuth settings caches, preserving the cache optimization while making invalidation independent of mtime granularity.
- Add package and tracker changelog entries.

## Evidence
All remote execution was through bunshin in `/tmp/senpi-mtime-20260911/`; no tests ran on the local Mac.

- gorky, Linux, Bun 1.4.2, pristine main before fix: auth test `9/20 pass, 11/20 fail`; settings test `15/20 pass, 5/20 fail`.
- gorky, Linux, Bun 1.4.2, after fix: auth `20/20 pass`; settings `20/20 pass`.
- gorky mutation replacing the SHA-256 revision with `size:mtimeNs`: auth `10/20 pass, 10 fail`; settings `14/20 pass, 6 fail`. Failures reproduced the exact stale-value assertions above.
- mengmotaMac, macOS, Bun 1.4.0 (no Bun 1.4.2 at the preferred path): focused post-fix auth and settings tests each passed once.
- mengmotaMac mutation: the production revision was changed back to `size:mtimeNs` and both tests were additionally forced to write the same mtime with `utimesSync`; auth exited 1 and settings exited 1 with the exact stale-value assertions above. The mutation was discarded before commit.
- Related remote focused suite after fix: 6 files, 90 passed, 1 skipped.

The broad `bun run test` attempt was intentionally not used as evidence: its remote invocation exceeded the 1-hour command deadline while running the full suite. The focused tests and required static `bun run check` completed successfully on gorky before that attempt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale auth credentials and provider settings after rapid same-tick rewrites on Linux. Auth reloads and the Cursor/Claude settings caches now compare SHA-256 file-content revisions instead of filesystem mtimes, so a rewrite landing within the same mtime tick is always observed.

**Bug Fixes**
- Adds `getFileContentRevision()` in `packages/coding-agent/src/utils/paths.ts`, hashing file contents with SHA-256.
- Auth snapshot reload coalescing in `auth-storage.ts` switches from mtime-based revisions to content revisions.
- Cursor CLI OAuth and Claude SDK OAuth settings fingerprints use content revisions instead of `mtimeMs:size`.
- Cache optimization is preserved; unchanged files still skip re-reading, and missing files still fall back to `"missing"`.
- Adds changelog and changes-tracker entries across the package.

<sup>Written for commit 1781d2689cb2840d5425858fcb8cebc47a40c264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

