### PR TITLE
fix(coding-agent): protect static catalog capabilities

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Remote pi.dev catalog refreshes no longer lower or replace capabilities declared by Senpi's static model catalog; existing rows and `-fast` variants remain authoritative, conflicting provider/model fields are exposed through the remote-catalog diagnostics API, and malformed remote rows are rejected.
+
 - The Windows RPC host supervisor now creates its internal socket directory recursively and provisions a missing public socket secret while reusing an existing valid one, so launching `--internal-rpc-host-supervisor` directly on a fresh profile reaches its listener instead of crashing with `ENOENT ... mkdir '<agentDir>\rpc-host-daemon\internal-<uuid>'` and then `ENOENT ... open '<publicSocket>.secret'` ([#1370](https://github.com/code-yeongyu/senpi/issues/1370))
 
 - A pool slot holding a provider's managed sentinel (`claude-sdk-oauth-managed`) is healed the moment auth.json is read and the repair is written back once, so a second login on an affected build no longer leaves a dead `login-N` entry that hard-errors every request whose affinity picks it; the rotation classifier also treats an unconfigured-slot auth miss as a per-credential failure, so a single bad slot can never dead-end a healthy multi-account pool.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,47 @@
 # changes
 
+## 2026-09-11 - Keep static model capabilities authoritative over remote catalog refreshes (senpi#1527)
+
+### What changed
+
+- `packages/coding-agent/src/core/remote-catalog-merge.ts` validates remote model rows at the ingest boundary, preserves all static capability fields for an existing model ID, refreshes only the remote display name and pricing metadata, preserves static rows omitted by the overlay, and returns named provider/model capability conflicts.
+- `packages/coding-agent/src/core/remote-catalog-provider.ts` records merge conflicts for each wrapped provider through `getRemoteCatalogConflicts()` while retaining the existing persisted catalog and refresh lifecycle.
+- `packages/coding-agent/test/remote-catalog-authority.test.ts` covers lower context-window protection, omitted `-fast` row preservation, capability conflict reporting, malformed-row rejection, and price metadata refresh.
+
+### Why
+
+- A newer pi.dev catalog could replace a fork-declared model wholesale, silently lowering deliberate tier windows such as Sol 650,000 and Astra 600,000 to 272,000. The same replacement also made stale remote capability metadata authoritative when the static fork catalog carried required rows or compatibility fields.
+
+### Why an extension could not handle it
+
+- Remote catalog ingestion and model merging occur inside `ModelRuntime` before extension code can observe or alter the provider registry; an extension-local repair would leave CLI, SDK, and extension-free sessions vulnerable to the same replacement.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/remote-catalog-provider.ts` refresh publication and provider wrapper.
+- LOW: new `packages/coding-agent/src/core/remote-catalog-merge.ts` and the colocated remote catalog regression tests.
+
+## 2026-09-11 - Keep static model capabilities authoritative over remote catalog refreshes (senpi#1527)
+
+### What changed
+
+- `packages/coding-agent/src/core/remote-catalog-merge.ts` (new): validates remote model rows at the ingest boundary, preserves all static capability fields for an existing model ID, refreshes only the remote display name and pricing metadata, preserves static rows omitted by the overlay, and returns named provider/model capability conflicts.
+- `packages/coding-agent/src/core/remote-catalog-provider.ts`: records the merge conflicts for each wrapped provider through `getRemoteCatalogConflicts()` while retaining the existing persisted catalog and refresh lifecycle.
+- `packages/coding-agent/test/remote-catalog-provider.test.ts`: covers lower context-window protection, omitted `-fast` row preservation, capability conflict reporting, malformed-row rejection, and price metadata refresh.
+
+### Why
+
+- A newer pi.dev catalog could replace a fork-declared model wholesale, silently lowering deliberate tier windows such as Sol 650,000 and Astra 600,000 to 272,000. The same replacement also made stale remote capability metadata authoritative even when the static fork catalog carried required rows or compatibility fields.
+
+### Why an extension could not handle it
+
+- Remote catalog ingestion and model merging occur inside `ModelRuntime` before extension code can observe or alter the provider registry; an extension-local repair would leave CLI, SDK, and extension-free sessions vulnerable to the same replacement.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/remote-catalog-provider.ts` refresh publication and provider wrapper.
+- LOW: new `packages/coding-agent/src/core/remote-catalog-merge.ts` and the colocated remote catalog regression tests.
+
 ## 2026-09-10 - Atomic account display-name metadata with shape-keyed sentinel guard (senpi#1495)
 
 ### What changed

--- a/packages/coding-agent/src/core/remote-catalog-merge.ts
+++ b/packages/coding-agent/src/core/remote-catalog-merge.ts
@@ -1,0 +1,105 @@
+import { isDeepStrictEqual } from "node:util";
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+const MODEL_CAPABILITY_FIELDS = [
+	"contextWindow",
+	"maxTokens",
+	"input",
+	"reasoning",
+	"thinkingLevelMap",
+	"upstreamModelId",
+	"serviceTier",
+	"recoverTextToolCalls",
+	"compat",
+] as const;
+
+type ModelCapabilityField = (typeof MODEL_CAPABILITY_FIELDS)[number];
+
+export type RemoteCatalogConflict = {
+	readonly providerId: string;
+	readonly modelId: string;
+	readonly fields: readonly ModelCapabilityField[];
+};
+
+type RemoteCatalogMerge = {
+	readonly models: Model<Api>[];
+	readonly conflicts: readonly RemoteCatalogConflict[];
+};
+
+export function mergeRemoteCatalogModels(
+	providerId: string,
+	baseline: readonly Model<Api>[],
+	dynamic: readonly Model<Api>[],
+): RemoteCatalogMerge {
+	const merged = [...baseline];
+	const conflicts: RemoteCatalogConflict[] = [];
+	for (const model of dynamic) {
+		const index = merged.findIndex((entry) => entry.id === model.id);
+		if (index < 0) {
+			merged.push(model);
+			continue;
+		}
+		const staticModel = merged[index];
+		const fields = MODEL_CAPABILITY_FIELDS.filter(
+			(field) => !isDeepStrictEqual(staticModel[field], model[field]),
+		);
+		if (fields.length > 0) conflicts.push({ providerId, modelId: model.id, fields });
+		merged[index] = { ...staticModel, name: model.name, cost: model.cost };
+	}
+	return { models: merged, conflicts };
+}
+
+export function parseRemoteCatalog(providerId: string, value: unknown): Model<Api>[] {
+	const entries = Array.isArray(value)
+		? value
+		: typeof value === "object" && value !== null && "models" in value && Array.isArray(value.models)
+			? value.models
+			: typeof value === "object" && value !== null
+				? Object.values(value)
+				: undefined;
+	if (!entries || !entries.every(isModelCatalogEntry)) {
+		throw new Error(`Invalid model catalog for provider "${providerId}"`);
+	}
+	return entries.map((model) => ({ ...model, provider: providerId }));
+}
+
+function isModelCatalogEntry(value: unknown): value is Model<Api> {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		typeof value.name === "string" &&
+		typeof value.api === "string" &&
+		typeof value.provider === "string" &&
+		typeof value.baseUrl === "string" &&
+		typeof value.reasoning === "boolean" &&
+		isInputArray(value.input) &&
+		isModelCost(value.cost) &&
+		isFiniteNumber(value.contextWindow) &&
+		isFiniteNumber(value.maxTokens)
+	);
+}
+
+function isInputArray(value: unknown): value is Model<Api>["input"] {
+	return (
+		Array.isArray(value) &&
+		value.every((modality) => modality === "text" || modality === "image" || modality === "video")
+	);
+}
+
+function isModelCost(value: unknown): value is Model<Api>["cost"] {
+	if (!isRecord(value)) return false;
+	return (
+		isFiniteNumber(value.input) &&
+		isFiniteNumber(value.output) &&
+		isFiniteNumber(value.cacheRead) &&
+		isFiniteNumber(value.cacheWrite)
+	);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/coding-agent/src/core/remote-catalog-merge.ts
+++ b/packages/coding-agent/src/core/remote-catalog-merge.ts
@@ -57,7 +57,7 @@ export function parseRemoteCatalog(providerId: string, value: unknown): Model<Ap
 			: typeof value === "object" && value !== null
 				? Object.values(value)
 				: undefined;
-	if (!entries || !entries.every(isModelCatalogEntry)) {
+	if (!entries?.every(isModelCatalogEntry)) {
 		throw new Error(`Invalid model catalog for provider "${providerId}"`);
 	}
 	return entries.map((model) => ({ ...model, provider: providerId }));

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -1,5 +1,10 @@
 import type { Api, Model, ModelsStoreEntry, Provider } from "@earendil-works/pi-ai";
 import { VERSION } from "../config.ts";
+import {
+	mergeRemoteCatalogModels,
+	parseRemoteCatalog,
+	type RemoteCatalogConflict,
+} from "./remote-catalog-merge.ts";
 import { fetchWithRetry } from "../utils/management-http.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 
@@ -24,44 +29,11 @@ export function remoteCatalogServesProvider(providerId: string, catalogBaseUrl?:
 	return catalogBaseUrl !== undefined || !FORK_ONLY_BUILTIN_PROVIDERS.has(providerId);
 }
 
-const INPUT_MODALITY_ORDER = ["text", "image", "video"] as const;
+const remoteCatalogConflicts = new WeakMap<Provider, readonly RemoteCatalogConflict[]>();
 
-/**
- * Union of input modalities, in canonical order. The remote overlay refreshes
- * costs/limits but may lag behind fork-declared capabilities (e.g. kimi-coding
- * k3 video input), so a catalog entry must never silently drop a modality the
- * built-in model already declares.
- */
-function mergeInputModalities(baseline: Model<Api>["input"], dynamic: Model<Api>["input"]): Model<Api>["input"] {
-	const set = new Set([...(dynamic ?? []), ...(baseline ?? [])]);
-	return INPUT_MODALITY_ORDER.filter((modality) => set.has(modality));
-}
-
-function mergeModels(baseline: readonly Model<Api>[], dynamic: readonly Model<Api>[]): Model<Api>[] {
-	const merged = [...baseline];
-	for (const model of dynamic) {
-		const index = merged.findIndex((entry) => entry.id === model.id);
-		if (index >= 0) {
-			merged[index] = { ...model, input: mergeInputModalities(merged[index].input, model.input) };
-		} else {
-			merged.push(model);
-		}
-	}
-	return merged;
-}
-
-function parseCatalog(providerId: string, value: unknown): Model<Api>[] {
-	const entries = Array.isArray(value)
-		? value
-		: typeof value === "object" && value !== null && "models" in value && Array.isArray(value.models)
-			? value.models
-			: typeof value === "object" && value !== null
-				? Object.values(value)
-				: undefined;
-	if (!entries) throw new Error(`Invalid model catalog for provider "${providerId}"`);
-	return entries
-		.filter((entry): entry is Model<Api> => typeof entry === "object" && entry !== null && "id" in entry)
-		.map((model) => ({ ...model, provider: providerId }));
+/** Return capability conflicts rejected from a provider's remote overlay. */
+export function getRemoteCatalogConflicts(provider: Provider): readonly RemoteCatalogConflict[] {
+	return remoteCatalogConflicts.get(provider) ?? [];
 }
 
 function remoteModels(
@@ -82,10 +54,9 @@ export function withRemoteCatalog(
 	localGeneratedAt?: number,
 ): Provider {
 	let dynamicModels: readonly Model<Api>[] = [];
-
-	return {
+	const wrappedProvider: Provider = {
 		...provider,
-		getModels: () => mergeModels(provider.getModels(), dynamicModels),
+		getModels: () => mergeRemoteCatalogModels(provider.id, provider.getModels(), dynamicModels).models,
 		refreshModels: async (context) => {
 			const stored = context.stored;
 			const restored = remoteModels(stored, localGeneratedAt).filter((model) => model.provider === provider.id);
@@ -93,6 +64,10 @@ export function withRemoteCatalog(
 				!(await context.publish({
 					update: () => {
 						dynamicModels = restored;
+						remoteCatalogConflicts.set(
+							wrappedProvider,
+							mergeRemoteCatalogModels(provider.id, provider.getModels(), restored).conflicts,
+						);
 					},
 				}))
 			) {
@@ -149,7 +124,7 @@ export function withRemoteCatalog(
 				await context.publish({ persist: { ...(stored ?? { models: [] }), checkedAt } });
 				throw new Error(`Model catalog request failed for ${provider.id}: ${response.status}`);
 			}
-			const refreshed = parseCatalog(provider.id, await response.json());
+			const refreshed = parseRemoteCatalog(provider.id, await response.json());
 			const lastModified = Date.parse(response.headers.get("last-modified") ?? "");
 			if (context.signal.aborted) return;
 			const entry = {
@@ -163,8 +138,14 @@ export function withRemoteCatalog(
 				persist: entry,
 				update: () => {
 					dynamicModels = published;
+					remoteCatalogConflicts.set(
+						wrappedProvider,
+						mergeRemoteCatalogModels(provider.id, provider.getModels(), published).conflicts,
+					);
 				},
 			});
 		},
 	};
+	remoteCatalogConflicts.set(wrappedProvider, []);
+	return wrappedProvider;
 }

--- a/packages/coding-agent/test/remote-catalog-authority.test.ts
+++ b/packages/coding-agent/test/remote-catalog-authority.test.ts
@@ -1,0 +1,162 @@
+import {
+	createProvider,
+	InMemoryModelsStore,
+	type Model,
+	type Provider,
+	type ModelsPublication,
+	type RefreshModelsContext,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getRemoteCatalogConflicts,
+	withRemoteCatalog,
+} from "../src/core/remote-catalog-provider.ts";
+
+const neverAbortedSignal = new AbortController().signal;
+
+function model(id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "test-provider",
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+}
+
+async function refreshProvider(provider: Provider, store: InMemoryModelsStore): Promise<void> {
+	const publish = async (publication: ModelsPublication): Promise<boolean> => {
+		if (publication.persist === null) await store.delete(provider.id);
+		else if (publication.persist !== undefined) await store.write(provider.id, publication.persist);
+		publication.update?.();
+		return true;
+	};
+	await provider.refreshModels?.({
+		credential: { type: "api_key" },
+		stored: await store.read(provider.id),
+		publish,
+		allowNetwork: true,
+		signal: neverAbortedSignal,
+	});
+}
+
+function provider(models: readonly Model<"openai-completions">[]): Provider {
+	return withRemoteCatalog(
+		createProvider({
+			id: "test-provider",
+			auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
+			models,
+			api: {
+				stream: () => {
+					throw new Error("not used");
+				},
+				streamSimple: () => {
+					throw new Error("not used");
+				},
+			},
+		}),
+	);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("remote catalog authority", () => {
+	it("never drops static input modalities when remote metadata is narrower", async () => {
+		const staticModel = {
+			...model("k3"),
+			input: ["text", "image", "video"] as Model<"openai-completions">["input"],
+		};
+		const remoteModel = { ...model("k3"), input: ["text", "image"] };
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ k3: remoteModel }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const wrapped = provider([staticModel]);
+		await refreshProvider(wrapped, new InMemoryModelsStore());
+
+		expect(wrapped.getModels().find((entry) => entry.id === "k3")?.input).toEqual(["text", "image", "video"]);
+	});
+
+	it("preserves static limits while refreshing remote pricing", async () => {
+		const staticModel = { ...model("gpt-5.6-sol"), contextWindow: 650_000, maxTokens: 128_000 };
+		const remoteModel = {
+			...model("gpt-5.6-sol"),
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+			cost: { input: 9, output: 9, cacheRead: 9, cacheWrite: 9 },
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ sol: remoteModel }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const wrapped = provider([staticModel]);
+		await refreshProvider(wrapped, new InMemoryModelsStore());
+
+		const merged = wrapped.getModels().find((entry) => entry.id === "gpt-5.6-sol");
+		expect(merged?.contextWindow).toBe(650_000);
+		expect(merged?.cost.input).toBe(9);
+	});
+
+	it("preserves omitted fast rows and reports capability conflicts", async () => {
+		const staticModel = {
+			...model("gpt-6-astra"),
+			input: ["text", "image", "video"] as Model<"openai-completions">["input"],
+			contextWindow: 600_000,
+		};
+		const staticFastModel = { ...staticModel, id: "gpt-6-astra-fast", serviceTier: "priority" as const };
+		const remoteModel = {
+			...staticModel,
+			input: ["text"],
+			contextWindow: 272_000,
+			serviceTier: "auto" as const,
+			cost: { input: 3, output: 3, cacheRead: 3, cacheWrite: 3 },
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ astra: remoteModel }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const wrapped = provider([staticModel, staticFastModel]);
+		await refreshProvider(wrapped, new InMemoryModelsStore());
+
+		const models = wrapped.getModels();
+		expect(models.map((entry) => entry.id)).toEqual(["gpt-6-astra", "gpt-6-astra-fast"]);
+		expect(models[0]?.contextWindow).toBe(600_000);
+		expect(models[0]?.input).toEqual(["text", "image", "video"]);
+		expect(getRemoteCatalogConflicts(wrapped)).toEqual([
+			{
+				providerId: "test-provider",
+				modelId: "gpt-6-astra",
+				fields: ["contextWindow", "input", "serviceTier"],
+			},
+		]);
+	});
+
+	it("rejects a remote row missing required model fields", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ malformed: { id: "malformed", contextWindow: 272_000 } }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const wrapped = provider([model("static")]);
+		await expect(refreshProvider(wrapped, new InMemoryModelsStore())).rejects.toThrow(
+			'Invalid model catalog for provider "test-provider"',
+		);
+		expect(wrapped.getModels().map((entry) => entry.id)).toEqual(["static"]);
+	});
+});

--- a/packages/coding-agent/test/remote-catalog-authority.test.ts
+++ b/packages/coding-agent/test/remote-catalog-authority.test.ts
@@ -4,7 +4,6 @@ import {
 	type Model,
 	type Provider,
 	type ModelsPublication,
-	type RefreshModelsContext,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/coding-agent/test/remote-catalog-provider.test.ts
+++ b/packages/coding-agent/test/remote-catalog-provider.test.ts
@@ -258,35 +258,4 @@ describe("remote catalog provider", () => {
 		expect(await store.read(provider.id)).toMatchObject({ models: [], checkedAt: expect.any(Number) });
 	});
 
-	it("never drops builtin-declared input modalities when the overlay replaces a model", async () => {
-		const staticModel = { ...model("k3"), input: ["text", "image", "video"] as Model<"openai-completions">["input"] };
-		const remoteModel = { ...model("k3"), input: ["text", "image"] as Model<"openai-completions">["input"] };
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(JSON.stringify({ k3: remoteModel }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
-			}),
-		);
-		const provider = withRemoteCatalog(
-			createProvider({
-				id: "test-provider",
-				auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
-				models: [staticModel],
-				api: {
-					stream: () => {
-						throw new Error("not used");
-					},
-					streamSimple: () => {
-						throw new Error("not used");
-					},
-				},
-			}),
-		);
-		const store = new InMemoryModelsStore();
-
-		await refreshProvider(provider, store);
-
-		const merged = provider.getModels().find((entry) => entry.id === "k3");
-		expect(merged?.input).toEqual(["text", "image", "video"]);
-	});
 });


### PR DESCRIPTION
## Summary\n- keep static model capabilities authoritative when a newer pi.dev overlay reports lower or incompatible values\n- preserve static rows, including omitted priority-tier variants, while allowing remote display-name and pricing refreshes\n- reject malformed remote model rows and expose provider/model capability conflicts through a diagnostics helper\n\n## Root cause\nmergeModels() replaced an existing static model with the remote object wholesale. A newer upstream catalog could therefore lower deliberate fork tier limits and remove fork-only capability metadata without a local code change.\n\n## Ideal behavior\nThe fork's declared catalog is authoritative for existing model IDs and rows. Remote data can add missing rows and refresh non-capability metadata, but cannot lower or replace declared capabilities. Conflicts are observable and malformed rows fail at ingestion.\n\n## Verification\n- RED: the new lower-window regression failed with expected 650000 -> 272000 behavior on the unchanged merge.\n- GREEN: bun test packages/coding-agent/test/remote-catalog-provider.test.ts packages/coding-agent/test/remote-catalog-authority.test.ts on Bun 1.4.2: 13 pass, 0 fail.\n- Mutation: replacing the static merge assignment caused the 650000/600000 assertions to fail.\n- LSP diagnostics are clean for all changed TypeScript files.\n\nFixes #1527\nRefs #1144\nRefs code-yeongyu/oh-my-openagent#8040


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops remote pi.dev catalog refreshes from replacing static model definitions, so a newer upstream catalog can no longer lower deliberate fork tier limits or strip fork-only capability metadata. Static capabilities stay authoritative; remote overlays can only add missing rows and refresh display names and pricing.

**Bug Fixes**
- Capability conflicts between static and remote rows are exposed through `getRemoteCatalogConflicts()`.
- Remote rows missing required fields are rejected at ingestion instead of being silently accepted.
- Rows omitted by the overlay, including `-fast` priority-tier variants, are preserved.

Fixes #1527.

<sup>Written for commit 7814eea997ffb7daff6d261332598d50f56a3aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

