### PR TITLE
fix(tui): complete dollar skill hints at token boundaries

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Complete skill hints for `$` tokens at valid prompt boundaries while preserving literal shell variables such as `$HOME` and `$1` ([#1575](https://github.com/code-yeongyu/senpi/issues/1575)).
+
 ### Removed
 
 ## [2026.9.10-2] - 2026-09-10

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,24 @@
 # TUI delta rendering fork changes
 
+## 2026-09-11 - Offer skill hints for valid dollar tokens in prompt text
+
+### What changed
+
+- `packages/tui/src/dollar-invocation-autocomplete.ts`: dollar invocation lookup now resolves the token at the cursor after ordinary prompt text, while rejecting common shell variables and positional parameters before consulting the skill catalog. Existing leading skill chaining and trailing-space insertion remain unchanged.
+- `packages/tui/test/autocomplete.test.ts`: adds provider coverage for the mid-line skill hint and canonical `$skill` insertion.
+
+### Why
+
+- The Codex-style skill picker should appear when a user types `$` in a valid prompt token, not only when the line consists entirely of a leading dollar invocation. Shell-like forms such as `$HOME` and `$1` must remain literal.
+
+### Why an extension could not handle it
+
+- Dollar token extraction and completion arbitration run inside the standalone TUI autocomplete provider before interactive-mode extensions receive the editor event.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/dollar-invocation-autocomplete.ts` around token extraction and shell-variable classification.
+
 ## 2026-09-10 - Use native TypeScript builds for omob performance
 
 ### What changed

--- a/packages/tui/src/dollar-invocation-autocomplete.ts
+++ b/packages/tui/src/dollar-invocation-autocomplete.ts
@@ -47,7 +47,11 @@ function leadingKnownSkillRun(text: string, knownSkills: ReadonlySet<string>): b
 		tokens.length > 0 &&
 		tokens.every((token) => {
 			const match = DOLLAR_QUERY_PATTERN.exec(token);
-			return match !== null && match[1] !== "" && knownSkills.has(match[1]);
+			if (match === null || match[1] === "") return false;
+			const name = match[1].startsWith(SKILL_COMMAND_PREFIX)
+				? match[1].slice(SKILL_COMMAND_PREFIX.length)
+				: match[1];
+			return name !== "" && knownSkills.has(name);
 		})
 	);
 }

--- a/packages/tui/src/dollar-invocation-autocomplete.ts
+++ b/packages/tui/src/dollar-invocation-autocomplete.ts
@@ -2,7 +2,24 @@ import type { AutocompleteItem, SlashCommand } from "./autocomplete.ts";
 import { fuzzyFilter } from "./fuzzy.ts";
 
 const SKILL_COMMAND_PREFIX = "skill:";
-const LEADING_DOLLAR_RUN_PATTERN = /^((?:\$[a-zA-Z][a-zA-Z0-9:_-]*\s+)*)\$([a-zA-Z0-9:_-]*)$/;
+const DOLLAR_QUERY_PATTERN = /^\$([a-zA-Z0-9:_-]*)$/;
+const COMMON_SHELL_VARIABLES = new Set([
+	"CI",
+	"EDITOR",
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"NODE_ENV",
+	"OLDPWD",
+	"PATH",
+	"PWD",
+	"SHELL",
+	"SHLVL",
+	"TERM",
+	"TMPDIR",
+	"USER",
+	"VISUAL",
+]);
 
 type DollarInvocationItem = {
 	readonly description?: string;
@@ -16,6 +33,23 @@ export interface DollarInvocationContext {
 	readonly prefix: string;
 	readonly query: string;
 	readonly skillsOnly: boolean;
+}
+
+function isDollarQueryCompletable(query: string): boolean {
+	if (query === "") return true;
+	if (query.startsWith("-") || query.startsWith("_") || /^\d/.test(query)) return false;
+	return !COMMON_SHELL_VARIABLES.has(query);
+}
+
+function leadingKnownSkillRun(text: string, knownSkills: ReadonlySet<string>): boolean {
+	const tokens = text.trim().split(/\s+/).filter(Boolean);
+	return (
+		tokens.length > 0 &&
+		tokens.every((token) => {
+			const match = DOLLAR_QUERY_PATTERN.exec(token);
+			return match !== null && match[1] !== "" && knownSkills.has(match[1]);
+		})
+	);
 }
 
 function commandName(command: SlashCommand | AutocompleteItem): string {
@@ -41,8 +75,6 @@ export function getDollarInvocationContext(
 	commands: readonly (SlashCommand | AutocompleteItem)[],
 ): DollarInvocationContext | null {
 	if (cursorLine !== 0) return null;
-	const match = textBeforeCursor.match(LEADING_DOLLAR_RUN_PATTERN);
-	if (!match) return null;
 
 	const knownSkills = new Set(
 		commands.flatMap((command) => {
@@ -50,20 +82,24 @@ export function getDollarInvocationContext(
 			return name ? [name] : [];
 		}),
 	);
-	const precedingSkills = match[1]
-		.trim()
-		.split(/\s+/)
-		.filter(Boolean)
-		.map((token) => token.slice(1))
-		.map((name) => (name.startsWith(SKILL_COMMAND_PREFIX) ? name.slice(SKILL_COMMAND_PREFIX.length) : name));
-	if (precedingSkills.some((name) => !knownSkills.has(name))) return null;
+	const tokenStart = textBeforeCursor.search(/\S+$/);
+	const token = tokenStart === -1 ? "" : textBeforeCursor.slice(tokenStart);
+	const match = DOLLAR_QUERY_PATTERN.exec(token);
+	if (!match) return null;
 
-	const rawQuery = match[2];
+	const rawQuery = match[1];
+	if (!isDollarQueryCompletable(rawQuery)) return null;
 	const explicitSkillNamespace = rawQuery.startsWith(SKILL_COMMAND_PREFIX);
+	const precedingText = tokenStart === -1 ? "" : textBeforeCursor.slice(0, tokenStart);
+	const hasEarlierDollarToken = precedingText.includes("$");
+	const hasKnownLeadingSkillRun = leadingKnownSkillRun(precedingText, knownSkills);
+	if (hasEarlierDollarToken && !hasKnownLeadingSkillRun) return null;
+	const isKnownSkillInOrdinaryText = !hasKnownLeadingSkillRun && knownSkills.has(rawQuery);
+	if (isKnownSkillInOrdinaryText) return null;
 	return {
 		prefix: `$${rawQuery}`,
 		query: explicitSkillNamespace ? rawQuery.slice(SKILL_COMMAND_PREFIX.length) : rawQuery,
-		skillsOnly: precedingSkills.length > 0 || explicitSkillNamespace,
+		skillsOnly: hasKnownLeadingSkillRun || explicitSkillNamespace,
 	};
 }
 

--- a/packages/tui/test/autocomplete-dollar.test.ts
+++ b/packages/tui/test/autocomplete-dollar.test.ts
@@ -73,11 +73,21 @@ describe("CombinedAutocompleteProvider dollar invocation suggestions", () => {
 		});
 	});
 
-	it("does not offer dollar invocations outside a valid prompt-leading run", async () => {
+	it("offers partial skills after ordinary prompt text", async () => {
 		const provider = new CombinedAutocompleteProvider(commands, "/tmp");
 
-		assert.strictEqual(await getSuggestions(provider, "explain $deb"), null);
+		assert.deepStrictEqual(
+			(await getSuggestions(provider, "explain $deb"))?.items.map((item) => item.value),
+			["$debugging"],
+		);
 		assert.strictEqual(await getSuggestions(provider, "$missing $deb"), null);
 		assert.strictEqual(await getSuggestions(provider, "$deb", 1), null);
+	});
+
+	it("leaves shell variables and positional parameters literal", async () => {
+		const provider = new CombinedAutocompleteProvider(commands, "/tmp");
+
+		assert.strictEqual(await getSuggestions(provider, "echo $HOME"), null);
+		assert.strictEqual(await getSuggestions(provider, "echo $1"), null);
 	});
 });

--- a/packages/tui/test/autocomplete-dollar.test.ts
+++ b/packages/tui/test/autocomplete-dollar.test.ts
@@ -73,6 +73,23 @@ describe("CombinedAutocompleteProvider dollar invocation suggestions", () => {
 		});
 	});
 
+	it("preserves explicit skill namespace chaining", async () => {
+		const provider = new CombinedAutocompleteProvider(commands, "/tmp");
+		const line = "$skill:debugging $front";
+		const result = await getSuggestions(provider, line);
+
+		assert.deepStrictEqual(
+			result?.items.map((item) => item.value),
+			["$frontend"],
+		);
+		assert.strictEqual(result?.prefix, "$front");
+		assert.deepStrictEqual(provider.applyCompletion([line], 0, line.length, result!.items[0]!, result!.prefix), {
+			lines: ["$skill:debugging $frontend "],
+			cursorLine: 0,
+			cursorCol: "$skill:debugging $frontend ".length,
+		});
+	});
+
 	it("offers partial skills after ordinary prompt text", async () => {
 		const provider = new CombinedAutocompleteProvider(commands, "/tmp");
 

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -575,4 +575,34 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.strictEqual(applied.lines[0], '"my folder/test.txt"');
 		});
 	});
+
+	describe("dollar skill token boundaries", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "skill:commit", description: "Commit changes" }],
+			"/tmp",
+		);
+
+		it("offers a skill after ordinary prompt text at a token boundary", async () => {
+			const line = "text $com";
+			const result = await getSuggestions(provider, [line], 0, line.length);
+
+			assert.ok(result, "Expected a dollar skill suggestion");
+			if (!result) return;
+			assert.strictEqual(result.prefix, "$com");
+			assert.deepStrictEqual(
+				result.items.map((item) => item.value),
+				["$commit"],
+			);
+
+			const applied = provider.applyCompletion([line], 0, line.length, result.items[0]!, result.prefix);
+			assert.strictEqual(applied.lines[0], "text $commit ");
+			assert.strictEqual(applied.cursorCol, "text $commit ".length);
+		});
+
+		it("does not hijack shell-like dollar syntax or complete prose words", async () => {
+			assert.strictEqual(await getSuggestions(provider, ["text $HOME"], 0, 10), null);
+			assert.strictEqual(await getSuggestions(provider, ["echo $1"], 0, 7), null);
+			assert.strictEqual(await getSuggestions(provider, ["please use $commit"], 0, 18), null);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #1575

## Summary

- make dollar skill autocomplete resolve the token at the cursor after ordinary prompt text
- keep leading skill chaining, slash compatibility, canonical insertion, and trailing-space behavior unchanged
- reject common shell variables and positional parameters before consulting the skill catalog

## QA and evidence

- RED: packages/tui/test/autocomplete.test.ts failed on the unchanged provider with actual: null for text $com; artifact: local-ignore/qa-evidence/20260911-dollar-skill-completion/criterion-c1-red.txt
- GREEN: focused TUI provider suite passed 29/29; dollar suite passed 6/6; slash suite passed 5/5.
- Real surface: isolated source Senpi TUI scenario passed 3/3 and rendered the $debugging skill row; xterm screenshot and transcript are under local-ignore/qa-evidence/20260911-20260911-dollar-skill-completion/.
- Full packages/tui test suite passed and root bun run check passed.

## Scope

The change is limited to the TUI dollar autocomplete parser, focused tests, and the TUI fork change tracker. It does not change skill loading, provider APIs, RPC contracts, or generated files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1575 by making dollar skill hints appear at token boundaries after ordinary prompt text. Previously `$` completions only worked for a full line of leading dollar invocations; now typing `explain $deb` offers `$debugging` while shell variables like `$HOME` and `$1` remain literal.

**Behavior**
- The provider now resolves the token at the cursor and rejects common shell variables and positional parameters before consulting the skill catalog.
- Existing leading skill chaining, explicit `skill:` namespace chaining, slash compatibility, canonical insertion, and trailing-space behavior are unchanged.
- Changes are confined to the TUI autocomplete provider, tests, and changelog docs; no skill loading, provider APIs, RPC contracts, or generated files changed.

<sup>Written for commit 94e66d81a8903dc5f68f538f7c049d548af56053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

