### PR TITLE
feat(interactive): put resume command on own line

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-11 - The resume hint prints the command on its own line
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the interactive quit path writes the resume hint as two lines - the dimmed `To resume this session:` label, then the resume command on the following line - instead of one line separated by a space. The hint is still emitted only for the non-signal shutdown path and is still gated on `formatResumeCommand` returning a command, so nothing changes about when it appears.
+
+### Why
+
+- The command is meant to be copied. On one line the dimmed label shares the line with the command, so a double-click or triple-click selection picks up the label prefix and the user has to trim it before pasting. Putting the command alone on the second line makes line-wise selection copy exactly the runnable command.
+
+### Why an extension could not handle it
+
+- The hint is written with `process.stdout.write` from `InteractiveMode.shutdown()` after the TUI has already been torn down and the runtime host disposed. No extension hook runs at that point, and extensions must not write to stdout around the terminal owner.
+
+### Expected merge conflict zones
+
+- LOW: the single `process.stdout.write` resume-hint call in `InteractiveMode.shutdown()` and the matching expectation in `packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts`.
+
 ## 2026-09-10 - Safe account labels in footer and English help (senpi#1495)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6106,7 +6106,9 @@ export class InteractiveMode {
 
 		const resumeCommand = formatResumeCommand(this.sessionManager);
 		if (resumeCommand) {
-			process.stdout.write(`${chalk.dim("To resume this session:")} ${resumeCommand}\n`);
+			// The command goes on its own line so a double-click or triple-click
+			// selects the command alone, without the dimmed label prefix.
+			process.stdout.write(`${chalk.dim("To resume this session:")}\n${resumeCommand}\n`);
 		}
 
 		process.exit(0);

--- a/packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts
@@ -147,7 +147,7 @@ describe("InteractiveMode.shutdown ordering (#5080)", () => {
 
 		expect(order).toEqual(["drainInput", "stop", "dispose"]);
 		expect(stdoutWrite).toHaveBeenCalledWith(
-			`${chalk.dim("To resume this session:")} ${APP_NAME} --session test-session\n`,
+			`${chalk.dim("To resume this session:")}\n${APP_NAME} --session test-session\n`,
 		);
 	});
 


### PR DESCRIPTION
## Problem

The interactive quit path prints the resume hint as a single line:

```
To resume this session: senpi --session 01a08f23-1101-7f8a-93aa-d6ab86637b4d
```

That command exists to be copied, but the dimmed `To resume this session:` label shares the line with it. A double-click or triple-click selection picks up the label prefix too, so the command has to be trimmed by hand before it can be pasted.

## Root cause

`InteractiveMode.shutdown()` joins the label and the command with a space in one `process.stdout.write` call.

## Fix

Write the label and the command as two lines, so the command occupies a line by itself and line-wise selection copies exactly the runnable command:

```
To resume this session:
senpi --session 01a08f23-1101-7f8a-93aa-d6ab86637b4d
```

Nothing changes about *when* the hint appears: it is still emitted only on the non-signal shutdown path, and still gated on `formatResumeCommand()` returning a command. The signal path still prints no hint.

## Tests

`packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts` already pinned the exact single-line string, so its expectation is updated to the two-line form. That test is the regression guard for this behavior.

Verified the updated expectation actually guards the change — with the test update applied but the `interactive-mode.ts` change reverted, the suite fails:

```
Test Files  1 failed (1)
     Tests  1 failed | 4 passed (5)
```

and with the source change applied it passes:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`bun run check` passes (exit 0) on this branch.

One note so the diff is not surprising: `biome check --write` reports `Checked 3760 files in 5s. Fixed 4 files.` — it reformats four `remote-catalog-*` files that this PR does not touch. That is pre-existing formatting drift on `main` as of d4b69da79, reproducible on a clean checkout of the base commit, and those rewrites are deliberately excluded here so the diff stays scoped to the resume hint.

## Tracker

`packages/coding-agent/src/modes/interactive/changes.md` gains an entry for the touched upstream-owned path under the four canonical headings, per the changes.md contract.
