### PR TITLE
fix(coding-agent): make changelog selection version-aware

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Branded builds can provide an absolute changelog path and authored version, with source-isolated seen-version tracking and interactive changelog rendering; engine changelog notifications retain their existing link rewriting and install telemetry behavior (fixes #1583).
+
 - Added the `deepseek-v4-1-flash` prompt preset for DeepSeek V4.1 Flash: it resolves every published id shape (`deepseek-flash`, `deepseek-v4.1-flash`, `deepseek/deepseek-v4.1-flash`, `deepseek-ai/DeepSeek-V4.1-Flash`, fireworks' `deepseek-v4p1-flash`, venice's `deepseek-v4-1-flash`) and the official DeepSeek provider's retired `deepseek-v4-flash` / `deepseek-v4-flash-vision-exp` aliases, which the DeepSeek API now serves with V4.1 Flash; the same alias on any other provider keeps the V4 Flash preset. The preset carries the shared core and the eval-routing stance only - none of the V4 Flash repair rules, which were written against V4-Flash-0731 transcripts and do not apply to the re-trained model ([#1574](https://github.com/code-yeongyu/senpi/issues/1574))
 - Saved OpenAI Codex and Claude SDK OAuth accounts can receive optional display names during login or through account rename commands; account IDs remain unchanged and safe account status surfaces render `displayName (id)`.
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -130,6 +130,7 @@ When this value is anything other than `"auto"`, it overrides any model-level `p
 | `tipsHistory` | object | - | Internal record of which tips were shown last (managed automatically) |
 | `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |
+| `changelogSeen` | object | - | Internal per-source record of the latest changelog version acknowledged (managed automatically) |
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous install/update version ping after first install or changelog-detected updates. This does not control update checks |
 | `enableAnalytics` | boolean | `false` | Opt-in analytics data sharing. Currently only asked for during the experimental first-time setup (`PI_EXPERIMENTAL=1`) |
 | `trackingId` | string | - | Analytics tracking identifier, generated when `enableAnalytics` is turned on |

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-09-11 - Support brand-owned changelog sources (senpi#1583)
+
+### What changed
+
+- `packages/coding-agent/src/core/brand.ts`: accepts an optional absolute `changelog.path` and authored `changelog.version` in the brand profile.
+- `packages/coding-agent/src/core/settings-manager.ts`: stores changelog-seen versions per source while preserving the legacy engine version fallback.
+- `packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts`: treats `changelogSeen` as routine settings during reload filtering.
+
+### Why
+
+- Branded distributions need to show and acknowledge their own changelog without confusing their release history with the engine's changelog.
+
+### Why an extension could not handle it
+
+- Brand profile parsing, persistent settings, and reload bookkeeping are core startup and configuration contracts that run before extensions can provide equivalent behavior.
+
+### Expected merge conflict zones
+
+- LOW: brand profile parsing, changelog settings accessors, and the config-reload routine settings key list.
+
 ## 2026-09-10 - Restrict GPT-6 Astra high-reasoning warning to max
 
 ### What changed

--- a/packages/coding-agent/src/core/brand.ts
+++ b/packages/coding-agent/src/core/brand.ts
@@ -28,6 +28,11 @@ export interface BrandUpdateChannel {
 	readonly changelogUrl?: string;
 }
 
+export interface BrandChangelog {
+	readonly path: string;
+	readonly version?: string;
+}
+
 export interface BrandProfile {
 	/** Product name shown to users and to the model. */
 	readonly name: string;
@@ -47,6 +52,17 @@ export interface BrandProfile {
 	readonly originator?: string;
 	/** Update channel of the branded product; absent means the product manages updates itself. */
 	readonly update?: BrandUpdateChannel;
+	readonly changelog?: BrandChangelog;
+}
+
+function readChangelog(source: Record<string, unknown>): BrandChangelog | undefined {
+	const value = source.changelog;
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	const changelog = value as Record<string, unknown>;
+	const path = readString(changelog, "path");
+	if (!path?.startsWith("/") || path.includes("\0")) return undefined;
+	const version = readString(changelog, "version");
+	return { path, ...(version ? { version } : {}) };
 }
 
 function readUpdateChannel(source: Record<string, unknown>): BrandUpdateChannel | undefined {
@@ -114,6 +130,7 @@ export function parseBrandProfile(raw: string | undefined): BrandProfile | undef
 		return undefined;
 	}
 
+	const changelog = readChangelog(source);
 	return {
 		name,
 		command: readString(source, "command"),
@@ -124,6 +141,7 @@ export function parseBrandProfile(raw: string | undefined): BrandProfile | undef
 		userAgent: readString(source, "userAgent") || name,
 		originator: readString(source, "originator"),
 		update: readUpdateChannel(source),
+		...(changelog ? { changelog } : {}),
 	};
 }
 

--- a/packages/coding-agent/src/core/changelog-source.ts
+++ b/packages/coding-agent/src/core/changelog-source.ts
@@ -1,0 +1,27 @@
+import { BRAND, getChangelogPath, VERSION } from "../config.ts";
+import type { BrandProfile } from "./brand.ts";
+
+export interface ChangelogSource {
+	readonly id: string;
+	readonly path: string;
+	readonly version: string | undefined;
+	readonly rewriteLinks: boolean;
+}
+
+function brandSource(brand: BrandProfile): ChangelogSource {
+	const configured = brand.changelog;
+	if (!configured) {
+		return { id: brand.name.toLowerCase(), path: getChangelogPath(), version: undefined, rewriteLinks: false };
+	}
+	return {
+		id: brand.name.toLowerCase(),
+		path: configured.path,
+		version: configured.version,
+		rewriteLinks: false,
+	};
+}
+
+export function resolveChangelogSource(): ChangelogSource {
+	if (BRAND) return brandSource(BRAND);
+	return { id: "engine", path: getChangelogPath(), version: VERSION, rewriteLinks: true };
+}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-11 - Resolve branded changelog sources (senpi#1583)
+
+### What changed
+
+- `packages/coding-agent/src/core/changelog-source.ts`: resolves the engine or brand changelog path, source identity, authored version, and link rewriting policy used by interactive notifications.
+
+### Why
+
+- Branded installations need an independent changelog source and seen-version namespace while the unbranded engine retains its existing release behavior.
+
+### Why an extension could not handle it
+
+- Source selection is required by the interactive host before extension UI can render update notices.
+
+### Expected merge conflict zones
+
+- LOW: the changelog source resolver and its config imports.
+
 ## 2026-09-11 - Keep static model capabilities authoritative over remote catalog refreshes (senpi#1527)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -5,6 +5,7 @@
 ### What changed
 
 - `packages/coding-agent/src/core/changelog-source.ts`: resolves the engine or brand changelog path, source identity, authored version, and link rewriting policy used by interactive notifications.
+- `packages/coding-agent/src/core/settings-manager.ts`: stores changelog seen versions in source-keyed settings slots without cross-edition clobbering.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,24 @@
 # config-reload Extension Changes
 
+## 2026-09-11 - Keep per-source changelog acknowledgements routine (senpi#1583)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts`: classifies `changelogSeen` as routine settings during reload filtering.
+
+### Why
+
+- Acknowledging a changelog must not trigger a substantive configuration reload or cascade across sessions.
+
+### Why an extension could not handle it
+
+- The routine-setting classification is internal to the builtin reload diff before extension callbacks run.
+
+### Expected merge conflict zones
+
+- LOW: the routine settings key set.
+
+
 ## Offload non-recursive watch creation to the worker (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
@@ -19,6 +19,7 @@ const ROUTINE_SETTINGS_KEYS: ReadonlySet<string> = new Set([
 	"modelLastOnThinkingLevels",
 	"modelServiceTiers",
 	"lastChangelogVersion",
+	"changelogSeen",
 	"tipsHistory",
 ]);
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -126,6 +126,7 @@ export interface ExperimentalSettings {
 
 export interface Settings {
 	lastChangelogVersion?: string;
+	changelogSeen?: Record<string, string>;
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: ThinkingLevel;
@@ -1052,6 +1053,19 @@ export class SettingsManager {
 	setLastChangelogVersion(version: string): void {
 		this.globalSettings.lastChangelogVersion = version;
 		this.markModified("lastChangelogVersion");
+		this.save();
+	}
+
+	getChangelogSeen(source = "engine"): string | undefined {
+		return (
+			this.settings.changelogSeen?.[source] ?? (source === "engine" ? this.settings.lastChangelogVersion : undefined)
+		);
+	}
+
+	setChangelogSeen(source: string, version: string): void {
+		if (!source || this.globalSettings.changelogSeen?.[source] === version) return;
+		this.globalSettings.changelogSeen = { ...(this.globalSettings.changelogSeen ?? {}), [source]: version };
+		this.markModified("changelogSeen", source);
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -82,6 +82,24 @@
 ## 2026-09-10 - /tree edits carry the leaf token and reach shared hosts
 # changes
 
+## 2026-09-11 - Show the active brand changelog without cross-source updates (senpi#1583)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: uses the resolved brand or engine changelog source, persists acknowledgements by source, caps entries at the active version, and avoids engine link rewriting and install telemetry for branded sources.
+
+### Why
+
+- A branded product's release notes and version history must remain separate from the engine's release channel and telemetry.
+
+### Why an extension could not handle it
+
+- Interactive startup notices and the `/changelog` command are host-owned rendering paths that execute outside extension control.
+
+### Expected merge conflict zones
+
+- LOW: changelog startup handling and the `/changelog` command in `interactive-mode.ts`.
+
 ## 2026-09-02 - Do not paint two live login inputs
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -61,7 +61,6 @@ import {
 	getDebugLogPath,
 	getDocsPath,
 	getShareViewerUrl,
-	VERSION,
 } from "../../config.ts";
 import {
 	type AgentSessionEvent,
@@ -79,6 +78,7 @@ import {
 	computeCacheWaste,
 	detectCacheMiss,
 } from "../../core/cache-stats.ts";
+import { resolveChangelogSource } from "../../core/changelog-source.ts";
 import { collectEntriesForBranchSummary } from "../../core/compaction/branch-summarization.ts";
 import { AssistantEditError, assistantTextEquals } from "../../core/edited-assistant-message.ts";
 import type {
@@ -130,7 +130,7 @@ import {
 	INSPECTOR_VM_IMPORT_WARNING,
 	isRecoverableInspectorVmImportError,
 } from "../../inspector-policy.ts";
-import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
+import { getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
@@ -1867,28 +1867,33 @@ export class InteractiveMode {
 			return undefined;
 		}
 
-		const lastVersion = this.settingsManager.getLastChangelogVersion();
-		const changelogPath = getChangelogPath();
+		const source = resolveChangelogSource();
+		if (!source.version) return undefined;
+		const lastVersion = this.settingsManager.getChangelogSeen(source.id);
+		const changelogPath = source.path;
 		const entries = parseChangelog(changelogPath);
 
 		if (!lastVersion) {
 			// Fresh install - record the version, send telemetry, don't show changelog
-			this.settingsManager.setLastChangelogVersion(VERSION);
-			this.reportInstallTelemetry(VERSION);
+			this.settingsManager.setChangelogSeen(source.id, source.version);
+			this.reportInstallTelemetry(source.version);
 			return undefined;
 		}
 
-		const newEntries = getNewEntries(entries, lastVersion);
+		const newEntries = getNewEntries(entries, lastVersion, source.version);
 		if (newEntries.length > 0) {
-			this.settingsManager.setLastChangelogVersion(VERSION);
-			this.reportInstallTelemetry(VERSION);
-			return newEntries.map((e) => normalizeChangelogLinks(e.content, e)).join("\n\n");
+			this.settingsManager.setChangelogSeen(source.id, source.version);
+			this.reportInstallTelemetry(source.version);
+			return newEntries
+				.map((e) => (source.rewriteLinks ? normalizeChangelogLinks(e.content, e) : e.content))
+				.join("\n\n");
 		}
 
 		return undefined;
 	}
 
 	private reportInstallTelemetry(version: string): void {
+		if (BRAND) return;
 		if (envValue("OFFLINE")) {
 			return;
 		}
@@ -8945,14 +8950,15 @@ export class InteractiveMode {
 	}
 
 	private handleChangelogCommand(): void {
-		const changelogPath = getChangelogPath();
+		const source = resolveChangelogSource();
+		const changelogPath = source.path;
 		const allEntries = parseChangelog(changelogPath);
 
 		const changelogMarkdown =
 			allEntries.length > 0
 				? allEntries
 						.reverse()
-						.map((e) => normalizeChangelogLinks(e.content, e))
+						.map((e) => (source.rewriteLinks ? normalizeChangelogLinks(e.content, e) : e.content))
 						.join("\n\n")
 				: "No changelog entries found.";
 

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
 import { existsSync, readFileSync } from "fs";
+import { compare, valid } from "semver";
 
 export interface ChangelogEntry {
 	major: number;
 	minor: number;
 	patch: number;
+	suffix?: string;
+	version?: string;
 	content: string;
 }
 
@@ -15,7 +18,51 @@ const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 const INLINE_MARKDOWN_LINK_RE = /(!?\[[^\]\n]+\]\()([^\s)]+)((?:\s+[^)]*)?\))/g;
 
 function entryVersion(entry: ChangelogEntry): string {
-	return `${entry.major}.${entry.minor}.${entry.patch}`;
+	return entry.version ?? `${entry.major}.${entry.minor}.${entry.patch}${entry.suffix ? `-${entry.suffix}` : ""}`;
+}
+
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const CALVER_RE = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:-([2-9]\d*))?$/;
+
+function isValidDate(value: string): boolean {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return false;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function isForeignVersion(version: string): boolean {
+	return version.startsWith("0.0.0-omob.") || /^\d+\.\d+\.\d+-0\.beta\./.test(version);
+}
+
+function compareVersionStrings(left: string, right: string): number | undefined {
+	const leftCalver = CALVER_RE.exec(left);
+	const rightCalver = CALVER_RE.exec(right);
+	if (leftCalver && rightCalver) {
+		const leftParts = [
+			Number(leftCalver[1]),
+			Number(leftCalver[2]),
+			Number(leftCalver[3]),
+			Number(leftCalver[4] ?? 1),
+		];
+		const rightParts = [
+			Number(rightCalver[1]),
+			Number(rightCalver[2]),
+			Number(rightCalver[3]),
+			Number(rightCalver[4] ?? 1),
+		];
+		for (let index = 0; index < leftParts.length; index += 1) {
+			if (leftParts[index] !== rightParts[index]) return leftParts[index] < rightParts[index] ? -1 : 1;
+		}
+		return 0;
+	}
+	const leftValid = valid(left);
+	const rightValid = valid(right);
+	if (!leftValid || !rightValid || isForeignVersion(left) !== isForeignVersion(right)) return undefined;
+	return Math.sign(compare(leftValid, rightValid));
 }
 
 function normalizeTag(version: string | ChangelogEntry): string {
@@ -119,11 +166,27 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 		const entries: ChangelogEntry[] = [];
 
 		let currentLines: string[] = [];
-		let currentVersion: { major: number; minor: number; patch: number } | null = null;
+		let currentVersion: { major: number; minor: number; patch: number; suffix?: string; version: string } | null =
+			null;
+		let fence: { character: "`" | "~"; length: number } | null = null;
 
 		for (const line of lines) {
-			// Check if this is a version header (## [x.y.z] ...)
-			if (line.startsWith("## ")) {
+			const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+			if (fenceMatch) {
+				const character = fenceMatch[1][0] === "`" ? "`" : "~";
+				if (!fence) fence = { character, length: fenceMatch[1].length };
+				else if (fence.character === character && fenceMatch[1].length >= fence.length) fence = null;
+			}
+			const headerMatch =
+				fence === null
+					? /^##[ \t]+(?:\[([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)\]|([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)))(?:[ \t]+-[ \t]+(\d{4}-\d{2}-\d{2}))?[ \t]*$/.exec(
+							line,
+						)
+					: null;
+			if (
+				headerMatch ||
+				(fence === null && /^##[ \t]+\[?Unreleased\]?[ \t]*(?:-[ \t]+\d{4}-\d{2}-\d{2})?[ \t]*$/.test(line))
+			) {
 				// Save previous entry if exists
 				if (currentVersion && currentLines.length > 0) {
 					entries.push({
@@ -133,14 +196,21 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 				}
 
 				// Try to parse version from this line
-				const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
-				if (versionMatch) {
+				if (headerMatch && isValidDate(headerMatch[3] ?? "2026-01-01")) {
+					const parts = /^(\d+)\.(\d+)\.(\d+)(?:-(.*))?$/.exec(headerMatch[1] ?? headerMatch[2]);
+					if (!parts) {
+						currentVersion = null;
+						currentLines = [];
+						continue;
+					}
 					currentVersion = {
-						major: Number.parseInt(versionMatch[1], 10),
-						minor: Number.parseInt(versionMatch[2], 10),
-						patch: Number.parseInt(versionMatch[3], 10),
+						major: Number(parts[1]),
+						minor: Number(parts[2]),
+						patch: Number(parts[3]),
+						suffix: parts[4],
+						version: `${parts[1]}.${parts[2]}.${parts[3]}${parts[4] ? `-${parts[4]}` : ""}`,
 					};
-					currentLines = [line];
+					currentLines = [];
 				} else {
 					// Reset if we can't parse version
 					currentVersion = null;
@@ -171,25 +241,33 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
  * Compare versions. Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
  */
 export function compareVersions(v1: ChangelogEntry, v2: ChangelogEntry): number {
-	if (v1.major !== v2.major) return v1.major - v2.major;
-	if (v1.minor !== v2.minor) return v1.minor - v2.minor;
-	return v1.patch - v2.patch;
+	return compareVersionStrings(entryVersion(v1), entryVersion(v2)) ?? 0;
 }
 
 /**
  * Get entries newer than lastVersion
  */
-export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): ChangelogEntry[] {
+export function getNewEntries(
+	entries: ChangelogEntry[],
+	lastVersion: string,
+	currentVersion?: string,
+): ChangelogEntry[] {
 	// Parse lastVersion
-	const parts = lastVersion.split(".").map(Number);
-	const last: ChangelogEntry = {
-		major: parts[0] || 0,
-		minor: parts[1] || 0,
-		patch: parts[2] || 0,
-		content: "",
-	};
-
-	return entries.filter((entry) => compareVersions(entry, last) > 0);
+	const parts = lastVersion.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.*))?$/);
+	if (!parts || isForeignVersion(lastVersion)) return [];
+	const current = currentVersion && VERSION_RE.test(currentVersion) ? currentVersion : undefined;
+	if (current && (isForeignVersion(current) || compareVersionStrings(lastVersion, current) === undefined)) return [];
+	return entries.filter((entry, index, all) => {
+		const version = entryVersion(entry);
+		const lower = compareVersionStrings(version, lastVersion);
+		const upper = current ? compareVersionStrings(version, current) : 0;
+		return (
+			lower !== undefined &&
+			lower > 0 &&
+			(upper === undefined || upper <= 0) &&
+			all.findIndex((candidate) => entryVersion(candidate) === version) === index
+		);
+	});
 }
 
 // Re-export getChangelogPath from paths.ts for convenience

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-11 - Parse versioned changelog entries for branded sources (senpi#1583)
+
+### What changed
+
+- `packages/coding-agent/src/utils/changelog.ts`: parses dated version headers and fenced examples safely, compares SemVer and CalVer entries, preserves prerelease suffixes, bounds notifications to the active source version, and de-duplicates repeated versions.
+
+### Why
+
+- Changelog notifications must understand Senpi's CalVer revisions and branded prerelease labels without showing entries from another source or future release.
+
+### Why an extension could not handle it
+
+- Parsing and ordering happen inside the host's changelog utility before interactive extensions receive control.
+
+### Expected merge conflict zones
+
+- LOW: changelog header parsing and version comparison helpers.
+
 ## Canonical identity resolves through the native realpath (2026-09-07)
 
 ### What changed

--- a/packages/coding-agent/test/brand.test.ts
+++ b/packages/coding-agent/test/brand.test.ts
@@ -208,3 +208,13 @@ describe("envValue", () => {
 		]);
 	});
 });
+
+describe("brand changelog contract", () => {
+	test("accepts an absolute changelog path and authored version", () => {
+		expect(
+			parseBrandProfile(
+				JSON.stringify({ name: "omo", changelog: { path: "/tmp/omo.md", version: "2026.9.11-omo" } }),
+			)?.changelog,
+		).toEqual({ path: "/tmp/omo.md", version: "2026.9.11-omo" });
+	});
+});

--- a/packages/coding-agent/test/changelog.test.ts
+++ b/packages/coding-agent/test/changelog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { type ChangelogEntry, normalizeChangelogLinks } from "../src/utils/changelog.ts";
+import { type ChangelogEntry, getNewEntries, normalizeChangelogLinks } from "../src/utils/changelog.ts";
 
 const entry: ChangelogEntry = {
 	major: 0,
@@ -7,6 +7,24 @@ const entry: ChangelogEntry = {
 	patch: 0,
 	content: "",
 };
+
+describe("getNewEntries", () => {
+	test("uses full CalVer tokens, cap, and source isolation", () => {
+		const make = (version: string): ChangelogEntry => ({
+			major: 2026,
+			minor: 9,
+			patch: 10,
+			version,
+			content: version,
+		});
+		expect(
+			getNewEntries([make("2026.9.10"), make("2026.9.10-2"), make("2026.9.11")], "2026.9.9", "2026.9.10-2").map(
+				(e) => e.version,
+			),
+		).toEqual(["2026.9.10", "2026.9.10-2"]);
+		expect(getNewEntries([make("0.0.0-omob.7")], "5.0.0-0.beta.3", "5.0.0-0.beta.4")).toEqual([]);
+	});
+});
 
 describe("normalizeChangelogLinks", () => {
 	test("rewrites package-relative changelog links to tag-pinned GitHub source links", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -20,6 +20,15 @@ import {
 } from "../src/core/settings-manager.ts";
 
 describe("SettingsManager", () => {
+	it("isolates changelog seen versions by source and persists them", async () => {
+		const manager = SettingsManager.inMemory({ lastChangelogVersion: "1.0.0" });
+		expect(manager.getChangelogSeen("engine")).toBe("1.0.0");
+		expect(manager.getChangelogSeen("omo")).toBeUndefined();
+		manager.setChangelogSeen("omo", "5.0.0-beta.2");
+		await manager.flush();
+		expect(manager.getChangelogSeen("engine")).toBe("1.0.0");
+		expect(manager.getChangelogSeen("omo")).toBe("5.0.0-beta.2");
+	});
 	it("bridges SENPI terminal capability overrides, with PI fallback", () => {
 		const previous = {
 			SENPI_HYPERLINKS: process.env.SENPI_HYPERLINKS,


### PR DESCRIPTION
Fixes #1583\n\n## Summary\n- preserve full changelog version tokens and release boundaries\n- order CalVer hotfixes correctly and cap startup entries at the current version\n- isolate changelog seen state by source and route branded changelog sources\n- prevent branded startup telemetry from reporting to the upstream install endpoint\n\n## Verification\n- clean package-root targeted tests: 4 files, 136 passed\n- CalVer script tests: 7 passed\n- git diff --check: passed\n- root check attempted on permitted remote compute; blocked by missing @typescript/typescript6 in the fresh dependency tree, recorded locally in task evidence\n\nThe implementation keeps RPC and app-server surfaces unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1583. Changelog selection is now version- and source-aware: the engine or brand resolves its own changelog path and version, tracks the seen version per source, and sorts and caps displayed entries correctly, so CalVer hotfixes order right and branded builds skip engine link rewriting and upstream install telemetry. Brand profiles may add an absolute `changelog.path` and authored `changelog.version`.

**Verification**

- Package-root targeted tests pass: 4 files, 136 tests, plus 7 CalVer tests.
- Root check blocked by a missing `@typescript/typescript6` in a fresh dependency tree, recorded in task evidence.
- RPC and app-server surfaces are unchanged.

<sup>Written for commit 1e4044fe6ddfb3f4b5e0c6cf261821935500efb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

