### PR TITLE
fix(rpc): preserve live hosts across empty identity probes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### Fixed
 
+- Windows RPC host ownership checks no longer treat a temporarily empty process-identity probe
+  for a live PID as evidence that the shared host is dead. Compatible endpoints are reused before
+  ownership probing, preventing concurrent callers from replacing a healthy named-pipe host
+  during a transient Windows CIM observation gap.
+
 - The ask-user overlay now uses plain Enter to confirm and advance through question tabs, keeps multi-select choices intact when confirming, provides an explicit Submit tab for optional comments and partial answers, prevents editor focus traps, and reports partial answers without requiring a comment ([#1573](https://github.com/code-yeongyu/senpi/issues/1573))
 
 - Remote pi.dev catalog refreshes no longer lower or replace capabilities declared by Senpi's static model catalog; existing rows and `-fast` variants remain authoritative, conflicting provider/model fields are exposed through the remote-catalog diagnostics API, and malformed remote rows are rejected.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## 2026-09-11 - Keep remote catalog sources clean under the static validation gate
+
+### What changed
+
+- `packages/coding-agent/src/core/remote-catalog-merge.ts` and
+  `packages/coding-agent/src/core/remote-catalog-provider.ts` are aligned with the repository's
+  enforced Biome formatting and import ordering.
+
+### Why
+
+- The repository-wide static gate must validate these shared runtime sources without formatter
+  drift; the change preserves their behavior and removes only pre-existing formatting violations.
+
+### Why an extension could not handle it
+
+- These are core model-catalog runtime modules checked directly by the repository static gate;
+  extensions cannot alter their source formatting or import graph.
+
+### Expected merge conflict zones
+
+- LOW around the remote catalog merge and provider imports.
+
 ## 2026-09-11 - Keep static model capabilities authoritative over remote catalog refreshes (senpi#1527)
 
 ### What changed

--- a/packages/coding-agent/src/core/remote-catalog-merge.ts
+++ b/packages/coding-agent/src/core/remote-catalog-merge.ts
@@ -40,9 +40,7 @@ export function mergeRemoteCatalogModels(
 			continue;
 		}
 		const staticModel = merged[index];
-		const fields = MODEL_CAPABILITY_FIELDS.filter(
-			(field) => !isDeepStrictEqual(staticModel[field], model[field]),
-		);
+		const fields = MODEL_CAPABILITY_FIELDS.filter((field) => !isDeepStrictEqual(staticModel[field], model[field]));
 		if (fields.length > 0) conflicts.push({ providerId, modelId: model.id, fields });
 		merged[index] = { ...staticModel, name: model.name, cost: model.cost };
 	}

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -1,12 +1,8 @@
 import type { Api, Model, ModelsStoreEntry, Provider } from "@earendil-works/pi-ai";
 import { VERSION } from "../config.ts";
-import {
-	mergeRemoteCatalogModels,
-	parseRemoteCatalog,
-	type RemoteCatalogConflict,
-} from "./remote-catalog-merge.ts";
 import { fetchWithRetry } from "../utils/management-http.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
+import { mergeRemoteCatalogModels, parseRemoteCatalog, type RemoteCatalogConflict } from "./remote-catalog-merge.ts";
 
 const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
 const REMOTE_CATALOG_ATTEMPT_TIMEOUT_MS = 4_000;

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## 2026-09-11 - Treat live processes with temporarily absent identity as observable gaps
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/daemon/process.ts`: `processMatchesPidFile`
+  now checks process liveness when a platform identity probe returns no identity. A live PID
+  remains an observation failure within the bounded probe budget instead of being treated as a
+  dead or replaced process.
+
+### Why
+
+- Windows CIM queries can transiently return an empty result for a process that is still alive.
+  Treating that result as a PID mismatch lets concurrent RPC host startup reclaim a healthy host.
+
+### Why an extension could not handle it
+
+- The process identity reader is the ownership boundary used by daemon and RPC lifecycle code;
+  extensions cannot safely alter its result after a host has been classified.
+
+### Expected merge conflict zones
+
+- LOW around `daemon/process.ts` process identity probe classification.
+
 ## 2026-09-11 - Partial ask-user responses resolve with unanswered ids
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/daemon/process.ts
+++ b/packages/coding-agent/src/modes/app-server/daemon/process.ts
@@ -70,7 +70,10 @@ export async function processMatchesPidFile(
 	for (let attempt = 1; attempt <= attempts; attempt++) {
 		try {
 			const current = await readStartTime(pidFile.pid);
-			return current === pidFile.processStartTime;
+			if (current !== undefined) return current === pidFile.processStartTime;
+			if (!isLive(pidFile.pid)) return false;
+			lastError = new Error("process identity probe returned no identity for a live process");
+			if (attempt < attempts) await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
 		} catch (error: unknown) {
 			if (!isLive(pidFile.pid)) return false;
 			lastError = error;

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## 2026-09-11 - Preserve shared hosts across transient empty identity probes
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/host-ensure.ts` now reaches the compatible endpoint
+  decision before consulting an ownership identity probe, so concurrent callers can reuse a
+  healthy shared host even when the platform probe is temporarily unavailable.
+- `packages/coding-agent/test/rpc-host-identity-regression.test.ts` records the live-PID
+  observation-gap and compatible-endpoint reuse contracts.
+
+### Why
+
+- Windows named-pipe startup could misclassify a live shared host after an empty or unavailable
+  process identity observation, then enter replacement startup and terminate the valid host.
+
+### Why an extension could not handle it
+
+- Endpoint ownership, compatibility probing, and host replacement are RPC supervisor operations
+  that execute before extension code is available.
+
+### Expected merge conflict zones
+
+- LOW around `host-ensure.ts` endpoint compatibility and ownership probe ordering.
+
 ## 2026-09-11 - Partial ask-user responses resolve with unanswered ids
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -9,6 +9,8 @@
   healthy shared host even when the platform probe is temporarily unavailable.
 - `packages/coding-agent/test/rpc-host-identity-regression.test.ts` records the live-PID
   observation-gap and compatible-endpoint reuse contracts.
+- The regression diagnostics distinguish compatible reuse from ownership probing, and retain the
+  original readiness/cleanup evidence instead of replacing it with a termination side effect.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -154,13 +154,13 @@ async function ensureHostLocked(
 ): Promise<EnsuredHost> {
 	const pidFile = await readPidFile(paths);
 	const protocol = await probeProtocolInfo(socket, EXISTING_HOST_PROBE_TIMEOUT_MS);
-	const probe = testOptions?.readProcessStartTime ?? readProcessStartTime;
-	const pidMatches = pidFile ? await processMatchesPidFile(pidFile, probe) : false;
 	if (isCompatible(protocol)) {
 		// A compatible socket is attachable even when another client surface
 		// started it. Only hosts we spawned are eligible for lifecycle management.
 		return { pid: pidFile?.pid ?? 0, socket, reused: true };
 	}
+	const probe = testOptions?.readProcessStartTime ?? readProcessStartTime;
+	const pidMatches = pidFile ? await processMatchesPidFile(pidFile, probe) : false;
 	if (protocol && !pidMatches) {
 		throw new Error(`RPC socket ${socket} is owned by an unmanaged host`);
 	}

--- a/packages/coding-agent/test/remote-catalog-authority.test.ts
+++ b/packages/coding-agent/test/remote-catalog-authority.test.ts
@@ -2,14 +2,11 @@ import {
 	createProvider,
 	InMemoryModelsStore,
 	type Model,
-	type Provider,
 	type ModelsPublication,
+	type Provider,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-	getRemoteCatalogConflicts,
-	withRemoteCatalog,
-} from "../src/core/remote-catalog-provider.ts";
+import { getRemoteCatalogConflicts, withRemoteCatalog } from "../src/core/remote-catalog-provider.ts";
 
 const neverAbortedSignal = new AbortController().signal;
 

--- a/packages/coding-agent/test/remote-catalog-provider.test.ts
+++ b/packages/coding-agent/test/remote-catalog-provider.test.ts
@@ -257,5 +257,4 @@ describe("remote catalog provider", () => {
 		expect(provider.getModels().map((entry) => entry.id)).toEqual(["static"]);
 		expect(await store.read(provider.id)).toMatchObject({ models: [], checkedAt: expect.any(Number) });
 	});
-
 });

--- a/packages/coding-agent/test/rpc-host-identity-regression.test.ts
+++ b/packages/coding-agent/test/rpc-host-identity-regression.test.ts
@@ -1,0 +1,78 @@
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { VERSION } from "../src/config.ts";
+import { ProcessIdentityUnreadableError, processMatchesPidFile } from "../src/modes/app-server/daemon/process.ts";
+import { createHostDaemonPaths, ensureHost } from "../src/modes/rpc/host-ensure.ts";
+import { authenticateSocket, createSocketSecret, resolveSocketTransportAddress, socketSecretPath } from "../src/modes/rpc/socket-transport.ts";
+
+describe("RPC ownership observation", () => {
+	it("does not classify an absent identity on a live pid as gone", async () => {
+		await expect(processMatchesPidFile(
+			{ pid: process.pid, processStartTime: "identity" },
+			async () => undefined,
+			() => true,
+			{ attempts: 1 },
+		)).rejects.toBeInstanceOf(ProcessIdentityUnreadableError);
+	});
+
+	it("still recognizes confirmed absence and a different process identity", async () => {
+		const recorded = { pid: process.pid, processStartTime: "identity" };
+		expect(await processMatchesPidFile(recorded, async () => undefined, () => false, { attempts: 1 })).toBe(false);
+		expect(await processMatchesPidFile(recorded, async () => "replacement", () => true, { attempts: 1 })).toBe(false);
+	});
+
+	it("concurrent callers reuse a compatible endpoint without consulting an unavailable ownership probe", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-identity-"));
+		const socketPath = join(root, "rpc.sock");
+		const secret = process.platform === "win32" ? await createSocketSecret(socketSecretPath(socketPath)) : undefined;
+		const connections = new Set<Socket>();
+		let replies = 0;
+		let probes = 0;
+		const server = createServer((socket) => {
+			connections.add(socket);
+			socket.once("close", () => connections.delete(socket));
+			const serve = () => {
+				let buffer = "";
+				socket.on("data", (chunk) => {
+					buffer += chunk.toString();
+					if (!buffer.includes("\n")) return;
+					const request = JSON.parse(buffer.slice(0, buffer.indexOf("\n")));
+					replies += 1;
+					socket.end(`${JSON.stringify({ id: request.id, success: true, data: { serverVersion: VERSION, capabilities: ["multi_session", "extension_events"] } })}\n`);
+				});
+			};
+			if (secret) authenticateSocket(socket, secret, serve);
+			else serve();
+		});
+		try {
+			const listening = once(server, "listening", { signal: AbortSignal.timeout(5_000) });
+			server.listen(resolveSocketTransportAddress(socketPath, process.platform, secret));
+			await listening;
+			const agentDirs = [join(root, "one"), join(root, "two")];
+			for (const agentDir of agentDirs) {
+				const paths = createHostDaemonPaths(agentDir);
+				await mkdir(paths.dir, { recursive: true });
+				await writeFile(paths.pidFile, JSON.stringify({ pid: process.pid, processStartTime: "unavailable" }));
+				await writeFile(paths.settingsFile, "preserved");
+			}
+			const results = await Promise.allSettled(agentDirs.map((agentDir) => ensureHost({
+				agentDir,
+				socket: socketPath,
+				_test: { readProcessStartTime: async () => { probes += 1; throw new Error("identity query unavailable"); } },
+			})));
+			expect(results.map((result) => result.status)).toEqual(["fulfilled", "fulfilled"]);
+			for (const result of results) if (result.status === "fulfilled") expect(result.value.reused).toBe(true);
+			expect(replies).toBe(2);
+			expect(probes).toBe(0);
+			for (const agentDir of agentDirs) expect(await readFile(createHostDaemonPaths(agentDir).settingsFile, "utf8")).toBe("preserved");
+		} finally {
+			for (const socket of connections) socket.destroy();
+			await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-host-identity-regression.test.ts
+++ b/packages/coding-agent/test/rpc-host-identity-regression.test.ts
@@ -7,22 +7,43 @@ import { describe, expect, it } from "vitest";
 import { VERSION } from "../src/config.ts";
 import { ProcessIdentityUnreadableError, processMatchesPidFile } from "../src/modes/app-server/daemon/process.ts";
 import { createHostDaemonPaths, ensureHost } from "../src/modes/rpc/host-ensure.ts";
-import { authenticateSocket, createSocketSecret, resolveSocketTransportAddress, socketSecretPath } from "../src/modes/rpc/socket-transport.ts";
+import {
+	authenticateSocket,
+	createSocketSecret,
+	resolveSocketTransportAddress,
+	socketSecretPath,
+} from "../src/modes/rpc/socket-transport.ts";
 
 describe("RPC ownership observation", () => {
 	it("does not classify an absent identity on a live pid as gone", async () => {
-		await expect(processMatchesPidFile(
-			{ pid: process.pid, processStartTime: "identity" },
-			async () => undefined,
-			() => true,
-			{ attempts: 1 },
-		)).rejects.toBeInstanceOf(ProcessIdentityUnreadableError);
+		await expect(
+			processMatchesPidFile(
+				{ pid: process.pid, processStartTime: "identity" },
+				async () => undefined,
+				() => true,
+				{ attempts: 1 },
+			),
+		).rejects.toBeInstanceOf(ProcessIdentityUnreadableError);
 	});
 
 	it("still recognizes confirmed absence and a different process identity", async () => {
 		const recorded = { pid: process.pid, processStartTime: "identity" };
-		expect(await processMatchesPidFile(recorded, async () => undefined, () => false, { attempts: 1 })).toBe(false);
-		expect(await processMatchesPidFile(recorded, async () => "replacement", () => true, { attempts: 1 })).toBe(false);
+		expect(
+			await processMatchesPidFile(
+				recorded,
+				async () => undefined,
+				() => false,
+				{ attempts: 1 },
+			),
+		).toBe(false);
+		expect(
+			await processMatchesPidFile(
+				recorded,
+				async () => "replacement",
+				() => true,
+				{ attempts: 1 },
+			),
+		).toBe(false);
 	});
 
 	it("concurrent callers reuse a compatible endpoint without consulting an unavailable ownership probe", async () => {
@@ -42,7 +63,9 @@ describe("RPC ownership observation", () => {
 					if (!buffer.includes("\n")) return;
 					const request = JSON.parse(buffer.slice(0, buffer.indexOf("\n")));
 					replies += 1;
-					socket.end(`${JSON.stringify({ id: request.id, success: true, data: { serverVersion: VERSION, capabilities: ["multi_session", "extension_events"] } })}\n`);
+					socket.end(
+						`${JSON.stringify({ id: request.id, success: true, data: { serverVersion: VERSION, capabilities: ["multi_session", "extension_events"] } })}\n`,
+					);
 				});
 			};
 			if (secret) authenticateSocket(socket, secret, serve);
@@ -59,19 +82,29 @@ describe("RPC ownership observation", () => {
 				await writeFile(paths.pidFile, JSON.stringify({ pid: process.pid, processStartTime: "unavailable" }));
 				await writeFile(paths.settingsFile, "preserved");
 			}
-			const results = await Promise.allSettled(agentDirs.map((agentDir) => ensureHost({
-				agentDir,
-				socket: socketPath,
-				_test: { readProcessStartTime: async () => { probes += 1; throw new Error("identity query unavailable"); } },
-			})));
+			const results = await Promise.allSettled(
+				agentDirs.map((agentDir) =>
+					ensureHost({
+						agentDir,
+						socket: socketPath,
+						_test: {
+							readProcessStartTime: async () => {
+								probes += 1;
+								throw new Error("identity query unavailable");
+							},
+						},
+					}),
+				),
+			);
 			expect(results.map((result) => result.status)).toEqual(["fulfilled", "fulfilled"]);
 			for (const result of results) if (result.status === "fulfilled") expect(result.value.reused).toBe(true);
 			expect(replies).toBe(2);
 			expect(probes).toBe(0);
-			for (const agentDir of agentDirs) expect(await readFile(createHostDaemonPaths(agentDir).settingsFile, "utf8")).toBe("preserved");
+			for (const agentDir of agentDirs)
+				expect(await readFile(createHostDaemonPaths(agentDir).settingsFile, "utf8")).toBe("preserved");
 		} finally {
 			for (const socket of connections) socket.destroy();
-			await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 			await rm(root, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/suite/prompt-single-home.test.ts
+++ b/packages/coding-agent/test/suite/prompt-single-home.test.ts
@@ -17,7 +17,6 @@ function registeredToolDescriptions(): Map<string, string> {
 		goalStoreRef: () => {
 			throw new Error("not used");
 		},
-		liveWakeSources: () => [],
 		accountCurrentAgentTurn: async () => null,
 		beginAgentGoalAccounting: () => {},
 		markGoalBlockedThisTurn: () => {},


### PR DESCRIPTION
## Summary\n\nFixes #1290\n\nWindows process identity queries can successfully return no identity while the PID is still alive. The RPC host ensure path treated that observation as a PID mismatch, allowing a concurrent caller to enter replacement startup and terminate a healthy shared host.\n\n## Root fix\n\n- Treat an empty identity result for a live PID as an observation gap, with the existing bounded probe budget, rather than as a dead process.\n- Keep confirmed-dead PIDs classified as gone.\n- Decide compatible endpoint reuse before consulting an ownership identity probe, so a healthy shared endpoint is not replaced solely because platform observation is temporarily unavailable.\n- Add sanitized regression coverage for live empty identity, confirmed absence, and concurrent compatible-endpoint reuse.\n- Record the ownership-boundary behavior in both nearest changes trackers.\n\n## Verification\n\n- RED: live PID with an empty identity was incorrectly resolved as false.\n- GREEN: bunx vitest run test/rpc-host-identity-regression.test.ts test/rpc-host-ensure.test.ts test/rpc-host-lifecycle.test.ts — 3 files, 53 tests passed.\n- Workspace build: bun run build — exit 0.\n- Biome focused check: passed.\n\nThe full repository typecheck remains blocked by the existing unrelated liveWakeSources type mismatch in prompt-single-home.test.ts; no test was skipped or weakened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1290: Windows RPC host ownership checks no longer treat a temporarily empty process-identity probe for a live PID as a dead host, so concurrent callers reuse a healthy shared host instead of replacing and killing it.

- Live PIDs with no identity are treated as observation gaps within the bounded probe budget; confirmed-dead PIDs are still classified as gone.
- Compatible endpoints are reused before the ownership identity probe runs.
- Adds regression coverage for live empty identity, confirmed absence, and concurrent reuse, and aligns remote catalog sources and tests with Biome formatting, removing the `liveWakeSources` mismatch that blocked the repository typecheck.

<sup>Written for commit 7986d1d360ceec8e9da69a7614f1fc087b43d718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

