### PR TITLE
fix(test): align prompt fixture with goal tool deps

### DIFF
--- a/packages/coding-agent/test/suite/prompt-single-home.test.ts
+++ b/packages/coding-agent/test/suite/prompt-single-home.test.ts
@@ -17,7 +17,6 @@ function registeredToolDescriptions(): Map<string, string> {
 		goalStoreRef: () => {
 			throw new Error("not used");
 		},
-		liveWakeSources: () => [],
 		accountCurrentAgentTurn: async () => null,
 		beginAgentGoalAccounting: () => {},
 		markGoalBlockedThisTurn: () => {},


### PR DESCRIPTION
Fixes #1591

Remove the obsolete liveWakeSources field from the prompt-single-home test fixture so it matches GoalToolRegistrationDeps.

Verified with the focused Vitest test (3 passed). The full typecheck no longer reports this fixture error; unrelated pre-existing dependency/API errors remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1591 by removing the obsolete `liveWakeSources` field from the `prompt-single-home` test fixture so it matches `GoalToolRegistrationDeps`.

<sup>Written for commit 8001ed9ef9ceacb7c3a0972d5c37aa7003983bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

