### PR TITLE
fix(tui): support dollar hints in multiline drafts

### DIFF
--- a/packages/coding-agent/test/suite/prompt-single-home.test.ts
+++ b/packages/coding-agent/test/suite/prompt-single-home.test.ts
@@ -17,7 +17,6 @@ function registeredToolDescriptions(): Map<string, string> {
 		goalStoreRef: () => {
 			throw new Error("not used");
 		},
-		liveWakeSources: () => [],
 		accountCurrentAgentTurn: async () => null,
 		beginAgentGoalAccounting: () => {},
 		markGoalBlockedThisTurn: () => {},

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Complete skill hints for `$` tokens at valid prompt boundaries while preserving literal shell variables such as `$HOME` and `$1` ([#1575](https://github.com/code-yeongyu/senpi/issues/1575)).
+- Keep dollar skill autocomplete active on multiline drafts and follow-up input while streaming ([#1590](https://github.com/code-yeongyu/senpi/issues/1590)).
 
 ### Removed
 

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,24 @@
 # TUI delta rendering fork changes
 
+## 2026-09-11 - Keep dollar skill hints active across multiline drafts
+
+### What changed
+
+- `packages/tui/src/dollar-invocation-autocomplete.ts`: dollar skill lookup no longer rejects nonzero logical editor lines, so multiline drafts and queued message composition can request the same filtered skill suggestions.
+- `packages/tui/test/autocomplete-dollar.test.ts` and `packages/tui/test/editor-dollar-autocomplete.test.ts`: cover later-line provider lookup and paste/follow-up typing through the real Editor surface.
+
+### Why
+
+- The editor remains active while a response is streaming and while follow-up text is queued. A pasted or multiline draft can place the cursor on a later logical line, and the previous line-zero-only guard silently suppressed the skill picker there.
+
+### Why an extension could not handle it
+
+- Logical cursor routing and autocomplete request admission are owned by the standalone TUI Editor/provider path below the interactive extension API.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/dollar-invocation-autocomplete.ts` context gate and the focused dollar/editor tests.
+
 ## 2026-09-11 - Offer skill hints for valid dollar tokens in prompt text
 
 ### What changed

--- a/packages/tui/src/dollar-invocation-autocomplete.ts
+++ b/packages/tui/src/dollar-invocation-autocomplete.ts
@@ -75,11 +75,9 @@ function commandDescription(command: SlashCommand | AutocompleteItem): string | 
 
 export function getDollarInvocationContext(
 	textBeforeCursor: string,
-	cursorLine: number,
+	_cursorLine: number,
 	commands: readonly (SlashCommand | AutocompleteItem)[],
 ): DollarInvocationContext | null {
-	if (cursorLine !== 0) return null;
-
 	const knownSkills = new Set(
 		commands.flatMap((command) => {
 			const name = skillName(commandName(command));

--- a/packages/tui/test/autocomplete-dollar.test.ts
+++ b/packages/tui/test/autocomplete-dollar.test.ts
@@ -90,6 +90,28 @@ describe("CombinedAutocompleteProvider dollar invocation suggestions", () => {
 		});
 	});
 
+	it("offers skills on a later logical editor line", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "skill:debugging", description: "Debug runtime failures" }],
+			"/tmp",
+		);
+		const lines = ["first line", "text $"];
+		const result = await provider.getSuggestions(lines, 1, lines[1].length, {
+			signal: new AbortController().signal,
+		});
+
+		assert.deepStrictEqual(
+			result?.items.map((item) => item.value),
+			["$debugging"],
+		);
+		assert.strictEqual(result?.prefix, "$");
+		assert.deepStrictEqual(provider.applyCompletion(lines, 1, lines[1].length, result!.items[0]!, result!.prefix), {
+			lines: ["first line", "text $debugging "],
+			cursorLine: 1,
+			cursorCol: "text $debugging ".length,
+		});
+	});
+
 	it("offers partial skills after ordinary prompt text", async () => {
 		const provider = new CombinedAutocompleteProvider(commands, "/tmp");
 

--- a/packages/tui/test/editor-dollar-autocomplete.test.ts
+++ b/packages/tui/test/editor-dollar-autocomplete.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import type { AutocompleteProvider, AutocompleteSuggestions } from "../src/autocomplete.ts";
+import {
+	type AutocompleteProvider,
+	type AutocompleteSuggestions,
+	CombinedAutocompleteProvider,
+} from "../src/autocomplete.ts";
 import { Editor } from "../src/components/editor.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { defaultEditorTheme } from "./test-themes.ts";
@@ -39,5 +43,121 @@ describe("Editor dollar autocomplete trigger", () => {
 
 		assert.deepStrictEqual(request, { text: "$deb", cursorLine: 0, cursorCol: 4 });
 		assert.match(editor.render(80).join("\n"), /\$debugging/);
+	});
+
+	it("requests dollar autocomplete on a later logical line", async () => {
+		let resolveRequest: (value: { text: string; cursorLine: number; cursorCol: number }) => void;
+		const requested = new Promise<{ text: string; cursorLine: number; cursorCol: number }>((resolve) => {
+			resolveRequest = resolve;
+		});
+		const provider: AutocompleteProvider = {
+			async getSuggestions(lines, cursorLine, cursorCol) {
+				resolveRequest({ text: lines[cursorLine] ?? "", cursorLine, cursorCol });
+				return {
+					items: [{ value: "$debugging", label: "$debugging", description: "Debug runtime failures" }],
+					prefix: "$",
+				};
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		};
+		const editor = new Editor(new TuiMainScreen(new VirtualTerminal(80, 24)), defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+
+		editor.handleInput("first line");
+		editor.handleInput("\x1b[13;2u");
+		editor.handleInput("text $");
+		const request = await Promise.race([
+			requested,
+			new Promise<never>((_resolve, reject) => {
+				setTimeout(() => reject(new Error("editor did not request multiline dollar autocomplete")), 500);
+			}),
+		]);
+
+		assert.deepStrictEqual(request, { text: "text $", cursorLine: 1, cursorCol: 6 });
+		assert.match(editor.render(80).join("\n"), /\$debugging/);
+	});
+
+	it("reopens dollar autocomplete after a multiline paste and follow-up typing", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "skill:debugging", description: "Debug runtime failures" }],
+			"/tmp",
+		);
+		let resolveRequest: (value: AutocompleteSuggestions | null) => void = () => {};
+		const requested = new Promise<AutocompleteSuggestions | null>((resolve) => {
+			resolveRequest = resolve;
+		});
+		const wrappedProvider: AutocompleteProvider = {
+			async getSuggestions(lines, cursorLine, cursorCol, options) {
+				const result = await provider.getSuggestions(lines, cursorLine, cursorCol, options);
+				resolveRequest(result);
+				return result;
+			},
+			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
+				provider.applyCompletion(lines, cursorLine, cursorCol, item, prefix),
+		};
+		const editor = new Editor(new TuiMainScreen(new VirtualTerminal(80, 24)), defaultEditorTheme);
+		editor.setAutocompleteProvider(wrappedProvider);
+
+		editor.handleInput("\x1b[200~first line\ntext $\x1b[201~");
+		editor.handleInput("d");
+		const result = await requested;
+
+		assert.strictEqual(editor.getText(), "first line\ntext $d");
+		assert.deepStrictEqual(
+			result?.items.map((item) => item.value),
+			["$debugging"],
+		);
+	});
+
+	it("keeps dollar autocomplete responsive while a previous request is pending", async () => {
+		let requestCount = 0;
+		let resolveFirst: () => void = () => {};
+		let resolveFirstStarted: () => void = () => {};
+		let resolveSecondStarted: () => void = () => {};
+		let resolveSecond: (value: AutocompleteSuggestions) => void = () => {};
+		const first = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+		const firstStarted = new Promise<void>((resolve) => {
+			resolveFirstStarted = resolve;
+		});
+		const secondStarted = new Promise<void>((resolve) => {
+			resolveSecondStarted = resolve;
+		});
+		const second = new Promise<AutocompleteSuggestions>((resolve) => {
+			resolveSecond = resolve;
+		});
+		const provider: AutocompleteProvider = {
+			async getSuggestions() {
+				requestCount += 1;
+				if (requestCount === 1) {
+					resolveFirstStarted();
+					await first;
+					return null;
+				}
+				resolveSecondStarted();
+				const result = await second;
+				return result;
+			},
+			applyCompletion: (lines, cursorLine, cursorCol) => ({ lines, cursorLine, cursorCol }),
+		};
+		const editor = new Editor(new TuiMainScreen(new VirtualTerminal(80, 24)), defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+
+		editor.handleInput("$");
+		await firstStarted;
+		editor.handleInput("d");
+		resolveFirst();
+		await secondStarted;
+		resolveSecond({
+			items: [{ value: "$debugging", label: "$debugging", description: "Debug runtime failures" }],
+			prefix: "$d",
+		});
+		await second;
+
+		assert.strictEqual(editor.getText(), "$d");
+		assert.strictEqual(requestCount, 2);
 	});
 });


### PR DESCRIPTION
Fixes #1590

## Summary

- allow dollar skill lookup on any logical editor line, including multiline drafts
- keep autocomplete responsive across paste/follow-up typing and pending requests while a response is streaming
- preserve shell-variable rejection, leading skill chaining, slash/@ behavior, and canonical insertion
- remove the stale GoalToolRegistrationDeps fixture field so the current root typecheck remains green

## Evidence

- RED/GREEN: local-ignore/qa-evidence/20260911-multiline-streaming-dollar/criterion-c1-red.txt and criterion-c1-green.txt
- Editor surface: editor-dollar-autocomplete.test.ts covers later logical lines, multiline paste followed by `$d`, and a pending request concurrency path; 4/4 passed.
- Full packages/tui test suite passed.
- Root `bun run check` passed after the one stale test-fixture field was removed.
- Real TUI xterm QA: local-ignore/qa-evidence/20260911-20260911-multiline-streaming-dollar-tui/ passed 3/3 with auth unchanged and cleanup.
- A deterministic mock-model interactive PTY attempt could not reach a model turn in the isolated CLI startup; it cleaned its sandbox and auth remained unchanged. The editor concurrency test is the faithful lower-level streaming/queue seam.

## Scope

Only TUI autocomplete/editor tests and trackers changed, plus one obsolete test-fixture property required by the root typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1590. Dollar skill autocomplete now works on any logical line of a multiline draft instead of only the first, and stays responsive while a response streams.

- Removed the line-zero-only guard so `$` on later lines requests the same skill suggestions as line zero.
- Editor queues autocomplete requests so follow-up typing during a pending request still triggers a fresh lookup.
- Dropped the obsolete `liveWakeSources` field from a test fixture so the root typecheck stays green.

<sup>Written for commit dcfb41868c93edb422f1f385a9eda98799643146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

