### PR TITLE
fix(test): pin the shipped partial-answer question contract over IPC

### DIFF
--- a/packages/coding-agent/test/suite/rpc-worker-host-support.ts
+++ b/packages/coding-agent/test/suite/rpc-worker-host-support.ts
@@ -67,7 +67,14 @@ function endpoint(input: Readable, output: Writable, diagnostic: () => string) {
 					reject(error);
 				},
 			};
-			const timer = setTimeout(() => listener.reject(new Error(`RPC deadline; ${diagnostic()}`)), ms);
+			// Name the awaited record: a bare deadline plus host stderr reads like a
+			// transport stall even when the host is healthy and the record simply never
+			// matched, which is how a contract drift once looked like socket backpressure.
+			const awaited = String(predicate).replace(/\s+/g, " ").slice(0, 200);
+			const timer = setTimeout(
+				() => listener.reject(new Error(`RPC deadline waiting for ${awaited}; ${diagnostic()}`)),
+				ms,
+			);
 			listeners.add(listener);
 		});
 	}

--- a/packages/coding-agent/test/suite/rpc-worker-routing.test.ts
+++ b/packages/coding-agent/test/suite/rpc-worker-routing.test.ts
@@ -185,23 +185,22 @@ it("broadcasts question prompts across IPC and hydrates a late attachment", asyn
 		const updated = a.wait((r) => r.type === "question_updated");
 		b.send({ type: "extension_ui_progress", sessionId, id: frame.id, answers: { q1: { selected: ["A"] } } });
 		expect((await updated).remainingMs).toBeGreaterThan(0);
+		// A submission with neither an answer nor a comment carries no decision: it is
+		// rejected and the question stays pending for every attachment.
 		const incomplete = b.wait((r) => r.error === "question_incomplete");
-		b.send({
-			type: "extension_ui_response",
-			sessionId,
-			id: frame.id,
-			answers: { q1: { selected: ["A"] } },
-			comment: "",
-		});
+		b.send({ type: "extension_ui_response", sessionId, id: frame.id, answers: {}, comment: "" });
 		await incomplete;
 		const ra = a.wait((r) => r.type === "question_resolved");
 		const rb = b.wait((r) => r.type === "question_resolved");
-		b.send({ type: "extension_ui_response", sessionId, id: frame.id, answers: {}, comment: "do it" });
-		expect(await ra).toMatchObject({ outcome: "comment-submitted" });
-		expect(await rb).toMatchObject({ outcome: "comment-submitted" });
+		// A partial answer map is a decision on every surface (ask-user/pending.ts): it
+		// resolves the question as answered and reports the ids left unanswered.
+		b.send({ type: "extension_ui_response", sessionId, id: frame.id, answers: { q1: { selected: ["A"] } } });
+		const resolution = { outcome: "answered", answers: { q1: { selected: ["A"] } }, unanswered: ["q2"] };
+		expect(await ra).toMatchObject(resolution);
+		expect(await rb).toMatchObject(resolution);
 		expect((await prompt).success).toBe(true);
 		const late = b.wait((r) => r.error === "question_already_resolved");
-		b.send({ type: "extension_ui_response", sessionId, id: frame.id, answers: {} });
+		b.send({ type: "extension_ui_response", sessionId, id: frame.id, answers: {}, comment: "do it" });
 		await late;
 		expect(c.records.filter((r) => r.method === "question")).toHaveLength(1);
 		const state = await c.request({ type: "get_state", sessionId });


### PR DESCRIPTION
Fixes #1598

## Symptom

`main` fails CI on every run in `Test (coding-agent 3/3)`:

```
FAIL  test/suite/rpc-worker-routing.test.ts > broadcasts question prompts across IPC and hydrates a late attachment
Error: RPC deadline; senpi rpc listening on unix:///tmp/senpi-worker-test-…/rpc.sock
 ❯ Timeout.<anonymous> test/suite/rpc-worker-host-support.ts:70:51
```

Observed on 34587895860 (`37a3a183f`) and 34585734143 (`0601d3eea`), and reproducible on a clean `main` checkout in ~33 s on an idle machine — this is a deterministic contract mismatch, not a runner flake.

## Root cause

`45063b6ad` ("fix(ask-user): align partial answers across transports", #1576) made a non-empty **partial** answer map a decision on every transport:

```diff
-if (!comment?.trim() && unanswered().length) return false;
+if (!comment?.trim() && Object.keys(answers).length === 0) return false;
```

(`packages/coding-agent/src/modes/rpc/connection-question-bridge.ts`, mirrored in `ask-user/pending.ts` and recorded in four `changes.md` trackers plus `docs/rpc.md`.)

The end-to-end IPC case added one day earlier by `b7646ab8f` (#1533) still drove the old rule: it submitted `{ answers: { q1: … }, comment: "" }` and waited for `question_incomplete`. Under the aligned contract that submission *resolves* the question as `answered`, so the awaited error is never emitted; the wait burns its 30 s deadline and the case fails. The unit-level and state-machine tests were migrated in `45063b6ad`; this IPC case was missed.

An instrumented run of the same fixture confirms the peers see `question_updated` → `question_resolved` directly, with no `question_incomplete` in any record stream.

### The interleaved backpressure stderr is unrelated

The shard log also shows `socket event queue overflow: 0 queued + 2166 incoming > 1024` and `socket event queue stalled … 57 queued bytes within 50ms`. Production defaults are 64 MiB / `DEFAULT_STALL_MS = 4_000`; the literal 1024 and 50 ms come from `test/socket-event-fanout.test.ts` and `test/suite/rpc-socket-stall.test.ts`, which inject `maxQueueBytes`/`stallMs` into in-process connections whose failure handler writes to the fork's shared stderr. The failing test's own host stderr — captured verbatim into the deadline message — contains only the listening line: no quarantine, no overflow, no stall. No production backpressure change is needed or made here.

## Fix (test surface only)

`test/suite/rpc-worker-routing.test.ts` now drives the shipped contract, with the same number of assertions and nothing loosened:

- an `extension_ui_response` with neither an answer nor a comment is still rejected with `question_incomplete` and leaves the question pending;
- a partial answer map resolves it, and both attached peers must observe `question_resolved` with `outcome: "answered"`, the submitted `answers` and `unanswered: ["q2"]` (previously only `outcome` was asserted);
- a response after resolution is still rejected with `question_already_resolved`;
- prompt completion, single-delivery replay to the late attachment and the empty `pendingQuestions` assertions are unchanged.

Every wait is still registered before the frame that triggers it, and no sleeps or polling were added.

`test/suite/rpc-worker-host-support.ts` names the awaited record in the deadline error (`RPC deadline waiting for (r) => r.error === "question_incomplete"; <host stderr>`). A bare deadline plus host stderr is what made this contract drift look like socket backpressure in the first place.

## Verification

All runs on a macOS ARM64 machine, Node 24, from this branch (`gorky` and the preferred remote test box were both offline for the duration; mesh directory checked before falling back).

- `CI=1 npx vitest run test/suite/rpc-worker-routing.test.ts` — 6 passed, 4 consecutive runs; the question case takes 3.0 s (it burned a 33.5 s deadline before the change).
- Pristine `main`, same command: `1 failed | 5 passed`, `broadcasts question prompts across IPC and hydrates a late attachment 33498ms`, `Error: RPC deadline`.
- Related cluster, one run: `rpc-worker-routing`, `rpc-question-bridge`, `ask-user-pending`, `ask-user-schema`, `ask-user-async-delivery`, `ask-user-extension`, `rpc-types-question`, `rpc-socket-stall`, `socket-event-fanout`, `rpc-worker-isolation`, `rpc-worker-overflow`, `rpc-worker-rebind-commit`, `rpc-worker-reservations`, `rpc-close-backpressure` — 14 files, 81 tests, all passed.
- `npx tsc --noEmit` exit 0, `node scripts/check-browser-smoke.mjs` exit 0, `biome check --error-on-warnings` on both changed files exit 0 (`npm run check`'s other gates — pinned deps, ts imports, shrinkwrap, install lock, Claude SDK platform lock — also passed; note its `biome --write` step reformats four pre-existing `remote-catalog-*` files on `main`, which were reverted and are not part of this PR, cf. #1443).

Changed paths are test-tree only, so the changelog gate requires no `CHANGELOG.md` entry and no `changes.md` coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing CI test in `rpc-worker-routing` by driving the shipped partial-answer question contract over IPC. The test previously submitted a partial answer map with an empty comment and waited for `question_incomplete`; under the aligned contract that submission resolves as `answered`, so the wait burned the 30s deadline and failed `main` on every run (#1598).

**Bug Fixes**
- Empty submissions (no answers, no comment) are still rejected with `question_incomplete` and leave the question pending.
- A partial answer map resolves as `answered` with `unanswered: ["q2"]` on every attached peer.
- Late responses after resolution are still rejected with `question_already_resolved`.
- The harness deadline error now names the awaited predicate so a missing record cannot read as a transport stall.

<sup>Written for commit 42b3b7c5a15a9106f1f2f15efe8cb470d386bee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

