### PR TITLE
fix(codemode): preserve column-capped eval output

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Column-capped eval output now preserves a recoverable full-output artifact ([#1597](https://github.com/code-yeongyu/senpi/issues/1597)).
+
 ### Removed
 
 ## [2026.9.10-2] - 2026-09-10

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -218,10 +218,11 @@ empty pipe (`true | ( … )`) while a cell is active. Output, exit codes, `cwd`,
 ## Output and artifacts
 
 Cell output is streamed while the cell runs. Large streams spill to an absolute
-file after the default 50 KiB threshold. With a session file such as
-`/path/session.jsonl`, artifacts live in `/path/session-artifacts/`; sessions
-without a file use a unique temporary directory. Truncated results include a
-plain-path notice such as `[Full output: /absolute/path/eval-….log]`.
+file after the default 50 KiB threshold or when the output column cap drops
+bytes. With a session file such as `/path/session.jsonl`, artifacts live in
+`/path/session-artifacts/`; sessions without a file use a unique temporary
+directory. Truncated results include a plain-path notice such as
+`[Full output: /absolute/path/eval-….log]`.
 
 ## Deliberate differences from oh-my-pi
 

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -4,7 +4,8 @@
 
 ### What changed
 
-- `src/output/streaming-output.ts`: raw output now starts the existing spill
+- `src/output/streaming-output-buffer.ts` and
+  `src/output/streaming-output.ts`: raw output now starts the existing spill
   artifact when the per-line column cap drops bytes, even if the total output
   has not crossed the spill threshold.
 - `src/prompt/eval-prompt-template.ts`: large text guidance now directs eval

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,36 @@
 # senpi-codemode fork changes
 
+## 2026-09-11 - Column-capped eval output keeps a recovery artifact
+
+### What changed
+
+- `src/output/streaming-output.ts`: raw output now starts the existing spill
+  artifact when the per-line column cap drops bytes, even if the total output
+  has not crossed the spill threshold.
+- `src/prompt/eval-prompt-template.ts`: large text guidance now directs eval
+  callers to bounded chunks or offset-based file reads and treats truncation
+  notices as incomplete output.
+- `test/output/streaming-output.test.ts`: column-cap truncation proves that the
+  preview remains bounded while the artifact contains the complete raw stream.
+
+### Why
+
+- A long `console.log` line can be truncated by the output column cap before
+  the spill threshold. Without an artifact, the model has no reliable way to
+  recover the omitted bytes.
+
+### Why an extension could not handle it
+
+- The column cap and raw-stream mirroring are owned by `OutputSink` before the
+  eval tool result and notice are built; an external extension cannot recover
+  bytes that the sink never writes.
+
+### Expected merge conflict zones
+
+- LOW in `src/output/streaming-output.ts` around `push()` and `#mirrorRaw()`.
+- LOW in `src/prompt/eval-prompt-template.ts` and
+  `test/output/streaming-output.test.ts`.
+
 ## 2026-09-10 - Every eval cell gets a run budget; `timeout` is that budget
 
 ### What changed

--- a/packages/senpi-codemode/src/output/streaming-output-buffer.ts
+++ b/packages/senpi-codemode/src/output/streaming-output-buffer.ts
@@ -1,0 +1,58 @@
+interface ByteSlice {
+	readonly text: string;
+	readonly bytes: number;
+}
+
+export function truncateHeadBytes(text: string, maxBytes: number): ByteSlice {
+	if (maxBytes <= 0) return { text: "", bytes: 0 };
+	const buffer = Buffer.from(text, "utf8");
+	if (buffer.length <= maxBytes) return { text, bytes: buffer.length };
+	let end = maxBytes;
+	while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
+	const slice = buffer.subarray(0, end);
+	return { text: slice.toString("utf8"), bytes: slice.length };
+}
+
+export function truncateTailBytes(text: string, maxBytes: number): ByteSlice {
+	if (maxBytes <= 0) return { text: "", bytes: 0 };
+	const buffer = Buffer.from(text, "utf8");
+	if (buffer.length <= maxBytes) return { text, bytes: buffer.length };
+	let start = buffer.length - maxBytes;
+	while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) start++;
+	const slice = buffer.subarray(start);
+	return { text: slice.toString("utf8"), bytes: slice.length };
+}
+
+export class TailBuffer {
+	readonly #maxBytes: number;
+	#text = "";
+	#bytes = 0;
+
+	constructor(maxBytes: number) {
+		this.#maxBytes = Math.max(0, Math.floor(maxBytes));
+	}
+
+	append(text: string): void {
+		if (text.length === 0) return;
+		if (this.#maxBytes === 0) {
+			this.#text = "";
+			this.#bytes = 0;
+			return;
+		}
+		const incomingBytes = Buffer.byteLength(text, "utf8");
+		const next =
+			incomingBytes >= this.#maxBytes
+				? truncateTailBytes(text, this.#maxBytes)
+				: truncateTailBytes(this.#text + text, this.#maxBytes);
+		this.#text = next.text;
+		this.#bytes = next.bytes;
+	}
+
+	text(): string {
+		return this.#text;
+	}
+
+	bytes(): number {
+		return this.#bytes;
+	}
+}

--- a/packages/senpi-codemode/src/output/streaming-output.ts
+++ b/packages/senpi-codemode/src/output/streaming-output.ts
@@ -89,9 +89,9 @@ export class OutputSink {
 		this.#totalBytes += rawBytes;
 		this.#totalNewlines += countNewlines(chunk);
 		this.#sawData = true;
+		const droppedBefore = this.#columnDroppedBytes;
 		const retained = this.#maxColumns > 0 ? this.#clampColumns(chunk) : chunk;
-		const columnCapDropped = Buffer.byteLength(retained, "utf8") < rawBytes;
-		this.#mirrorRaw(chunk, columnCapDropped);
+		this.#mirrorRaw(chunk, this.#columnDroppedBytes > droppedBefore);
 		this.#retain(retained);
 	}
 

--- a/packages/senpi-codemode/src/output/streaming-output.ts
+++ b/packages/senpi-codemode/src/output/streaming-output.ts
@@ -2,11 +2,11 @@ import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { dirname } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail } from "../host-sdk.ts";
 import { formatMiddleElisionMarker } from "./output-meta.ts";
-import { TailBuffer, truncateHeadBytes, truncateTailBytes } from "./streaming-output-buffer.ts";
+import { TailBuffer, truncateHeadBytes } from "./streaming-output-buffer.ts";
 
 export { artifactNotice, formatMiddleElisionMarker, resolveSessionArtifactsDir } from "./output-meta.ts";
-export { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail, TailBuffer };
 export { truncateHeadBytes, truncateTailBytes } from "./streaming-output-buffer.ts";
+export { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, TailBuffer, truncateTail };
 
 export const ARTIFACT_DEFAULT_HEAD_BYTES = 3 * 1024 * 1024;
 

--- a/packages/senpi-codemode/src/output/streaming-output.ts
+++ b/packages/senpi-codemode/src/output/streaming-output.ts
@@ -2,9 +2,11 @@ import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { dirname } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail } from "../host-sdk.ts";
 import { formatMiddleElisionMarker } from "./output-meta.ts";
+import { TailBuffer, truncateHeadBytes, truncateTailBytes } from "./streaming-output-buffer.ts";
 
 export { artifactNotice, formatMiddleElisionMarker, resolveSessionArtifactsDir } from "./output-meta.ts";
-export { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail };
+export { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail, TailBuffer };
+export { truncateHeadBytes, truncateTailBytes } from "./streaming-output-buffer.ts";
 
 export const ARTIFACT_DEFAULT_HEAD_BYTES = 3 * 1024 * 1024;
 
@@ -31,11 +33,6 @@ export interface OutputSinkOptions {
 	readonly chunkThrottleMs?: number;
 }
 
-interface ByteSlice {
-	readonly text: string;
-	readonly bytes: number;
-}
-
 function countNewlines(text: string): number {
 	let count = 0;
 	let cursor = text.indexOf("\n");
@@ -48,60 +45,6 @@ function countNewlines(text: string): number {
 
 function lineCount(text: string): number {
 	return text.length === 0 ? 0 : countNewlines(text) + 1;
-}
-
-function truncateHeadBytes(text: string, maxBytes: number): ByteSlice {
-	if (maxBytes <= 0) return { text: "", bytes: 0 };
-	const buffer = Buffer.from(text, "utf8");
-	if (buffer.length <= maxBytes) return { text, bytes: buffer.length };
-	let end = maxBytes;
-	while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
-	const slice = buffer.subarray(0, end);
-	return { text: slice.toString("utf8"), bytes: slice.length };
-}
-
-function truncateTailBytes(text: string, maxBytes: number): ByteSlice {
-	if (maxBytes <= 0) return { text: "", bytes: 0 };
-	const buffer = Buffer.from(text, "utf8");
-	if (buffer.length <= maxBytes) return { text, bytes: buffer.length };
-	let start = buffer.length - maxBytes;
-	while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) start++;
-	const slice = buffer.subarray(start);
-	return { text: slice.toString("utf8"), bytes: slice.length };
-}
-
-export class TailBuffer {
-	readonly #maxBytes: number;
-	#text = "";
-	#bytes = 0;
-
-	constructor(maxBytes: number) {
-		this.#maxBytes = Math.max(0, Math.floor(maxBytes));
-	}
-
-	append(text: string): void {
-		if (text.length === 0) return;
-		if (this.#maxBytes === 0) {
-			this.#text = "";
-			this.#bytes = 0;
-			return;
-		}
-		const incomingBytes = Buffer.byteLength(text, "utf8");
-		const next =
-			incomingBytes >= this.#maxBytes
-				? truncateTailBytes(text, this.#maxBytes)
-				: truncateTailBytes(this.#text + text, this.#maxBytes);
-		this.#text = next.text;
-		this.#bytes = next.bytes;
-	}
-
-	text(): string {
-		return this.#text;
-	}
-
-	bytes(): number {
-		return this.#bytes;
-	}
 }
 
 export class OutputSink {
@@ -146,8 +89,10 @@ export class OutputSink {
 		this.#totalBytes += rawBytes;
 		this.#totalNewlines += countNewlines(chunk);
 		this.#sawData = true;
-		this.#mirrorRaw(chunk);
-		this.#retain(this.#maxColumns > 0 ? this.#clampColumns(chunk) : chunk);
+		const retained = this.#maxColumns > 0 ? this.#clampColumns(chunk) : chunk;
+		const columnCapDropped = Buffer.byteLength(retained, "utf8") < rawBytes;
+		this.#mirrorRaw(chunk, columnCapDropped);
+		this.#retain(retained);
 	}
 
 	dump(notice?: string): Promise<OutputSummary> {
@@ -167,13 +112,13 @@ export class OutputSink {
 		this.#pendingChunk += chunk;
 	}
 
-	#mirrorRaw(chunk: string): void {
+	#mirrorRaw(chunk: string, columnCapDropped: boolean): void {
 		if (this.#artifactPath === undefined) return;
 		if (this.#file !== undefined) {
 			this.#file.write(chunk);
 			return;
 		}
-		if (this.#totalBytes <= this.#spillThreshold) {
+		if (!columnCapDropped && this.#totalBytes <= this.#spillThreshold) {
 			this.#beforeSpill += chunk;
 			return;
 		}

--- a/packages/senpi-codemode/src/prompt/eval-prompt-template.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt-template.ts
@@ -1,7 +1,7 @@
 export const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls{{#if spawns}}, tool calls and \`task\` subagents{{else}} and tool calls{{/if}}: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls{{#if spawns}}, tool calls and \`task\` subagents{{else}} and tool calls{{/if}}: define helpers and clients once and reuse them instead of re-importing or re-reading. For large text, use bounded chunks or write it to a file and read it with offsets; treat truncation notices as incomplete data and follow the full-output path. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 {{#if styleClaude}}<eval_first_batching>
 Batch a step's independent calls in one cell with \`parallel(thunks)\`; write real code around them - loops, branches, joins, a try/except per risky item - and keep every failed or missing item in the result verbatim; re-read truncated output before deciding.

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -5,7 +5,7 @@ exports[`buildEvalPrompt > renders the all with spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls, tool calls and \`task\` subagents: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls, tool calls and \`task\` subagents: define helpers and clients once and reuse them instead of re-importing or re-reading. For large text, use bounded chunks or write it to a file and read it with offsets; treat truncation notices as incomplete data and follow the full-output path. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 Batch a step's independent calls in one cell with \`parallel(thunks)\`.
 - Write real code around the calls - loops, branches, joins, a try/except per risky item - and keep every failed or missing item in the result verbatim; re-read truncated output before deciding.
@@ -71,7 +71,7 @@ exports[`buildEvalPrompt > renders the js without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. For large text, use bounded chunks or write it to a file and read it with offsets; treat truncation notices as incomplete data and follow the full-output path. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 Batch a step's independent calls in one cell with \`parallel(thunks)\`.
 - Write real code around the calls - loops, branches, joins, a try/except per risky item - and keep every failed or missing item in the result verbatim; re-read truncated output before deciding.
@@ -127,7 +127,7 @@ exports[`buildEvalPrompt > renders the js-py without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. For large text, use bounded chunks or write it to a file and read it with offsets; treat truncation notices as incomplete data and follow the full-output path. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 Batch a step's independent calls in one cell with \`parallel(thunks)\`.
 - Write real code around the calls - loops, branches, joins, a try/except per risky item - and keep every failed or missing item in the result verbatim; re-read truncated output before deciding.

--- a/packages/senpi-codemode/test/output/streaming-output.test.ts
+++ b/packages/senpi-codemode/test/output/streaming-output.test.ts
@@ -98,6 +98,54 @@ describe("OutputSink", () => {
 		expect(summary.totalBytes).toBe(Buffer.byteLength("abcdefgh\nnext", "utf8"));
 	});
 
+	it("mirrors raw output when a column cap truncates before spill", async () => {
+		// Given
+		const dir = await createTempDir();
+		const artifactPath = join(dir, "column-cap.log");
+		const input = `${"x".repeat(50)}\n`;
+		const sink = new OutputSink({
+			artifactPath,
+			spillThreshold: 50 * 1024,
+			maxColumns: 8,
+		});
+
+		// When
+		sink.push(input);
+		const summary = await sink.dump();
+
+		// Then
+		expect(summary.output).toBe("xxxxxxxx…\n");
+		expect(summary.truncated).toBe(true);
+		expect(summary.columnTruncatedLines).toBe(1);
+		expect(summary.columnDroppedBytes).toBe(42);
+		expect(summary.artifactId).toBe(artifactPath);
+		expect(await readFile(artifactPath, "utf8")).toBe(input);
+	});
+
+	it("preserves split UTF-8 output in the column-cap artifact", async () => {
+		// Given
+		const dir = await createTempDir();
+		const artifactPath = join(dir, "column-cap-utf8.log");
+		const input = `${"가".repeat(20)}\n`;
+		const sink = new OutputSink({
+			artifactPath,
+			spillThreshold: 50 * 1024,
+			maxColumns: 8,
+		});
+
+		// When
+		sink.push(input.slice(0, 7));
+		sink.push(input.slice(7));
+		const summary = await sink.dump();
+
+		// Then
+		expect(summary.truncated).toBe(true);
+		expect(summary.columnTruncatedLines).toBe(1);
+		expect(summary.columnDroppedBytes).toBeGreaterThan(0);
+		expect(summary.output).not.toContain("\ufffd");
+		expect(await readFile(artifactPath, "utf8")).toBe(input);
+	});
+
 	it("flushes throttled chunks without dropping preview data", async () => {
 		// Given
 		vi.spyOn(Date, "now").mockReturnValue(100_000);

--- a/packages/senpi-codemode/test/output/streaming-output.test.ts
+++ b/packages/senpi-codemode/test/output/streaming-output.test.ts
@@ -146,6 +146,28 @@ describe("OutputSink", () => {
 		expect(await readFile(artifactPath, "utf8")).toBe(input);
 	});
 
+	it("mirrors a narrow column-cap loss below the ellipsis size", async () => {
+		// Given
+		const dir = await createTempDir();
+		const artifactPath = join(dir, "column-cap-narrow-gap.log");
+		const input = `${"x".repeat(770)}\n`;
+		const sink = new OutputSink({
+			artifactPath,
+			spillThreshold: 50 * 1024,
+			maxColumns: 768,
+		});
+
+		// When
+		sink.push(input);
+		const summary = await sink.dump();
+
+		// Then
+		expect(summary.truncated).toBe(true);
+		expect(summary.columnDroppedBytes).toBe(2);
+		expect(summary.artifactId).toBe(artifactPath);
+		expect(await readFile(artifactPath, "utf8")).toBe(input);
+	});
+
 	it("flushes throttled chunks without dropping preview data", async () => {
 		// Given
 		vi.spyOn(Date, "now").mockReturnValue(100_000);


### PR DESCRIPTION
## Summary
Column-capped eval output now preserves the complete raw stream in the existing artifact path even when the total output is below the normal spill threshold. The eval prompt also tells callers to use bounded chunks or offset-based file reads for large text.

## Changes
- Start the existing spill artifact whenever the per-line column cap drops bytes, including narrow losses smaller than the UTF-8 ellipsis marker.
- Keep UTF-8 and split-chunk handling on the existing OutputSink path.
- Split the byte-window and tail buffer primitives from the oversized streaming-output module.
- Document the threshold-independent artifact trigger and refresh prompt snapshots.

## QA & Evidence
- RED: local evidence under local-ignore/qa-evidence/ulw-eval-output-loss/19-red-narrow-gap.txt shows the pre-fix 770-byte / 768-byte-cap assertion failing because artifactId was undefined.
- GREEN: 20-green-narrow-gap.txt passes after switching to the sink drop-counter delta.
- Output and UTF-8 regressions: 04-column-cap-artifact.txt and 05-column-cap-utf8-split.txt show artifact recovery, complete raw output, positive dropped-byte metadata, and no replacement character.
- Focused regression: 3 files, 38 tests passed in 21-review-blocker-focused-tests.txt.
- Package regression: 115 test files passed, 809 tests passed in 10-package-tests.txt.
- Real JS QA: 08-qa-js-cell.txt and 11-rebase-qa.txt show the real JS driver exiting 0 with capped output and the direct OutputSink artifact round trip passing.
- Root validation: bun run check exited 0 and final bunx tsc --noEmit exited 0. Formatter-only changes outside this scope were removed before push.

## Risks & Residuals
The change reuses the existing artifact lifecycle and does not alter spill thresholds or inline preview limits. Evidence is local and contains no credentials or private environment data. Cubic review was skipped by the repository check workflow.

Fixes #1597