### PR TITLE
feat(auth): add the Devin CLI OAuth login flow

### DIFF
--- a/packages/ai/src/auth/oauth/devin-callback.ts
+++ b/packages/ai/src/auth/oauth/devin-callback.ts
@@ -1,0 +1,145 @@
+/**
+ * Devin CLI OAuth loopback callback.
+ *
+ * Devin registers ONE redirect URI for the CLI, so the callback binds the fixed
+ * loopback port 59653 instead of an ephemeral one: a different port is rejected
+ * by the authorize page. The server is one-shot, validates the issued state
+ * before spending the code, and renders the shared OAuth result pages.
+ */
+
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { getProviderEnvValue } from "../../utils/provider-env.ts";
+import type { OAuthCredential } from "../types.ts";
+import { exchangeDevinAuthorizationCode } from "./devin-token.ts";
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.ts";
+
+export const DEVIN_CALLBACK_PORT = 59653;
+export const DEVIN_CALLBACK_PATH = "/callback";
+
+export type DevinCallbackServer = {
+	callbackUrl: string;
+	close: () => void;
+	/** Hand the login to manual code entry unless a callback already claimed it. */
+	cancelWait: () => void;
+	waitForCredential: () => Promise<OAuthCredential | null>;
+};
+
+function callbackHost(): string {
+	return getProviderEnvValue("PI_OAUTH_CALLBACK_HOST") || "127.0.0.1";
+}
+
+function sendHtml(response: ServerResponse, status: number, html: string): void {
+	response.statusCode = status;
+	response.setHeader("content-type", "text/html; charset=utf-8");
+	response.setHeader("cache-control", "no-store");
+	response.end(html);
+}
+
+export async function startDevinCallbackServer(input: {
+	state: string;
+	verifier: string;
+	signal: AbortSignal;
+	loginTimeoutMs: number;
+}): Promise<DevinCallbackServer> {
+	if (input.signal.aborted) throw new Error("Login cancelled");
+	const host = callbackHost();
+	let resolveCredential: (credential: OAuthCredential | null) => void = () => {};
+	let rejectCredential: (error: Error) => void = () => {};
+	const credential = new Promise<OAuthCredential | null>((resolve, reject) => {
+		resolveCredential = resolve;
+		rejectCredential = reject;
+	});
+
+	let claimed = false;
+	let settled = false;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	let onAbort: (() => void) | undefined;
+
+	const close = (): void => {
+		if (timeout) clearTimeout(timeout);
+		if (onAbort) input.signal.removeEventListener("abort", onAbort);
+		server.close();
+	};
+
+	const finish = (result: { credential: OAuthCredential | null } | { error: Error }): void => {
+		if (settled) return;
+		settled = true;
+		close();
+		if ("credential" in result) resolveCredential(result.credential);
+		else rejectCredential(result.error);
+	};
+
+	const server: Server = createServer((request, response) => {
+		void (async () => {
+			const requestUrl = new URL(request.url ?? "/", `http://${host}`);
+			if (request.method !== "GET" || requestUrl.pathname !== DEVIN_CALLBACK_PATH) {
+				sendHtml(response, 404, oauthErrorHtml("OAuth callback route not found."));
+				return;
+			}
+			if (claimed || settled) {
+				sendHtml(response, 409, oauthErrorHtml("This OAuth callback has already been used."));
+				return;
+			}
+
+			const oauthError = requestUrl.searchParams.get("error");
+			if (oauthError) {
+				const description = requestUrl.searchParams.get("error_description") ?? oauthError;
+				sendHtml(response, 400, oauthErrorHtml("Devin authorization was denied.", description));
+				finish({ error: new Error(`Devin authorization failed: ${description}`) });
+				return;
+			}
+
+			// The state guard runs before the code is spent: a forged callback must
+			// never reach the token endpoint.
+			const state = requestUrl.searchParams.get("state") ?? "";
+			if (state !== input.state) {
+				sendHtml(response, 400, oauthErrorHtml("Devin authorization state mismatch."));
+				finish({ error: new Error("Devin OAuth callback state mismatch") });
+				return;
+			}
+
+			const code = requestUrl.searchParams.get("code");
+			if (!code) {
+				sendHtml(response, 400, oauthErrorHtml("Devin returned no authorization code."));
+				return;
+			}
+			claimed = true;
+
+			try {
+				const result = await exchangeDevinAuthorizationCode(code, input.verifier, input.signal);
+				sendHtml(response, 200, oauthSuccessHtml("Signed in to Devin. You may now close this page."));
+				finish({ credential: result });
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Unknown token exchange error";
+				sendHtml(response, 502, oauthErrorHtml("Devin token exchange failed.", message));
+				finish({ error: error instanceof Error ? error : new Error(message) });
+			}
+		})();
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(DEVIN_CALLBACK_PORT, host, () => {
+			server.removeListener("error", reject);
+			resolve();
+		});
+	});
+
+	server.on("error", (error) => finish({ error }));
+	onAbort = () => finish({ error: new Error("Login cancelled") });
+	input.signal.addEventListener("abort", onAbort, { once: true });
+	if (input.signal.aborted) {
+		close();
+		throw new Error("Login cancelled");
+	}
+	timeout = setTimeout(() => finish({ error: new Error("Devin OAuth login timed out") }), input.loginTimeoutMs);
+
+	return {
+		callbackUrl: `http://${host}:${DEVIN_CALLBACK_PORT}${DEVIN_CALLBACK_PATH}`,
+		close,
+		cancelWait: () => {
+			if (!claimed) finish({ credential: null });
+		},
+		waitForCredential: () => credential,
+	};
+}

--- a/packages/ai/src/auth/oauth/devin-token.ts
+++ b/packages/ai/src/auth/oauth/devin-token.ts
@@ -1,0 +1,107 @@
+/**
+ * Devin (Cognition) CLI token exchange.
+ *
+ * Devin's CLI grant is deliberately non-standard: the authorization code is
+ * redeemed with a bare JSON body carrying only the code and the PKCE verifier
+ * (no client_id, no grant_type), and the response returns ONE opaque JWT in
+ * "token" that serves as both the access and the refresh credential. Expiry is
+ * read from the JWT itself because the response carries no expires_in.
+ */
+
+import type { OAuthCredential } from "../types.ts";
+
+export const DEVIN_TOKEN_URL = "https://api.devin.ai/auth/cli/token";
+export const DEVIN_API_ENDPOINT = "https://api.devin.ai";
+
+/** Devin issues long-lived CLI tokens; used when the JWT carries no usable exp. */
+export const DEVIN_FALLBACK_EXPIRY_MS = 31_536_000_000;
+
+const TOKEN_EXCHANGE_TIMEOUT_MS = 30_000;
+
+type JsonObject = Record<string, unknown>;
+
+function decodeJwtExpiry(token: string): number | undefined {
+	const payload = token.split(".")[1];
+	if (!payload) return undefined;
+	const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+	const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+	try {
+		const parsed = JSON.parse(atob(padded)) as JsonObject;
+		const exp = parsed.exp;
+		if (typeof exp === "number" && Number.isFinite(exp) && exp > 0) return Math.trunc(exp * 1000);
+	} catch {
+		// A token whose payload is not readable JSON falls back to the fixed window.
+	}
+	return undefined;
+}
+
+function errorDetail(body: JsonObject): string | undefined {
+	if (typeof body.error_description === "string") return body.error_description;
+	if (typeof body.message === "string") return body.message;
+	if (typeof body.error === "string") return body.error;
+	if (body.error && typeof body.error === "object" && !Array.isArray(body.error)) {
+		const message = (body.error as JsonObject).message;
+		if (typeof message === "string") return message;
+	}
+	return undefined;
+}
+
+/** Builds the credential Devin's CLI stores: one token for access and refresh. */
+export function devinCredential(token: string): OAuthCredential {
+	return {
+		type: "oauth",
+		access: token,
+		refresh: token,
+		expires: decodeJwtExpiry(token) ?? Date.now() + DEVIN_FALLBACK_EXPIRY_MS,
+	};
+}
+
+export async function exchangeDevinAuthorizationCode(
+	code: string,
+	verifier: string,
+	signal: AbortSignal,
+): Promise<OAuthCredential> {
+	if (signal.aborted) throw new Error("Login cancelled");
+	const controller = new AbortController();
+	const onAbort = () => controller.abort(signal.reason);
+	signal.addEventListener("abort", onAbort, { once: true });
+	const timeout = setTimeout(
+		() => controller.abort(new Error("Devin OAuth token exchange timed out")),
+		TOKEN_EXCHANGE_TIMEOUT_MS,
+	);
+
+	let response: Response;
+	let body: JsonObject = {};
+	try {
+		response = await fetch(DEVIN_TOKEN_URL, {
+			method: "POST",
+			headers: { accept: "application/json", "content-type": "application/json" },
+			body: JSON.stringify({ code, code_verifier: verifier }),
+			signal: controller.signal,
+		});
+		try {
+			const parsed = (await response.json()) as unknown;
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed as JsonObject;
+		} catch {
+			if (response.ok) throw new Error("Devin OAuth returned invalid JSON");
+		}
+	} catch (error) {
+		if (signal.aborted) throw new Error("Login cancelled");
+		if (controller.signal.aborted) throw new Error("Devin OAuth token exchange timed out");
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+		signal.removeEventListener("abort", onAbort);
+	}
+
+	if (!response.ok) {
+		const detail = errorDetail(body);
+		throw new Error(`Devin OAuth token exchange failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}`);
+	}
+
+	if (typeof body.token !== "string" || body.token.length === 0) {
+		throw new Error('Devin OAuth response carries no "token"');
+	}
+
+	return devinCredential(body.token);
+}

--- a/packages/ai/src/auth/oauth/devin.ts
+++ b/packages/ai/src/auth/oauth/devin.ts
@@ -1,0 +1,114 @@
+/**
+ * Devin (Cognition) CLI OAuth flow.
+ *
+ * Mirrors the Devin CLI login: the authorize page at app.devin.ai redeems a
+ * PKCE S256 challenge against the fixed loopback redirect, and the resulting
+ * code is exchanged for a single long-lived CLI token. There is no refresh
+ * grant - Devin re-issues the token through a fresh login - so refresh returns
+ * the stored credential untouched.
+ *
+ * NOTE: the callback module uses node:http and is CLI-only, never browser.
+ */
+
+import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
+import { startDevinCallbackServer } from "./devin-callback.ts";
+import { DEVIN_API_ENDPOINT, exchangeDevinAuthorizationCode } from "./devin-token.ts";
+import { generatePKCE } from "./pkce.ts";
+
+const AUTHORIZE_URL = "https://app.devin.ai/auth/cli/continue";
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+function parseAuthorizationInput(input: string): string | undefined {
+	const value = input.trim();
+	if (!value) return undefined;
+	try {
+		return new URL(value).searchParams.get("code") ?? undefined;
+	} catch {
+		// not a URL
+	}
+	if (value.includes("code=")) return new URLSearchParams(value).get("code") ?? undefined;
+	return value;
+}
+
+function authorizeUrl(input: { redirectUri: string; challenge: string; state: string }): string {
+	const url = new URL(AUTHORIZE_URL);
+	url.search = new URLSearchParams({
+		response_type: "code",
+		redirect_uri: input.redirectUri,
+		code_challenge: input.challenge,
+		code_challenge_method: "S256",
+		state: input.state,
+		prompt: "select_account",
+	}).toString();
+	return url.toString();
+}
+
+async function loginDevin(interaction: ProviderAuthInteraction): Promise<OAuthCredential> {
+	const { verifier, challenge } = await generatePKCE();
+	const state = crypto.randomUUID();
+	const callback = await startDevinCallbackServer({
+		state,
+		verifier,
+		signal: interaction.signal,
+		loginTimeoutMs: LOGIN_TIMEOUT_MS,
+	});
+	const manualAbort = new AbortController();
+	let manualInput: string | undefined;
+	let manualError: Error | undefined;
+
+	try {
+		interaction.notify({
+			type: "progress",
+			message: `Listening for the Devin OAuth callback on ${callback.callbackUrl}`,
+		});
+		interaction.notify({
+			type: "auth_url",
+			url: authorizeUrl({ redirectUri: callback.callbackUrl, challenge, state }),
+			instructions:
+				"Sign in to Devin in your browser. If the browser is on another machine, paste the final redirect URL here.",
+		});
+
+		const manualPromise = interaction
+			.prompt({
+				type: "manual_code",
+				message: "Complete sign-in in your browser, or paste the authorization code / redirect URL here:",
+				placeholder: callback.callbackUrl,
+				signal: manualAbort.signal,
+			})
+			.then((input) => {
+				manualInput = input;
+				callback.cancelWait();
+			})
+			.catch((error) => {
+				manualError = error instanceof Error ? error : new Error(String(error));
+				callback.cancelWait();
+			});
+
+		const credential = await callback.waitForCredential();
+		if (manualError) throw manualError;
+		if (credential) return credential;
+
+		await manualPromise;
+		if (manualError) throw manualError;
+		const code = manualInput ? parseAuthorizationInput(manualInput) : undefined;
+		if (!code) throw new Error("Missing authorization code");
+		interaction.notify({ type: "progress", message: "Exchanging the authorization code for a Devin token..." });
+		return await exchangeDevinAuthorizationCode(code, verifier, interaction.signal);
+	} finally {
+		manualAbort.abort();
+		callback.close();
+	}
+}
+
+export const devinOAuth: OAuthAuth = {
+	name: "Devin",
+	isSubscription: true,
+	loginLabel: "Sign in with Devin",
+	login: loginDevin,
+	async refresh(credential, _signal) {
+		return credential;
+	},
+	async toAuth(credential) {
+		return { apiKey: credential.access, baseUrl: DEVIN_API_ENDPOINT };
+	},
+};

--- a/packages/ai/src/auth/oauth/load.ts
+++ b/packages/ai/src/auth/oauth/load.ts
@@ -19,6 +19,7 @@ type OAuthFlowLoaders = {
 	kimiCoding: () => OAuthAuth | Promise<OAuthAuth>;
 	xai: () => OAuthAuth | Promise<OAuthAuth>;
 	cursor: () => OAuthAuth | Promise<OAuthAuth>;
+	devin: () => OAuthAuth | Promise<OAuthAuth>;
 	radius: (options: { name: string; gateway: string }) => OAuthAuth | Promise<OAuthAuth>;
 };
 
@@ -62,6 +63,11 @@ export const loadXaiOAuth = async (): Promise<OAuthAuth> => {
 export const loadCursorOAuth = async (): Promise<OAuthAuth> => {
 	if (bundledLoaders) return bundledLoaders.cursor();
 	return ((await importOAuthModule("./cursor.ts")) as { cursorOAuth: OAuthAuth }).cursorOAuth;
+};
+
+export const loadDevinOAuth = async (): Promise<OAuthAuth> => {
+	if (bundledLoaders) return bundledLoaders.devin();
+	return ((await importOAuthModule("./devin.ts")) as { devinOAuth: OAuthAuth }).devinOAuth;
 };
 
 export const loadRadiusOAuth = async (options: { name: string; gateway: string }): Promise<OAuthAuth> => {

--- a/packages/ai/src/bun-oauth.ts
+++ b/packages/ai/src/bun-oauth.ts
@@ -1,5 +1,6 @@
 import { anthropicOAuth } from "./auth/oauth/anthropic.ts";
 import { cursorOAuth } from "./auth/oauth/cursor.ts";
+import { devinOAuth } from "./auth/oauth/devin.ts";
 import { githubCopilotOAuth } from "./auth/oauth/github-copilot.ts";
 import { kimiCodingOAuth } from "./auth/oauth/kimi-coding.ts";
 import { registerBundledOAuthFlowLoaders } from "./auth/oauth/load.ts";
@@ -18,6 +19,7 @@ export function registerBunOAuthFlows(): void {
 		kimiCoding: () => kimiCodingOAuth,
 		xai: () => xaiOAuth,
 		cursor: () => cursorOAuth,
+		devin: () => devinOAuth,
 		radius: createRadiusOAuth,
 	});
 }

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,28 @@
+## Devin CLI OAuth login flow (2026-09-11)
+
+### What changed
+
+- `packages/ai/src/auth/oauth/devin.ts`: new Devin (Cognition) OAuth flow. Generates a PKCE S256 challenge plus a uuid state, sends the user to `https://app.devin.ai/auth/cli/continue` with `response_type=code`, the loopback `redirect_uri` and `prompt=select_account`, and races the loopback callback against the manual paste prompt for headless sessions. Exports `devinOAuth` whose `refresh` is a no-op (Devin has no refresh grant) and whose `toAuth` returns the stored token plus the `https://api.devin.ai` base URL.
+- `packages/ai/src/auth/oauth/devin-callback.ts`: one-shot loopback callback server pinned to `127.0.0.1:59653/callback`, the single redirect URI Devin registers for the CLI. Validates the issued state before the authorization code is spent, renders the shared OAuth result pages, and reports exchange failures through both the page and the login promise.
+- `packages/ai/src/auth/oauth/devin-token.ts`: the non-standard CLI token exchange. Posts JSON carrying only `code` and `code_verifier` (no client_id, no grant_type) with `Accept: application/json`, then builds the credential from the single `token` field used as both access and refresh, with expiry decoded from the JWT `exp` and a 31536000000 ms fallback.
+- `packages/ai/src/auth/oauth/load.ts`: adds `devin` to `OAuthFlowLoaders` and exports `loadDevinOAuth`, so the flow resolves through the same lazy-import boundary as every other provider and stays out of browser-reachable static imports.
+- `packages/ai/src/bun-oauth.ts`: registers `devin: () => devinOAuth` in the statically bundled flow set so the standalone Bun binary can run the login without dynamic import.
+
+### Why
+
+- senpi had no Devin authentication at all: no flow module, no loader entry, no bundled registration, so Devin could not be signed into from senpi even though its CLI grant is a plain public-client authorization-code flow.
+- Devin's grant deviates from the OAuth defaults the existing helpers assume (fixed redirect port, no client_id, no grant_type, one token serving as access and refresh, expiry only inside the JWT), so the deviations are pinned in code next to the reasons rather than rediscovered per incident.
+
+### Why an extension could not handle it
+
+- OAuth flows are resolved inside `packages/ai` through `registerBundledOAuthFlowLoaders` and the `OAuthFlowLoaders` type; an extension cannot add a member to that registry, cannot participate in the standalone Bun binary's static bundle, and cannot return an `OAuthAuth` that the credential store and auth resolution treat as first-class.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/auth/oauth/load.ts`: the `OAuthFlowLoaders` member list and the block of `load*OAuth` exports — upstream adding a provider touches the same two spots.
+- `packages/ai/src/bun-oauth.ts`: the import list and the `registerBundledOAuthFlowLoaders` object literal.
+- The three `packages/ai/src/auth/oauth/devin*.ts` files are additions with no upstream counterpart and should not conflict.
+
 ## PR #1304 review fixes: shared auth-miss prefix, login merge, sentinel repair (2026-09-10)
 
 ### What changed

--- a/packages/ai/test/devin-oauth.test.ts
+++ b/packages/ai/test/devin-oauth.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { devinOAuth } from "../src/auth/oauth/devin.ts";
+import { loadDevinOAuth, loadOpenRouterOAuth } from "../src/auth/oauth/load.ts";
+import type { ProviderAuthInteraction } from "../src/auth/types.ts";
+
+const TOKEN_URL = "https://api.devin.ai/auth/cli/token";
+const CALLBACK_URL = "http://127.0.0.1:59653/callback";
+const FALLBACK_EXPIRY_MS = 31_536_000_000;
+const nativeFetch = globalThis.fetch;
+const neverAbortedSignal = new AbortController().signal;
+
+function base64url(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+/** Minimal unsigned JWT: only the payload is read by the expiry parser. */
+function jwt(payload: Record<string, unknown>): string {
+	const encode = (value: unknown) => base64url(new TextEncoder().encode(JSON.stringify(value)));
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+type LoginDrive = {
+	authorizeUrl: URL | undefined;
+	callbackResponse: Promise<Response> | undefined;
+	exchangeInit: RequestInit | undefined;
+};
+
+/**
+ * Drives the real login: waits for the auth_url notification, then calls the
+ * loopback callback the flow is listening on, exactly as a browser would.
+ */
+function driveLogin(
+	token: unknown,
+	options: { status?: number; state?: (issued: string) => string; raw?: string } = {},
+): { drive: LoginDrive; interaction: ProviderAuthInteraction } {
+	const drive: LoginDrive = { authorizeUrl: undefined, callbackResponse: undefined, exchangeInit: undefined };
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = input instanceof Request ? input.url : String(input);
+		if (url !== TOKEN_URL) return nativeFetch(input, init);
+		drive.exchangeInit = init;
+		if (options.raw !== undefined) return new Response(options.raw, { status: options.status ?? 200 });
+		return jsonResponse(token, options.status ?? 200);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+
+	const interaction: ProviderAuthInteraction = {
+		signal: neverAbortedSignal,
+		prompt: () => new Promise<string>(() => {}),
+		notify: (event) => {
+			if (event.type !== "auth_url") return;
+			drive.authorizeUrl = new URL(event.url);
+			const redirect = new URL(drive.authorizeUrl.searchParams.get("redirect_uri") ?? "");
+			redirect.searchParams.set("code", "authorization-code");
+			const issued = drive.authorizeUrl.searchParams.get("state") ?? "";
+			redirect.searchParams.set("state", options.state ? options.state(issued) : issued);
+			drive.callbackResponse = nativeFetch(redirect);
+		},
+	};
+	return { drive, interaction };
+}
+
+describe.sequential("Devin OAuth", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+	});
+
+	it("is registered in the OAuth loader registry beside the existing flows", async () => {
+		await expect(loadDevinOAuth()).resolves.toBe(devinOAuth);
+		await expect(loadOpenRouterOAuth()).resolves.toMatchObject({ name: "OpenRouter OAuth" });
+		expect(devinOAuth.name).toBe("Devin");
+		expect(devinOAuth.loginLabel).toBe("Sign in with Devin");
+	});
+
+	it("exchanges the callback code for the Devin token and derives expiry from the JWT", async () => {
+		const exp = Math.floor(Date.now() / 1000) + 3_600;
+		const token = jwt({ exp });
+		const { drive, interaction } = driveLogin({ token });
+
+		const credential = await devinOAuth.login(interaction);
+
+		expect(credential).toEqual({ type: "oauth", access: token, refresh: token, expires: exp * 1000 });
+		expect((await drive.callbackResponse)?.status).toBe(200);
+		expect(drive.exchangeInit?.method).toBe("POST");
+		expect(new Headers(drive.exchangeInit?.headers).get("accept")).toBe("application/json");
+		const body = JSON.parse(String(drive.exchangeInit?.body)) as Record<string, unknown>;
+		expect(Object.keys(body).sort()).toEqual(["code", "code_verifier"]);
+		expect(body.code).toBe("authorization-code");
+	});
+
+	it("builds the CLI authorize URL with PKCE S256, a uuid state and the loopback redirect", async () => {
+		const token = jwt({ exp: Math.floor(Date.now() / 1000) + 60 });
+		const { drive, interaction } = driveLogin({ token });
+
+		await devinOAuth.login(interaction);
+
+		expect(drive.authorizeUrl?.origin).toBe("https://app.devin.ai");
+		expect(drive.authorizeUrl?.pathname).toBe("/auth/cli/continue");
+		expect(drive.authorizeUrl?.searchParams.get("response_type")).toBe("code");
+		expect(drive.authorizeUrl?.searchParams.get("redirect_uri")).toBe(CALLBACK_URL);
+		expect(drive.authorizeUrl?.searchParams.get("prompt")).toBe("select_account");
+		expect(drive.authorizeUrl?.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(drive.authorizeUrl?.searchParams.get("state")).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+		);
+		expect(drive.authorizeUrl?.searchParams.has("client_id")).toBe(false);
+
+		const body = JSON.parse(String(drive.exchangeInit?.body)) as Record<string, unknown>;
+		const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(String(body.code_verifier)));
+		expect(drive.authorizeUrl?.searchParams.get("code_challenge")).toBe(base64url(new Uint8Array(digest)));
+	});
+
+	it("falls back to the one-year expiry when the token carries no usable exp", async () => {
+		const token = jwt({ sub: "user" });
+		const { interaction } = driveLogin({ token });
+		const before = Date.now();
+
+		const credential = await devinOAuth.login(interaction);
+
+		expect(credential.expires).toBeGreaterThanOrEqual(before + FALLBACK_EXPIRY_MS);
+		expect(credential.expires).toBeLessThanOrEqual(Date.now() + FALLBACK_EXPIRY_MS);
+	});
+
+	it("rejects a callback whose state does not match the issued state", async () => {
+		const { drive, interaction } = driveLogin({ token: jwt({ exp: 1 }) }, { state: () => "forged-state" });
+
+		await expect(devinOAuth.login(interaction)).rejects.toThrow(/state/i);
+		expect((await drive.callbackResponse)?.status).toBe(400);
+	});
+
+	it("surfaces a failed token exchange instead of storing a broken credential", async () => {
+		const { drive, interaction } = driveLogin({ error: "invalid_grant" }, { status: 403 });
+
+		await expect(devinOAuth.login(interaction)).rejects.toThrow(/403/);
+		expect((await drive.callbackResponse)?.status).toBe(502);
+	});
+
+	it("rejects a token response that is not usable JSON", async () => {
+		const { interaction } = driveLogin(undefined, { raw: "<html>gateway</html>" });
+
+		await expect(devinOAuth.login(interaction)).rejects.toThrow(/JSON|token/i);
+	});
+
+	it("rejects a 200 response that carries no token", async () => {
+		const { interaction } = driveLogin({ ok: true });
+
+		await expect(devinOAuth.login(interaction)).rejects.toThrow(/token/i);
+	});
+
+	it("has no refresh grant and authenticates requests against the Devin API endpoint", async () => {
+		const credential = { type: "oauth", access: "devin-token", refresh: "devin-token", expires: 42 } as const;
+
+		await expect(devinOAuth.refresh(credential, neverAbortedSignal)).resolves.toBe(credential);
+		await expect(devinOAuth.toAuth(credential)).resolves.toEqual({
+			apiKey: "devin-token",
+			baseUrl: "https://api.devin.ai",
+		});
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added Devin (Cognition) OAuth login: sign in through Devin's CLI authorization flow (PKCE S256, loopback callback on `127.0.0.1:59653`, state validated before the code is spent) and senpi stores the issued CLI token with its JWT-derived expiry (fixes #1601).
+
 - Branded builds can provide an absolute changelog path and authored version, with source-isolated seen-version tracking and interactive changelog rendering; engine changelog notifications retain their existing link rewriting and install telemetry behavior (fixes #1583).
 
 - Added the `deepseek-v4-1-flash` prompt preset for DeepSeek V4.1 Flash: it resolves every published id shape (`deepseek-flash`, `deepseek-v4.1-flash`, `deepseek/deepseek-v4.1-flash`, `deepseek-ai/DeepSeek-V4.1-Flash`, fireworks' `deepseek-v4p1-flash`, venice's `deepseek-v4-1-flash`) and the official DeepSeek provider's retired `deepseek-v4-flash` / `deepseek-v4-flash-vision-exp` aliases, which the DeepSeek API now serves with V4.1 Flash; the same alias on any other provider keeps the V4 Flash preset. The preset carries the shared core and the eval-routing stance only - none of the V4 Flash repair rules, which were written against V4-Flash-0731 transcripts and do not apply to the re-trained model ([#1574](https://github.com/code-yeongyu/senpi/issues/1574))


### PR DESCRIPTION
## Summary
Adds the Devin (Cognition) CLI OAuth login flow to senpi. Until now there was no way to sign in to Devin from senpi at all: the OAuth framework shipped flows for Anthropic, Cursor, Copilot, Kimi, Codex, OpenRouter, Radius and xAI, but no Devin flow, no loader entry and no bundled registration. The flow follows Devin's published CLI contract exactly.

## Changes
- `auth/oauth/devin.ts`: login orchestration — PKCE S256 + uuid state, authorize at app.devin.ai/auth/cli/continue with prompt=select_account, loopback redirect, and the manual paste fallback for headless/remote sessions.
- `auth/oauth/devin-callback.ts`: one-shot loopback callback on the fixed port 127.0.0.1:59653/callback (Devin registers one redirect URI, so an ephemeral port is rejected). The issued state is validated before the code is ever spent.
- `auth/oauth/devin-token.ts`: the non-standard token exchange — JSON body carrying only `code` and `code_verifier` (no client_id, no grant_type), `Accept: application/json`, the single `token` used as both access and refresh, and expiry read from the JWT `exp` with a one-year fallback.
- Registered in the OAuth loader registry (`auth/oauth/load.ts`) and in the statically bundled Bun flows (`bun-oauth.ts`).
- `test/devin-oauth.test.ts`: 9 offline regression tests.

## QA & Evidence
- **RED first:** `vitest test/devin-oauth.test.ts` failed with `Cannot find module '../src/auth/oauth/devin.ts'` before any production file existed.
- **GREEN:** 9/9 pass.
- **Mutation proof (the tests can actually fail):** disabling the state guard fails only "rejects a callback whose state does not match the issued state"; ignoring the JWT exp fails only "derives expiry from the JWT"; reverting both restores 9/9.
- **Regression:** 12 auth/OAuth suites, 111 tests pass — the loader registry still resolves every pre-existing flow.
- **Typecheck:** `tsgo -p packages/ai/tsconfig.build.json --noEmit` exits 0; the pre-commit gate (biome, repo-wide `tsc --noEmit`, browser smoke) passed.
- **Real-surface drive:** a throwaway script ran the real `devinOAuth.login()` against a local stub token endpoint with the genuine loopback callback bound on 59653 and a real browser-style GET to the redirect URI. Observed: callback page HTTP 200, `POST /auth/cli/token` with `accept=application/json` and body keys `code,code_verifier`, credential `type=oauth` with refresh == access, expiry equal to the JWT exp, credential-store round trip listing `devin:oauth`, `toAuth` returning baseUrl https://api.devin.ai, and refresh returning the stored credential unchanged. No real Devin endpoint and no real credential were used; the stub server was closed and port 59653 verified free afterwards.

## Scope
Auth only. The Devin Cascade model transport/provider is a separate feature and is deliberately not part of this PR, so no provider catalog entry is added here.

## Related Issues
Fixes #1601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Devin (Cognition) CLI OAuth login flow so users can sign in to Devin from senpi, which previously had no Devin flow at all. Fixes #1601.

**Devin flow**
- Authorizes at `app.devin.ai/auth/cli/continue` with PKCE S256 and a uuid state.
- Binds the one-shot loopback callback to the fixed port `127.0.0.1:59653/callback` since Devin registers a single redirect URI, with a manual paste fallback for headless sessions.
- Sends the token exchange as a JSON body with only `code` and `code_verifier` (no `client_id` or `grant_type`) and reuses the single returned JWT for both access and refresh.
- Reads expiry from the JWT `exp` with a one-year fallback; `refresh()` returns the stored credential unchanged.
- Registers in the OAuth loader registry and Bun bundled flows with 9 offline regression tests; the Devin Cascade model transport is intentionally out of scope.
- Records the flow in the `packages/ai` changes tracker and the `coding-agent` changelog.

<sup>Written for commit ac860dfc4a951f96cd50930900335bd2417c8040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

