### PR TITLE
docs(changelog): complete the unreleased changelog for the next release

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 
 - Pooled OAuth credential slots now retain optional human-readable display names while preserving immutable slot identities for selection, affinity, refresh, and failover.
+- Added the Devin (Cognition) Cascade transport: `devin-agent` Connect/protobuf streaming is mapped natively onto the shared stream contract, so text, thinking, tool calls, usage and stop reasons arrive as ordinary events, a failed or content-filtered stop is surfaced as an error instead of a silent end, and a truncated turn keeps the `length` stop reason. Model discovery is authenticated with the stored credential and falls back to the bundled SWE seed when the discovery endpoint is unavailable, so an offline or rate-limited discovery never empties the model list ([#1604](https://github.com/code-yeongyu/senpi/issues/1604)).
+- Added Devin (Cognition) CLI OAuth: the authorization flow is PKCE S256 with a loopback callback on `127.0.0.1:59653` and the state validated before the code is spent, and the issued CLI token is stored with the expiry derived from its own JWT rather than an assumed lifetime ([#1601](https://github.com/code-yeongyu/senpi/issues/1601)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Changed
 
-- `update_goal` with status `blocked` is now rejected while a live resumption channel (monitor, background session, detached eval cell, child task, or pending question) can still deliver, and again until the same blocker has survived three goal turns since the goal became active or the user last spoke; the goal continuation prompt states both rules, declares retries unbounded, and requires the completion audit to match verification scope to requirement scope. `create_goal` now carries a decision rule for work that outlives the turn instead of "only when explicitly requested".
+- The goal continuation prompt and the `update_goal` tool description now spell out when a goal may be marked blocked: never while a live resumption channel (monitor, background session, detached eval cell, child task, or pending question) can still deliver, and not until the same blocker has survived three goal turns since the goal became active or the user last spoke. Both surfaces declare retries unbounded and require the completion audit to match verification scope to requirement scope, and `create_goal` now carries a decision rule for work that outlives the turn instead of "only when explicitly requested". The transition itself stays model-controlled: `update_goal` enforces only that a `blocked` call carries a reason, so a model that judges the audit passed is never mechanically refused.
 - The GPT-6 Astra preset drops its three-attempt failure cap for an unbounded-retry rule that widens the source on an empty lookup, ends a turn only when a pending handle will wake the session, requires a named next step to be taken in the same turn, and defaults its question tool to the non-blocking mode.
 
 ### Fixed
@@ -37,6 +37,10 @@
 - A provider-owned login pool is merged onto the stored pool at commit time instead of overwriting it with the pre-browser-flow snapshot, so a sibling account's rotated refresh token and rate-limit block survive another account's interactive login.
 - The Claude SDK lane's session-lock and bare `invalid_request` remint, and its `Provider is not configured:` fallback exclusion, are scoped to that provider: provider-agnostic stream stalls keep consuming the shared same-model retry budget and still escalate to the configured fallback chain, and another provider's auth miss or `invalid_request` still hops the chain.
 - OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted, and an interleaved waiting or info step replaces (never duplicates) the live `(to cancel)`/`(to close)` hint row.
+- A Windows RPC reuse probe registers its socket error listener before it writes the named-pipe handshake, so a pipe an idle host removed while the probe was in flight is observed as "no existing host" and the caller starts a fresh one, instead of the `ENOENT` escaping the probe and failing the session start ([#1593](https://github.com/code-yeongyu/senpi/pull/1593)).
+- A terminal provider policy rejection now blocks the active goal instead of queuing automatic recoveries that cannot succeed, and the unstructured Codex diagnostic (`This request was blocked by our safety systems`) is trusted only when the message carries the Codex responses api id, so a provider-agnostic "Provider is not configured" style refusal from another provider or gateway keeps its ordinary provider and system recovery; the api id is pinned against the shipped model catalog so renaming it there cannot silently disarm the guard ([#1520](https://github.com/code-yeongyu/senpi/issues/1520) by [@rlaope](https://github.com/rlaope)).
+- A persisted Claude SDK binding whose prompt or toolset drifted after a stream-start timeout now forks the stored session at its last assistant UUID instead of flattening megabytes of transcript into a fresh request, and the timeout and a bare `invalid_request` remint the same model instead of hard-hopping onto an unauthenticated gateway route ([#1304](https://github.com/code-yeongyu/senpi/pull/1304) by [@eddieparc](https://github.com/eddieparc)).
+- Auth and cached provider-settings reload detection now uses file content revisions instead of filesystem mtimes, so two rewrites inside one filesystem timestamp tick are still observed and the session picks up the newer credentials deterministically.
 
 ### Removed
 
@@ -49,10 +53,6 @@
 ### Changed
 
 ### Fixed
-
-- Auth and cached provider-settings reload detection now uses file content revisions instead of filesystem mtimes, so rapid same-tick rewrites are observed deterministically.
-
-- A provider-agnostic "Provider is not configured" style refusal no longer ends a goal as a Codex policy rejection. The gate now requires the Codex responses api id, so another provider or gateway emitting the same sentence keeps provider and system recovery instead of blocking the goal; the api id is pinned against the shipped model catalog so renaming it there cannot silently disarm the guard ([#1520](https://github.com/code-yeongyu/senpi/issues/1520))
 
 - A bare `.` submitted on a session that already has messages no longer renders as a user message in the TUI. It stays the manual-continue shortcut the session delivers as a hidden continuation, so nothing is painted for it while idle or while steering an active turn; a `.` on an empty session and a `.` carrying image attachments remain ordinary user input ([#1569](https://github.com/code-yeongyu/senpi/issues/1569))
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Changed
 
+- The eval tool instructions now tell callers to emit large text in bounded chunks or through offset-based file reads, and to treat a truncation notice as incomplete data that must be recovered from the full-output path instead of being read as the whole result ([#1600](https://github.com/code-yeongyu/senpi/pull/1600)).
+
 ### Fixed
 
-- Column-capped eval output now preserves a recoverable full-output artifact ([#1597](https://github.com/code-yeongyu/senpi/issues/1597)).
+- Column-capped eval output now preserves a recoverable full-output artifact, so a cell whose output is clipped by a narrow terminal column cap still exposes the complete text through the artifact path ([#1600](https://github.com/code-yeongyu/senpi/pull/1600)).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

The senpi `[Unreleased]` changelog did not match what is actually on `main`, so the next release would have shipped an inaccurate and incomplete changelog. This PR fixes it before the release is cut.

Measured against `git diff v2026.9.10-2..main` (99 commits, 19 merged PRs):

1. **One entry described reverted behavior.** The `update_goal` entry claimed the tool now *rejects* `blocked` while a live resumption channel can deliver. Commit `038d39437` ("restore model-controlled blocked transitions") deleted `blocked-audit.ts`, its 230-line test, and the enforcement in `tool-registration.ts`; what shipped is guidance in the continuation prompt and the tool description, with the transition left to the model. Rewritten to say that.
2. **Two post-tag fixes were filed under the already published `[2026.9.10-2]` section.** `git show v2026.9.10-2:packages/coding-agent/CHANGELOG.md` does not contain either entry, so both landed after the tag and would never have appeared in a release. Moved into `[Unreleased]`. (All ten other package changelogs are byte-identical to the tag in that section.)
3. **Four shipped behavior changes had no entry at all:**
   - the vanished Windows named-pipe reuse probe (#1593)
   - the terminal provider policy rejection gate (#1520, PR #1521)
   - the Claude SDK fork-on-drift + same-model remint fix (#1304)
   - the Devin Cascade transport (#1604) and Devin CLI OAuth (#1601) in `packages/ai`, where the code lives (only `packages/coding-agent` had them)
4. **One wrong citation.** The column-capped eval output entry cited #1597; the change is #1600. Corrected, and the chunked-output instruction change that shipped with it is now recorded.

## Verification

- `git show v2026.9.10-2:packages/<pkg>/CHANGELOG.md` vs `origin/main` for all 11 packages: only `coding-agent` differs in the released section, by exactly the two moved entries.
- Every citation checked against `GET /repos/code-yeongyu/senpi/commits/<sha>/pulls`: `990c88cde` -> #1593, `fd91edd36` -> #1304, `348a68933` -> #1521.
- Behavior claims checked in the tree, not in commit subjects: `session-stream.ts` / `session-registry.ts` fork at `lastAssistantUuid`, `host-ensure.ts` registers the error listener before the handshake, `blocked-audit.ts` is absent.
- Changelog-only PR: no runtime source changed, so the changelog gate's tracker audit has nothing to cover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `[Unreleased]` changelog for the next release so it matches what actually shipped on `main`; the prior version described reverted behavior, filed post-tag fixes under the already published release, and missed four shipped changes.

- Rewrote the `update_goal` blocked entry to reflect the reverted enforcement; the rule now lives in the continuation prompt and tool description while the transition stays model-controlled.
- Moved two post-tag fixes from the published `[2026.9.10-2]` section into `[Unreleased]`.
- Added entries for the Windows named-pipe reuse probe, the terminal provider policy rejection gate, the Claude SDK fork-on-drift fix, and the Devin Cascade transport and CLI OAuth.
- Corrected the eval output citation from #1597 to #1600 and recorded the chunked-output instruction change that shipped with it.

<sup>Written for commit 8dd1a32927bc4302dbaced71f6c620be9452b700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

