### PR TITLE
docs(tui): describe dollar hints on any logical line

### DIFF
--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -57,8 +57,8 @@ native/                     Optional Darwin/Win32 modifier binaries (prebuilt, l
 
 ## $-INVOCATION
 
-- A leading `$` on prompt line 0 offers the same candidate list as `/`: slash commands insert as `/name`, skills as bare `$name`.
-- After one known skill, only further skills are offered. Mid-line `$` (e.g. `$HOME`) stays literal.
+- A `$` token at a valid boundary on any logical prompt line — the first line, a line after `shift+enter`, or a line from a multiline paste — offers the same candidate list as `/`: slash commands insert as `/name`, skills as bare `$name`.
+- After one known skill, only further skills are offered on that line. A `$` that is not at a token boundary, and shell-style expansions such as `$HOME` or `$1`, stay literal.
 - Completion application must preserve trailing-space behavior for both `/command ` and `$skill ` forms.
 
 ## ANTI-PATTERNS


### PR DESCRIPTION
## Summary

`packages/tui/AGENTS.md` still described the `$` skill-invocation surface as line-0 only. The cursor-line gate was removed when multiline dollar hints landed, so the guide contradicted both the shipped behavior and the tests that pin it.

## Change

Documentation only — two bullets in the `$-INVOCATION` section:

- a `$` token at a valid boundary on any logical prompt line (first line, after `shift+enter`, or a line from a multiline paste) offers the same candidate list as `/`;
- skill chaining is per line, and tokens that are not at a boundary — including `$HOME` and `$1` — stay literal.

No source, test, or behavior change.

## Verification

- `git diff` touches `packages/tui/AGENTS.md` only (2 insertions, 2 deletions).
- Behavior described here is pinned by `packages/tui/test/autocomplete-dollar.test.ts` and `packages/tui/test/editor-dollar-autocomplete.test.ts` (later logical line, multiline paste, shell-variable rejection, chaining).
- Real source TUI evidence for the multiline/streaming case is recorded on #1590.

Fixes #1606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `packages/tui/AGENTS.md` so the `$-INVOCATION` docs match the shipped behavior: `$` hints now work on any logical prompt line, not just line 0. The docs previously said line 0 only, but the cursor-line gate was removed. This is documentation-only; no source, test, or behavior changes. Fixes #1606.

<sup>Written for commit 2c616496119af3e49bbecf01a2d9e82e71afe49b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

