### PR TITLE
fix(rpc): keep a live host whose identity probe is starved

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Image-heavy `/resume` sessions no longer reparse the complete JSONL once per evicted resident string; one ordered materialization pass performs one authoritative history load while preserving transcript contents and branch state ([#1407](https://github.com/code-yeongyu/senpi/issues/1407))
 
+- A shared RPC host is no longer torn down because its own process-identity probe was starved. A host we spawned that is alive and answering its socket is registered with a guard-less pidfile, and a record without an identity guard reads as unknown ownership everywhere, so it can neither claim a host nor authorize a signal; a later ensure that cannot verify it simply starts a fresh host. On a loaded Windows machine, where every `Get-CimInstance` attempt can exceed its timeout, session start no longer fails with `started but its process identity stayed unreadable`.
+
 - Windows RPC host ownership checks no longer treat a temporarily empty process-identity probe
   for a live PID as evidence that the shared host is dead. Compatible endpoints are reused before
   ownership probing, preventing concurrent callers from replacing a healthy named-pipe host

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## 2026-09-12 - Read a guard-less pidfile as unknown ownership
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/daemon/process.ts`: `DaemonPidFile.processStartTime`
+  accepts `null` for a record written while the identity probe was starved, `parseDaemonPidFile`
+  round-trips it, and `processMatchesPidFile` answers only the liveness half for such a record - a
+  pid that is gone is `false`, a live one raises `ProcessIdentityUnreadableError`.
+
+### Why
+
+- The RPC host registration needs a way to record a live host it cannot fingerprint. Without a
+  representable "no guard" state the supervisor had to choose between killing a healthy host and
+  writing a record that later callers would mistake for proven ownership; the null guard makes the
+  unknown explicit so no caller can signal a pid it never verified.
+
+### Why an extension could not handle it
+
+- The pidfile contract is consumed by daemon and RPC supervisor code that runs before extensions
+  load.
+
+### Expected merge conflict zones
+
+- LOW around the `DaemonPidFile` shape and the head of `processMatchesPidFile`.
+
 ## 2026-09-11 - Treat live processes with temporarily absent identity as observable gaps
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/daemon/process.ts
+++ b/packages/coding-agent/src/modes/app-server/daemon/process.ts
@@ -2,7 +2,12 @@ import { execFile } from "node:child_process";
 
 export interface DaemonPidFile {
 	readonly pid: number;
-	readonly processStartTime: string;
+	/**
+	 * Identity guard for the recorded pid. `null` means the host was registered while its
+	 * identity probe was starved: the pid is known, ownership is not provable, and no caller
+	 * may signal it on that record.
+	 */
+	readonly processStartTime: string | null;
 }
 
 export function parseDaemonPidFile(text: string): DaemonPidFile | undefined {
@@ -13,12 +18,17 @@ export function parseDaemonPidFile(text: string): DaemonPidFile | undefined {
 		if (error instanceof SyntaxError) return undefined;
 		throw error;
 	}
-	if (!isRecord(parsed) || typeof parsed.pid !== "number" || typeof parsed.processStartTime !== "string") {
+	const unguarded = parsed !== null && isRecord(parsed) && parsed.processStartTime === null;
+	if (
+		!isRecord(parsed) ||
+		typeof parsed.pid !== "number" ||
+		(!unguarded && typeof parsed.processStartTime !== "string")
+	) {
 		return undefined;
 	}
-	if (!Number.isInteger(parsed.pid) || parsed.pid <= 0 || parsed.processStartTime.trim() === "") {
-		return undefined;
-	}
+	if (!Number.isInteger(parsed.pid) || parsed.pid <= 0) return undefined;
+	if (unguarded) return { pid: parsed.pid, processStartTime: null };
+	if (typeof parsed.processStartTime !== "string" || parsed.processStartTime.trim() === "") return undefined;
 	return { pid: parsed.pid, processStartTime: parsed.processStartTime };
 }
 
@@ -64,6 +74,12 @@ export async function processMatchesPidFile(
 	isLive: (pid: number) => boolean = processIsLive,
 	retry: IdentityProbeRetry = {},
 ): Promise<boolean> {
+	// A record without an identity guard answers only the liveness half of the question: a pid
+	// that is gone is gone, and a live one stays unknown so it is never claimed or signalled.
+	if (pidFile.processStartTime === null) {
+		if (!isLive(pidFile.pid)) return false;
+		throw new ProcessIdentityUnreadableError(pidFile.pid, 0, new Error("pidfile carries no process identity guard"));
+	}
 	const attempts = Math.max(1, retry.attempts ?? 5);
 	const delayMs = retry.delayMs ?? 200;
 	let lastError: unknown;

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,36 @@
 # changes
 
+## 2026-09-12 - Keep a live host whose identity probe is starved
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/host-ensure.ts` registers a spawned host whose process
+  identity stayed unreadable with a guard-less pidfile (`processStartTime: null`) instead of
+  throwing and terminating the child, and the unhurried second read now honors the injected test
+  probe so the starved-probe path is reachable without a Windows runner.
+- `matchesPidFileOrUnknown` maps `ProcessIdentityUnreadableError` to "not ours" for the reuse
+  decision, so an observation gap starts a fresh host instead of failing the whole ensure.
+- `packages/coding-agent/test/rpc-host-ensure.test.ts` pins the registration, the guard-less
+  reuse path, and the restart from a guard-less pidfile.
+
+### Why
+
+- Every win32 identity attempt spawns `powershell.exe` with `Get-CimInstance` under a 1s timeout.
+  On a loaded runner all attempts time out, so a healthy host that had already bound its pipe was
+  refused and killed with `started but its process identity stayed unreadable`. The comment above
+  that throw already stated the intended behavior - keep the healthy host - while the code did the
+  opposite; this is the CI failure observed on the `RPC named pipes (Windows)` job.
+
+### Why an extension could not handle it
+
+- Host registration and ownership probing run inside the RPC supervisor before any extension is
+  loaded.
+
+### Expected merge conflict zones
+
+- LOW around the `startHost` identity block and `ensureHostLocked`'s ownership call in
+  `host-ensure.ts`.
+
 ## 2026-09-11 - Preserve shared hosts across transient empty identity probes
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -160,7 +160,7 @@ async function ensureHostLocked(
 		return { pid: pidFile?.pid ?? 0, socket, reused: true };
 	}
 	const probe = testOptions?.readProcessStartTime ?? readProcessStartTime;
-	const pidMatches = pidFile ? await processMatchesPidFile(pidFile, probe) : false;
+	const pidMatches = pidFile ? await matchesPidFileOrUnknown(pidFile, probe) : false;
 	if (protocol && !pidMatches) {
 		throw new Error(`RPC socket ${socket} is owned by an unmanaged host`);
 	}
@@ -225,16 +225,16 @@ async function startHost(
 		]);
 		// UNKNOWN identity on a live child: the probe was starved, not the host. Give the CIM table
 		// one unhurried read (the per-attempt win32 default is 1s, which a loaded runner exceeds on
-		// every attempt) before deciding. Without an identity the pidfile cannot carry an ownership
-		// guard, so a healthy host must still be kept rather than torn down for an unreadable probe.
-		const processStartTime =
-			observedStartTime ?? (await readProcessStartTime(child.pid, process.platform, 15_000).catch(() => undefined));
-		if (processStartTime === undefined) {
-			throw new Error(
-				`RPC socket host pid ${child.pid} started but its process identity stayed unreadable; refusing to register an unguarded pidfile`,
-			);
-		}
-		pidFile = { pid: child.pid, processStartTime };
+		// every attempt) before deciding.
+		const unhurriedProbe = testOptions?.readProcessStartTime
+			? testOptions.readProcessStartTime
+			: (pid: number) => readProcessStartTime(pid, process.platform, 15_000);
+		const processStartTime = observedStartTime ?? (await unhurriedProbe(child.pid).catch(() => undefined));
+		// Still unreadable: the host is ours, alive, and about to prove itself on the socket, so it is
+		// registered WITHOUT an ownership guard instead of being torn down for a starved probe. A
+		// guard-less record never claims ownership and never authorizes a signal - every later caller
+		// reads it as unknown - so the worst case is a fresh host next time, not a killed healthy one.
+		pidFile = { pid: child.pid, processStartTime: processStartTime ?? null };
 		await testOptions?.beforePidFileWrite?.();
 		await writeFile(paths.pidFile, `${JSON.stringify(pidFile)}\n`, { mode: 0o600 });
 		child.unref();
@@ -303,6 +303,23 @@ async function startHost(
 	// appeared while readiness was being checked. Never unlink an endpoint we
 	// cannot prove this start owned.
 	throw new Error(diagnostic);
+}
+
+/**
+ * Ownership for the reuse decision. An identity we cannot read proves nothing: it can neither
+ * claim the host nor authorize a kill, so it reads as "not ours" and the caller starts fresh
+ * rather than failing the whole ensure on an observation gap.
+ */
+async function matchesPidFileOrUnknown(
+	pidFile: DaemonPidFile,
+	probe: (pid: number) => Promise<string | undefined>,
+): Promise<boolean> {
+	try {
+		return await processMatchesPidFile(pidFile, probe);
+	} catch (error: unknown) {
+		if (error instanceof ProcessIdentityUnreadableError) return false;
+		throw error;
+	}
 }
 
 async function stopSpawnedChild(

--- a/packages/coding-agent/test/rpc-host-ensure.test.ts
+++ b/packages/coding-agent/test/rpc-host-ensure.test.ts
@@ -289,6 +289,33 @@ describe("ensureHost", () => {
 		expect(failuresLeft).toBe(0);
 	}, 20_000);
 
+	it("registers a live host whose identity stays unreadable instead of tearing it down", async () => {
+		// The Windows CI variant that survived the retry work: every Get-CimInstance attempt is
+		// starved, so the spawned host never yields an identity. The host itself is healthy and
+		// answering, so it must be registered without an ownership guard rather than killed.
+		const qa = await scratch("unreadable-identity");
+		const host = await ensureFixtureHost(qa, { readProcessStartTime: async () => undefined });
+		expect(host).toMatchObject({ socket: qa.socket, reused: false });
+		const pidFile = JSON.parse(await readFile(createHostDaemonPaths(qa.agentDir).pidFile, "utf8")) as unknown;
+		expect(pidFile).toMatchObject({ pid: host.pid, processStartTime: null });
+		const second = await ensureFixtureHost(qa);
+		expect(second).toMatchObject({ socket: qa.socket, reused: true });
+	}, 20_000);
+
+	it("starts fresh when an unguarded pidfile's host no longer answers", async () => {
+		// A pidfile written without an identity guard can never authorize a kill, so a later
+		// ensure must start a new host instead of failing on the unreadable identity.
+		const qa = await scratch("unguarded-pidfile");
+		const live = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60_000)"], { stdio: "ignore" });
+		children.push(live);
+		const paths = createHostDaemonPaths(qa.agentDir);
+		await mkdir(dirname(paths.pidFile), { recursive: true });
+		await writeFile(paths.pidFile, `${JSON.stringify({ pid: live.pid, processStartTime: null })}\n`);
+		const host = await ensureFixtureHost(qa);
+		expect(host.reused).toBe(false);
+		expect(host.pid).not.toBe(live.pid);
+	}, 20_000);
+
 	it("treats a failing probe against a dead pid as gone and starts a fresh host", async () => {
 		const qa = await scratch("dead-probe");
 		// A real process that has already exited: liveness is genuinely false.
@@ -497,6 +524,32 @@ describe("processMatchesPidFile", () => {
 		);
 		expect(matches).toBe(true);
 		expect(calls).toBe(3);
+	});
+
+	it("reads a pidfile without an identity guard as unreadable while the pid is live", async () => {
+		await expect(
+			processMatchesPidFile(
+				{ pid: process.pid, processStartTime: null },
+				async () => "ignored",
+				() => true,
+				{
+					attempts: 1,
+				},
+			),
+		).rejects.toBeInstanceOf(ProcessIdentityUnreadableError);
+	});
+
+	it("reads a pidfile without an identity guard as gone once the pid is not live", async () => {
+		await expect(
+			processMatchesPidFile(
+				{ pid: 4_294_967_294, processStartTime: null },
+				async () => "ignored",
+				() => false,
+				{
+					attempts: 1,
+				},
+			),
+		).resolves.toBe(false);
 	});
 
 	it("reads a failing probe against a dead pid as gone without retrying", async () => {


### PR DESCRIPTION
## Summary

The `RPC named pipes (Windows)` job failed on a **changelog-only** PR (#1607, job 103325796125) with the annotation:

```
Error: RPC socket host pid 5216 started but its process identity stayed unreadable; refusing to register an unguarded pidfile
 ❯ startHost src/modes/rpc/host-ensure.ts:233
 ❯ ensureHost src/modes/rpc/host-ensure.ts:142
 ❯ test/rpc-host-ensure.test.ts:69  (serializes concurrent starts for one socket across agent directories)
```

The same job was green on the base commit, so this is not a regression from that PR - it is the starved-probe variant of the #1290 flake family, and it is a real product failure on Windows, not only a test flake.

## Root cause

Every win32 identity attempt spawns `powershell.exe` with `Get-CimInstance Win32_Process` under a 1s per-attempt timeout (`daemon/process.ts`). On a loaded machine every attempt times out, so `waitForStartTime(pid, 10_000)` and the unhurried 15s retry both come back empty, and `startHost` threw. Its own `catch` then SIGTERM/SIGKILLs the child - a host that was alive and had already bound its pipe. The comment directly above that throw already stated the intended behavior ("a healthy host must still be kept rather than torn down for an unreadable probe"); the code did the opposite.

## Fix

- `DaemonPidFile.processStartTime` accepts `null`: an explicit "no identity guard" state. `parseDaemonPidFile` round-trips it, and `processMatchesPidFile` answers only the liveness half for such a record - a pid that is gone is `false`, a live one raises `ProcessIdentityUnreadableError`. Every kill path already routes that error to `unknown` and never signals, so a guard-less record can neither claim a host nor authorize a signal.
- `startHost` registers the live host with that guard-less pidfile instead of throwing, so a starved probe costs an ownership guard, never a running host.
- `ensureHostLocked` reads an unreadable identity as "not ours" (`matchesPidFileOrUnknown`) and starts a fresh host instead of failing the whole ensure.
- The unhurried second probe now honors the injected test probe, so the starved path is reachable from a test seam instead of only on a loaded Windows runner.

## Evidence

RED (fix reverted, tests present) - `2 failed | 22 passed`:

```
FAIL  ensureHost > registers a live host whose identity stays unreadable instead of tearing it down
  expected { pid: 67278, processStartTime: "Sat Sep 12 01:02:51 2026" } to match { processStartTime: null }
FAIL  processMatchesPidFile > reads a pidfile without an identity guard as unreadable while the pid is live
  promise resolved "false" instead of rejecting
```

GREEN (fix applied) - `Test Files 1 passed (1) / Tests 24 passed (24)`.

MUTATION (fix applied, `matchesPidFileOrUnknown`'s catch removed) - the third test earns its keep:

```
FAIL  ensureHost > starts fresh when an unguarded pidfile's host no longer answers
  ProcessIdentityUnreadableError: ... pidfile carries no process identity guard
```

The real Windows surface is this PR's own `RPC named pipes (Windows)` job.

Related: #1290 (flake family), #1593 (previous identity-gap fix in the same file).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the RPC host ownership guard so a live host with a starved identity probe is kept instead of torn down. On loaded Windows machines every `Get-CimInstance` attempt times out, so `startHost` threw and its catch terminated a host that was alive and already answering its socket.

**Bug Fixes**

- `DaemonPidFile.processStartTime` accepts `null` as a guard-less record; `parseDaemonPidFile` round-trips it and `processMatchesPidFile` answers only the liveness half for it.
- `startHost` registers the live host with that record instead of throwing; the guard-less record can neither claim the host nor authorize a signal.
- `ensureHostLocked` reads an unreadable identity as "not ours" and starts a fresh host instead of failing the whole ensure.

<sup>Written for commit 573d697c5d0ba96928e5bfa6facef598552c817d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

