### PR TITLE
fix(scripts): keep fork-owned model catalog shards during generation

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,3 +1,24 @@
+## 2026-09-12 - Fork-owned model catalog shards survive generation
+
+### What changed
+
+- `packages/ai/scripts/model-shards.ts` (new) owns shard ownership: `FORK_OWNED_MODEL_SHARDS` lists the `*.models.ts` catalogs the fork maintains by hand (currently `devin.models.ts`), and `isPrunableModelShard` decides deletion.
+- `packages/ai/scripts/generate-models.ts` prunes through that predicate instead of deleting every shard the current run did not write.
+- `packages/ai/scripts/model-data.ts` excludes fork-owned shards when it compares the shard directory against the aggregator's provider imports.
+- `packages/ai/test/model-shards.test.ts` derives the expected fork-owned set from the tree - the shards providers import minus the shards `src/models.generated.ts` imports - so a new hand-authored provider fails this test instead of the release.
+
+### Why
+
+- models.dev has no `devin` provider, so `devin.models.ts` is hand-authored and the aggregator never imports it. The release job regenerates the catalog before typechecking, so generation deleted the shard and `tsc` failed with `Cannot find module './devin.models.ts'` (run 34621164006), and `check:model-data` already failed on the committed tree for the same reason. Ordinary CI typechecks the committed catalog, so neither failure is visible outside the release path.
+
+### Why an extension could not handle it
+
+- Catalog generation and its validation are build-time scripts that run long before any extension loads.
+
+### Expected merge conflict zones
+
+- LOW: the shard prune loop in `generate-models.ts` and the shard comparison in `readModelDataStructure`.
+
 ## 2026-09-10 - Venice AI catalog generation
 
 ### What changed

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSy
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { fetchOpenGatewayModels } from "./generate-models-opengateway.ts";
+import { isPrunableModelShard } from "./model-shards.ts";
 import { getEffortThinkingLevelMap, type ModelsDevReasoningOption } from "./models-dev-reasoning-options.ts";
 import { getOpenRouterThinkingLevelMap, type OpenRouterReasoningMetadata } from "./openrouter-reasoning-options.ts";
 import {
@@ -3575,7 +3576,7 @@ async function generateModels() {
 					writeFileSync(join(providersDir, filename), output);
 				}
 				for (const entry of readdirSync(providersDir)) {
-					if (entry.endsWith(".models.ts") && !generatedShardFiles.has(entry)) rmSync(join(providersDir, entry));
+					if (isPrunableModelShard(entry, generatedShardFiles)) rmSync(join(providersDir, entry));
 				}
 
 				let output = generatedHeader;

--- a/packages/ai/scripts/model-data.ts
+++ b/packages/ai/scripts/model-data.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { FORK_OWNED_MODEL_SHARDS, MODEL_SHARD_SUFFIX } from "./model-shards.ts";
 
 export const MODEL_DATA_SCHEMA_VERSION = 3;
 export const MODEL_DATA_MANIFEST_FILE = ".manifest.json";
@@ -99,7 +100,7 @@ export function readModelDataStructure(packageRoot: string): ModelDataStructure 
 	const providerIds = readModelDataProviderIds(packageRoot);
 	const expectedShards = providerIds.map((providerId) => `${providerId}.models.ts`).sort();
 	const actualShards = readdirSync(providersDir)
-		.filter((entry) => entry.endsWith(".models.ts"))
+		.filter((entry) => entry.endsWith(MODEL_SHARD_SUFFIX) && !FORK_OWNED_MODEL_SHARDS.has(entry))
 		.sort();
 	if (!sameStrings(expectedShards, actualShards)) {
 		throw new Error(

--- a/packages/ai/scripts/model-shards.ts
+++ b/packages/ai/scripts/model-shards.ts
@@ -1,0 +1,19 @@
+/**
+ * Ownership rules for the per-provider `*.models.ts` catalog shards.
+ *
+ * The generator writes one shard per models.dev provider and prunes every other
+ * shard so a provider dropped upstream cannot linger. A fork provider that
+ * models.dev does not describe owns its shard by hand, and pruning it breaks the
+ * provider module that imports it - a failure only the release job sees, because
+ * ordinary CI type-checks against the committed catalog instead of regenerating
+ * it. Such shards are listed here and left alone.
+ */
+export const FORK_OWNED_MODEL_SHARDS: ReadonlySet<string> = new Set<string>(["devin.models.ts"]);
+
+export const MODEL_SHARD_SUFFIX = ".models.ts";
+
+export function isPrunableModelShard(entry: string, generatedShardFiles: ReadonlySet<string>): boolean {
+	if (!entry.endsWith(MODEL_SHARD_SUFFIX)) return false;
+	if (generatedShardFiles.has(entry)) return false;
+	return !FORK_OWNED_MODEL_SHARDS.has(entry);
+}

--- a/packages/ai/test/model-shards.test.ts
+++ b/packages/ai/test/model-shards.test.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { readModelDataStructure } from "../scripts/model-data.ts";
 import { FORK_OWNED_MODEL_SHARDS, isPrunableModelShard, MODEL_SHARD_SUFFIX } from "../scripts/model-shards.ts";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -54,5 +55,9 @@ describe("model catalog shard ownership", () => {
 
 	it("ignores files that are not catalog shards", () => {
 		expect(isPrunableModelShard("devin.ts", new Set())).toBe(false);
+	});
+
+	it("accepts the committed catalog while fork-owned shards sit beside the generated ones", () => {
+		expect(() => readModelDataStructure(packageRoot)).not.toThrow();
 	});
 });

--- a/packages/ai/test/model-shards.test.ts
+++ b/packages/ai/test/model-shards.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { FORK_OWNED_MODEL_SHARDS, isPrunableModelShard, MODEL_SHARD_SUFFIX } from "../scripts/model-shards.ts";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const providersDir = join(packageRoot, "src/providers");
+
+function generatedShardNames(): Set<string> {
+	const aggregator = readFileSync(join(packageRoot, "src/models.generated.ts"), "utf8");
+	const names = new Set<string>();
+	for (const match of aggregator.matchAll(/from "\.\/providers\/([^"]+\.models\.ts)"/g)) {
+		const [, shard] = match;
+		if (shard !== undefined) names.add(shard);
+	}
+	return names;
+}
+
+function importedShardNames(): Set<string> {
+	const names = new Set<string>();
+	for (const entry of readdirSync(providersDir)) {
+		if (!entry.endsWith(".ts") || entry.endsWith(MODEL_SHARD_SUFFIX)) continue;
+		const source = readFileSync(join(providersDir, entry), "utf8");
+		for (const match of source.matchAll(/from "\.\/([^"]+\.models\.ts)"/g)) {
+			const [, shard] = match;
+			if (shard !== undefined) names.add(shard);
+		}
+	}
+	return names;
+}
+
+describe("model catalog shard ownership", () => {
+	it("declares every shard a provider imports that the generator does not write", () => {
+		const generated = generatedShardNames();
+		expect(generated.size).toBeGreaterThan(0);
+		const handOwned = [...importedShardNames()].filter((shard) => !generated.has(shard)).sort();
+		expect(handOwned).toEqual([...FORK_OWNED_MODEL_SHARDS].sort());
+	});
+
+	it("prunes a shard the run did not write and the fork does not own", () => {
+		expect(isPrunableModelShard("retired-provider.models.ts", new Set(["anthropic.models.ts"]))).toBe(true);
+	});
+
+	it("keeps a shard the current run wrote", () => {
+		expect(isPrunableModelShard("anthropic.models.ts", new Set(["anthropic.models.ts"]))).toBe(false);
+	});
+
+	it("keeps every fork-owned shard the generator never writes", () => {
+		for (const shard of FORK_OWNED_MODEL_SHARDS) {
+			expect(isPrunableModelShard(shard, new Set(["anthropic.models.ts"]))).toBe(false);
+		}
+	});
+
+	it("ignores files that are not catalog shards", () => {
+		expect(isPrunableModelShard("devin.ts", new Set())).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

The senpi release run [34621164006](https://github.com/code-yeongyu/senpi/actions/runs/34621164006) failed with:

```
Cannot find module './devin.models.ts' or its corresponding type declarations.
```

`scripts/generate-models.ts` regenerates the catalog from models.dev, then deletes every `*.models.ts` shard it did not write:

```ts
for (const entry of readdirSync(providersDir)) {
  if (entry.endsWith(".models.ts") && !generatedShardFiles.has(entry)) rmSync(join(providersDir, entry));
}
```

`src/providers/devin.models.ts` is hand-authored (Devin's credential-free seed; models.dev has no `devin` provider and the aggregator never imports it), so regeneration deleted it and `src/providers/devin.ts` lost its import. **This is release-only**: PR CI typechecks against the committed catalog, so the tree is green everywhere except inside the release job, and every release attempt fails at the same spot until this lands.

## Fix

`scripts/model-shards.ts` owns the rule: `isPrunableModelShard(entry, generatedShardFiles)` prunes a shard only when the current run did not write it **and** the fork does not own it. `FORK_OWNED_MODEL_SHARDS` currently holds `devin.models.ts`.

## Evidence

The ownership test derives the expected set from the tree instead of hardcoding it: it reads which shards `src/models.generated.ts` imports (generator-written) and which shards `src/providers/*.ts` import, and requires the difference to equal `FORK_OWNED_MODEL_SHARDS`. A future hand-authored provider therefore fails this test rather than the release.

RED (with `FORK_OWNED_MODEL_SHARDS` empty):

```
FAIL  test/model-shards.test.ts > declares every shard a provider imports that the generator does not write
AssertionError: expected [ 'devin.models.ts' ] to deeply equal []
Tests  1 failed | 4 passed (5)
```

GREEN (after declaring the shard): `Tests 5 passed (5)`.

Real surface: the next release dispatch, which reaches `Publish prepared version` instead of dying in `Run release`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the model catalog tooling so fork-owned shards like `devin.models.ts` survive both generation and validation, which were failing the release with a missing module error.

- Introduces `isPrunableModelShard` in `scripts/model-shards.ts` to skip deleting fork-owned shards during regeneration.
- Excludes fork-owned shards from model-data validation so `check:model-data` passes on the committed tree and after regeneration.
- Adds a test that derives the expected fork-owned set from the tree, so future hand-authored shards fail the test instead of the release.
- Records the ownership rule in `packages/ai/changes.md`.

<sup>Written for commit 25750340ad26dc4c76117f6823c307f99df52035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

