### PR TITLE
test(coding-agent): stop pinning the opencode-go V4.1 Flash catalog id

### DIFF
--- a/packages/coding-agent/test/suite/prompt-presets-deepseek-v4-1-flash.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-deepseek-v4-1-flash.test.ts
@@ -149,9 +149,12 @@ describe("DeepSeek V4.1 Flash prompt preset", () => {
 				"deepseek/deepseek-v4-flash",
 				"openrouter/deepseek/deepseek-v4.1-flash",
 				"vercel-ai-gateway/deepseek/deepseek-v4.1-flash",
-				"opencode-go/deepseek-flash",
 			]),
 		);
+		// opencode-go renames its V4.1 Flash id between catalog regenerations
+		// (deepseek-flash -> deepseek-v4.1-flash on 2026-09-11); pin the provider's
+		// presence in the V4.1 set, not one spelling.
+		expect(catalogModelIds.some((id) => id.startsWith("opencode-go/"))).toBe(true);
 		expect(misses).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

`prompt-presets-deepseek-v4-1-flash.test.ts` has been red on `main` since the `v2026.9.11` release commit regenerated the opencode-go catalog and renamed `deepseek-flash` to `deepseek-v4.1-flash`. The coverage test still pinned the old spelling, so `Test (coding-agent 2/3)` fails on every PR and the next release's test gate would fail with it.

Fixes #1618

## Change

The test keeps pinning the ids that are stable across regenerations (official `deepseek/deepseek-v4-flash`, `openrouter/deepseek/deepseek-v4.1-flash`, `vercel-ai-gateway/deepseek/deepseek-v4.1-flash`) and asserts opencode-go's **presence** in the V4.1 set instead of one spelling. The existing `misses` assertion still proves every V4.1 catalog model routes to the preset.

## Verification

- BASE (`origin/main` 4f4cd7451): `1 failed | 36 passed` — same failure as CI run 34671781938 shard 2/3.
- This branch: `37 passed (37)`.
- Mutation: asserting a non-existent provider (`no-such-provider/`) fails the test, so the presence check is live.
- Pre-commit (biome, repo `tsc --noEmit`, browser smoke) passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DeepSeek V4.1 Flash preset coverage test so CI and the release gate stop failing on `main`. The test previously pinned the old `opencode-go/deepseek-flash` spelling, which the `v2026.9.11` catalog regeneration renamed to `opencode-go/deepseek-v4.1-flash`.

- Keeps pinning the stable official, `openrouter`, and `vercel-ai-gateway` catalog ids, and now asserts `opencode-go`'s presence in the V4.1 set instead of one spelling that changes between regenerations.
- The `misses` assertion still verifies every V4.1 catalog model routes to the preset.
- Fixes #1618.

<sup>Written for commit 1f373c93ff7155f1c3db3c5645d1bb7d0d127cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

