### PR TITLE
fix(coding-agent): accept macOS Option-composed glyphs for the async ask-user shortcut

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed the async ask-user widget's advertised `option+a` shortcut doing nothing in macOS terminals that let Option compose characters (the Terminal.app, iTerm2, Ghostty and kitty defaults): on macOS the composed `å`/`Å` glyphs now expand the pending question too, `alt+a` keeps working everywhere, and other platforms keep treating those glyphs as text (fixes #1620).
+
 ### Removed
 
 ## [2026.9.12] - 2026-09-12

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,30 @@
+## 2026-09-12 - Async ask-user shortcut accepts macOS Option-composed glyphs (senpi#1620)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts`: new
+  `matchesAskUserAnswerKey(data, platform)` keeps `alt+a` (`ESC a` / CSI-u alt) on every platform
+  and, on darwin only, also accepts the glyphs the `a` key types when the terminal lets Option
+  compose (`å`, `Å`, raw or as a kitty CSI-u printable). `ASK_USER_ANSWER_KEY` and the widget label
+  (`option+a` on darwin, `alt+a` elsewhere) are unchanged.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `handleAskUserShortcut` matches
+  through `matchesAskUserAnswerKey` instead of `matchesKey(data, ASK_USER_ANSWER_KEY)`.
+
+### Why
+
+- Terminal.app, iTerm2, Ghostty and kitty default to Option composing characters on macOS, so the
+  advertised `option+a` arrived as `å` and inserted text instead of expanding the pending question.
+
+### Why an extension could not handle it
+
+- The shortcut is consumed inside `CustomEditor.onExtensionShortcut` before extension shortcuts run,
+  and the async widget is interactive-mode state; no extension hook sees the raw editor input first.
+
+### Expected merge conflict zones
+
+- LOW: the `ask-user-async-widget.ts` import list and `handleAskUserShortcut` in
+  `packages/coding-agent/src/modes/interactive/interactive-mode.ts` (fork-only code).
+
 ## 2026-09-11 - Ask-user overlay uses an explicit question and submit flow
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
@@ -6,7 +6,7 @@
  * interactive-mode can turn ordinary composer text into the comment answer.
  */
 
-import { Container, Text, type TUI } from "@earendil-works/pi-tui";
+import { Container, decodeKittyPrintable, matchesKey, Text, type TUI } from "@earendil-works/pi-tui";
 import type { QuestionRequest, QuestionResponse } from "../../../core/extensions/types.ts";
 import { theme } from "../theme/theme.ts";
 import { formatCountdownLabel, type QuestionDraft } from "./ask-user-question-state.ts";
@@ -17,6 +17,21 @@ import { rawKeyHint } from "./keybinding-hints.ts";
 export const ASK_USER_WIDGET_KEY = "ask-user";
 /** Editor shortcut that expands the pending question into the full component. */
 export const ASK_USER_ANSWER_KEY = "alt+a";
+/**
+ * What the `a` key types on macOS when the terminal lets Option compose
+ * characters instead of sending it as Alt (the default in Terminal.app,
+ * iTerm2, Ghostty and kitty). Accepting these keeps the advertised `option+a`
+ * working without a terminal-settings detour; other platforms never see
+ * Option this way, so they keep treating the glyphs as text.
+ */
+const DARWIN_OPTION_A_GLYPHS: ReadonlySet<string> = new Set(["å", "Å"]);
+
+/** True when `data` is the editor input that expands the pending question on `platform`. */
+export function matchesAskUserAnswerKey(data: string, platform: NodeJS.Platform = process.platform): boolean {
+	if (matchesKey(data, ASK_USER_ANSWER_KEY)) return true;
+	if (platform !== "darwin") return false;
+	return DARWIN_OPTION_A_GLYPHS.has(decodeKittyPrintable(data) ?? data);
+}
 
 function hasAnswer(answer: QuestionResponse["answers"][string] | undefined): boolean {
 	if (!answer) return false;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -149,11 +149,11 @@ import {
 } from "./compaction-queue-transfer.ts";
 import { ArminComponent } from "./components/armin.ts";
 import {
-	ASK_USER_ANSWER_KEY,
 	ASK_USER_WIDGET_KEY,
 	AskUserAsyncWidget,
 	buildCommentResponse,
 	buildTimedOutResponse,
+	matchesAskUserAnswerKey,
 	unansweredIds,
 } from "./components/ask-user-async-widget.ts";
 import { AskUserQuestionComponent } from "./components/ask-user-question.ts";
@@ -3946,7 +3946,7 @@ export class InteractiveMode {
 	/** Editor shortcut: expand the pending async question into the full component. */
 	private handleAskUserShortcut(data: string): boolean {
 		const state = this.asyncQuestion;
-		if (!state || this.askUserQuestion || !matchesKey(data, ASK_USER_ANSWER_KEY)) return false;
+		if (!state || this.askUserQuestion || !matchesAskUserAnswerKey(data)) return false;
 		const component = new AskUserQuestionComponent(
 			state.request,
 			(response) => {

--- a/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { QuestionRequest } from "../../src/core/extensions/types.ts";
+import {
+	ASK_USER_WIDGET_KEY,
+	matchesAskUserAnswerKey,
+} from "../../src/modes/interactive/components/ask-user-async-widget.ts";
+import { AskUserQuestionComponent } from "../../src/modes/interactive/components/ask-user-question.ts";
+import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../src/utils/ansi.ts";
+import { createFakeInteractiveMode, type FakeInteractiveMode } from "./helpers/ask-user-async-fake-mode.ts";
+
+const ALT_A = "\x1ba";
+/** What Option+A types in a macOS terminal that lets Option compose (Terminal.app, iTerm2, Ghostty, kitty defaults). */
+const OPTION_A_GLYPH = "å";
+const OPTION_SHIFT_A_GLYPH = "Å";
+/** The same glyph reported as a CSI-u printable while the kitty keyboard protocol is active. */
+const KITTY_OPTION_A_GLYPH = "\x1b[229u";
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true, enumerable: true });
+}
+
+function buildRequest(): QuestionRequest {
+	return {
+		requestId: "req-platform",
+		questions: [
+			{
+				id: "auth",
+				header: "Auth",
+				question: "Which auth method?",
+				options: [{ label: "OAuth" }, { label: "API key" }],
+				multiSelect: false,
+			},
+		],
+		waitForAnswer: false,
+		timeoutMs: 30 * 60_000,
+	};
+}
+
+function overlay(fake: FakeInteractiveMode): AskUserQuestionComponent | undefined {
+	return fake.editorContainer.children.find((child) => child instanceof AskUserQuestionComponent);
+}
+
+function askPending(fake: FakeInteractiveMode): void {
+	const pending = fake.createExtensionUIContext().question?.(buildRequest(), { timeout: 30 * 60_000 });
+	if (!pending) throw new Error("question() returned nothing");
+}
+
+afterEach(() => {
+	if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+	else Reflect.deleteProperty(process, "platform");
+});
+
+describe("OS-aware async ask-user answer shortcut", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	describe("matchesAskUserAnswerKey", () => {
+		it.each<NodeJS.Platform>(["darwin", "linux", "win32"])("accepts alt+a as ESC a on %s", (platform) => {
+			expect(matchesAskUserAnswerKey(ALT_A, platform)).toBe(true);
+		});
+
+		it("accepts the Option-composed glyphs for the a key on darwin only", () => {
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "darwin")).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_SHIFT_A_GLYPH, "darwin")).toBe(true);
+			expect(matchesAskUserAnswerKey(KITTY_OPTION_A_GLYPH, "darwin")).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "linux")).toBe(false);
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "win32")).toBe(false);
+		});
+
+		it("never treats plain or multi-character text as the shortcut", () => {
+			expect(matchesAskUserAnswerKey("a", "darwin")).toBe(false);
+			expect(matchesAskUserAnswerKey("åå", "darwin")).toBe(false);
+			expect(matchesAskUserAnswerKey("", "darwin")).toBe(false);
+		});
+	});
+
+	describe("editor shortcut", () => {
+		it("expands the pending question when Option+A arrives as å on darwin", () => {
+			setPlatform("darwin");
+			const fake = createFakeInteractiveMode({ isStreaming: true });
+			askPending(fake);
+
+			expect(fake.pressEditorKey(OPTION_A_GLYPH)).toBe(true);
+			const component = overlay(fake);
+			expect(component).toBeInstanceOf(AskUserQuestionComponent);
+			expect(fake.ui.setFocus).toHaveBeenLastCalledWith(component);
+		});
+
+		it("still expands the pending question on ESC a on darwin", () => {
+			setPlatform("darwin");
+			const fake = createFakeInteractiveMode({ isStreaming: true });
+			askPending(fake);
+
+			expect(fake.pressEditorKey(ALT_A)).toBe(true);
+			expect(overlay(fake)).toBeInstanceOf(AskUserQuestionComponent);
+		});
+
+		it("leaves å as ordinary editor text on linux", () => {
+			setPlatform("linux");
+			const fake = createFakeInteractiveMode({ isStreaming: true });
+			askPending(fake);
+
+			expect(fake.pressEditorKey(OPTION_A_GLYPH)).toBe(false);
+			expect(overlay(fake)).toBeUndefined();
+			expect(fake.widgetText(ASK_USER_WIDGET_KEY)).toContain("Question pending (1 unanswered)");
+		});
+	});
+
+	describe("widget label", () => {
+		it.each<[NodeJS.Platform, string]>([
+			["darwin", "option+a"],
+			["linux", "alt+a"],
+			["win32", "alt+a"],
+		])("names the shortcut %s as %s", (platform, label) => {
+			setPlatform(platform);
+			const fake = createFakeInteractiveMode();
+			askPending(fake);
+
+			expect(stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "")).toContain(`${label} to answer`);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The async (`waitForAnswer: false`) ask-user widget advertises `option+a` on macOS, but Terminal.app, iTerm2, Ghostty and kitty let Option compose characters by default, so Option+A arrived as the glyph `å` and was inserted into the editor instead of expanding the pending question. The label was platform-aware; the matcher was not.

`matchesAskUserAnswerKey(data, platform)` now keeps `alt+a` (`ESC a` / CSI-u alt) working on every platform and, on darwin only, also accepts the Option-composed glyphs for the `a` key (`å`, `Å`, as raw text or as a kitty CSI-u printable). Other platforms keep treating those glyphs as ordinary text. `ASK_USER_ANSWER_KEY` and the widget label (`option+a` on darwin, `alt+a` elsewhere) are unchanged.

Fixes #1620

## Changes

- `packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts`: `matchesAskUserAnswerKey` + `DARWIN_OPTION_A_GLYPHS`
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `handleAskUserShortcut` matches through the helper
- `packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts` (new): matcher per platform, editor shortcut on darwin/linux, widget label per platform
- `packages/coding-agent/src/modes/interactive/changes.md`, `packages/coding-agent/CHANGELOG.md` `[Unreleased]`

## Verification

- RED before the change (remote macOS host, tree `5039b4d68`): `ask-user-async-shortcut-platform.test.ts` 6 failed / 5 passed — `expands the pending question when Option+A arrives as å on darwin` failed with `expected false to be true`; matcher cases failed with `matchesAskUserAnswerKey is not a function`.
- GREEN after the change: `bun run --cwd packages/coding-agent test test/suite/ask-user-async-shortcut-platform.test.ts test/suite/ask-user-async-tui.test.ts test/suite/ask-user-question-component.test.ts` → 3 files / 42 tests passed.
- `bun scripts/check-pr-changelog.mjs --base origin/main` → PASS; `biome check` clean on the touched files; pre-commit checks passed.
- Real-surface pty proof (macOS, `å` bytes expanding the overlay) is posted on #1620.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The async ask-user shortcut (`option+a` on macOS) did nothing in macOS terminals that let Option compose characters by default—Option+A arrived as the glyph `å` and was inserted into the editor instead of expanding the pending question. The shortcut matcher is now platform-aware.

- Adds `matchesAskUserAnswerKey` (used by `handleAskUserShortcut`) that keeps `alt+a` working everywhere and, on macOS only, also accepts `å`/`Å` (raw or kitty CSI-u printable).
- Other platforms still treat those glyphs as text; the widget label remains `option+a` on darwin and `alt+a` elsewhere.
- Adds `ask-user-async-shortcut-platform.test.ts` covering matcher, editor shortcut, and label per platform.
- Fixes #1620.

<sup>Written for commit 4ba31ca1b9f5c333789a26f4aececf46f899545d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

