### PR TITLE
fix(rpc): bind session-write grants to live writers and release superseded paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed a long-lived RPC session dying with `session_path_in_use` after 64 session replacements: session-write grants are now bound to the writers that still exist, so a replaced session file is released as soon as the worker reports its new one. A superseded path can be reopened in a new worker instead of staying blocked for the host's lifetime, opening an explicit session file no longer burns a second phantom grant, and an exhausted per-worker budget is reported as the distinct `session_reservation_limit` (fixes #1612).
+
 ### Removed
 
 ## [2026.9.12] - 2026-09-12

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -222,10 +222,17 @@ and only then constructs its session writer and runtime. A conflicting alias att
 explicitly before opening another writer.
 
 SessionManager writes, switches, forks, new sessions and imports obtain the same grant before writer creation or
-append-side normalization. Acquired paths are conservatively retained for that worker's entire lifetime, including
-superseded paths after a switch. Each worker may reserve at most 64 paths; an exhausted reservation budget fails
-explicitly. Close or an opening deadline requests worker termination, but does not release reservations or worker
-capacity until the actual exit event. A syscall that cannot yet be interrupted can therefore keep an entry
+append-side normalization. A grant is bound to a LIVE writer, not to the worker's lifetime: every snapshot a fully
+open worker publishes names the session files its live session writers still own, and the host releases each granted
+path that list (and the worker's current session path) no longer names. A session replaced by `new_session`,
+`switch_session`, a fork or an import therefore frees its previous file as soon as the replacement is published:
+another `open_session` for that superseded path opens its own worker instead of attaching or failing, and the
+previous opening spelling stops resolving to the replaced owner. Each worker may reserve at most 64 live paths
+at once; a request past that budget first reconciles against the latest snapshot and only then fails with
+`session_reservation_limit`, which is distinct from `session_path_in_use` (another owner holds the path). Only a
+fully open entry reconciles. An entry that is opening, closing or quarantined keeps every acquired path, because a
+worker stuck in a syscall can still be writing a path it can no longer report. Close or an opening deadline requests
+worker termination, but does not release reservations or worker capacity until the actual exit event. A syscall that cannot yet be interrupted can therefore keep an entry
 internally quarantined after the routing handle has closed. `list_sessions` continues to publish `closing`, not a
 new status: existing clients must not mistake a quarantined worker for a live reattach target. Retry the path only
 after that entry disappears.
@@ -296,7 +303,8 @@ In the response `error` field, machine-matchable:
 
 - `unknown_session`
 - `session_closing`
-- `session_path_in_use` (path held by an opening, closing, quarantined, or superseded owner; a fully-open current owner is attached instead)
+- `session_path_in_use` (path held by an opening, closing, or quarantined owner; a fully-open current owner is attached instead, and a path a live owner has superseded is released rather than held)
+- `session_reservation_limit` (this worker already holds 64 live session paths; the open or session replacement was refused without disturbing the existing session)
 - `missing_session_id` (session-scoped command without `sessionId` in multi mode)
 - `multi_session_disabled` (`open_session` in classic mode)
 - `invalid_path` (relative `sessionPath`/`cwd`)
@@ -313,7 +321,7 @@ Strict FIFO per session; one total stdout order; cross-session order unspecified
 
 ### Duplicate/idempotency
 
-Duplicate `open_session` while a path reservation is held by a fully-open session → ATTACH (`attached: true`, same handle); while held by an `opening`/`closing` entry (including internal quarantine) → `session_path_in_use`. `close_session` releases one attachment; the runtime is disposed only when the last attachment closes. A close for an entry already `closing` joins its in-flight teardown. `close_session` on unknown/already-closed → `unknown_session` error. The grace window is configurable by the host through `SENPI_RPC_CLOSE_GRACE_MS`. Request `id`s are client-owned; the server echoes them without dedup.
+Duplicate `open_session` while a path reservation is held by a fully-open session → ATTACH (`attached: true`, same handle); while held by an `opening`/`closing` entry (including internal quarantine) → `session_path_in_use`. A path whose owner has already replaced it with another session file is no longer held: that open allocates a new worker and resumes the file. `close_session` releases one attachment; the runtime is disposed only when the last attachment closes. A close for an entry already `closing` joins its in-flight teardown. `close_session` on unknown/already-closed → `unknown_session` error. The grace window is configurable by the host through `SENPI_RPC_CLOSE_GRACE_MS`. Request `id`s are client-owned; the server echoes them without dedup.
 
 ## Protocol Overview
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -13,7 +13,7 @@ import { type ExtensionRunner, emitSessionShutdownEvent } from "./extensions/run
 import type { CreateAgentSessionResult } from "./sdk.ts";
 import { assertSessionCwdExists } from "./session-cwd.ts";
 import { SessionManager } from "./session-manager.ts";
-import { reserveSessionWrite } from "./session-write-reservation.ts";
+import { reserveSessionWrite, unregisterSessionWriter } from "./session-write-reservation.ts";
 
 /**
  * Result returned by runtime creation.
@@ -206,7 +206,11 @@ export class AgentSessionRuntime {
 			targetSessionFile,
 		});
 		this.beforeSessionInvalidate?.();
+		const replaced = this.session.sessionManager;
 		this.session.dispose();
+		// Nothing writes to the replaced manager once its session is disposed, so the
+		// shared host may hand its session file to another worker.
+		unregisterSessionWriter(replaced);
 	}
 
 	private async reportRemovedExtensions(): Promise<void> {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,38 @@
 # changes
 
+## 2026-09-12 - Bind session-write grants to live writers (senpi#1612)
+
+### What changed
+
+- `packages/coding-agent/src/core/session-write-reservation.ts` adds a live-writer registry
+  (`registerSessionWriter`, `unregisterSessionWriter`, `liveSessionWritePaths`) that holds owners
+  weakly, prunes collected ones on enumeration, and reports the current session file of every live
+  persisted writer.
+- `packages/coding-agent/src/core/session-manager.ts` registers every persisted manager in its
+  constructor, and splits `newSession()` into `_resetToNewSession()` (state reset and header, no
+  path work) plus the path allocation. `_setSessionFile()` now resets in place for a missing or
+  empty explicit file instead of allocating and reserving a second path it immediately discards.
+- `packages/coding-agent/src/core/agent-session-runtime.ts` unregisters the replaced session
+  manager after `teardownCurrent()` disposes it, so a superseded session file has no live writer.
+- `packages/coding-agent/test/suite/regressions/1612-session-manager-single-reservation.test.ts`
+  pins that opening a missing or zero-byte session file reserves exactly that one path.
+
+### Why
+
+- Under the shared RPC host every reservation was permanent, so a long-lived session died at the
+  64-path worker budget with `session_path_in_use`, and each explicit open burned two grants
+  instead of one. Ownership now follows the writer that actually exists.
+
+### Why an extension could not handle it
+
+- `SessionManager` and the runtime replacement path own session-file writes below the extension
+  boundary; the grant is taken synchronously before any extension observes the new session.
+
+### Expected merge conflict zones
+
+- MEDIUM: `session-manager.ts` around `newSession()` / `_setSessionFile()`.
+- LOW: the `teardownCurrent()` tail in `agent-session-runtime.ts` and the reservation module.
+
 ## 2026-09-11 - Batch persisted entry hydration after resident-string eviction (senpi#1407)
 
 ### What changed

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -21,7 +21,7 @@ import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { listSessionInfos, listSessionsFromDir, type SessionListProgress } from "./session-discovery.ts";
 import { materializeSessionEntries } from "./session-entry-materializer.ts";
 import { type ResidentStoreStats, ResidentStringStore } from "./session-resident-store.ts";
-import { reserveSessionWrite } from "./session-write-reservation.ts";
+import { registerSessionWriter, reserveSessionWrite } from "./session-write-reservation.ts";
 
 export type { SessionListProgress } from "./session-discovery.ts";
 
@@ -906,6 +906,9 @@ export class SessionManager {
 		this.cwd = resolvePath(cwd);
 		this.sessionDir = normalizePath(sessionDir);
 		this.persist = persist;
+		// A persisted manager owns its session file for as long as it lives; the shared
+		// RPC host reads this registry to release grants no writer holds anymore.
+		if (persist) registerSessionWriter(this);
 		if (persist && this.sessionDir && !existsSync(this.sessionDir)) {
 			mkdirSync(this.sessionDir, { recursive: true });
 		}
@@ -954,8 +957,9 @@ export class SessionManager {
 				if (statSync(explicitPath).size > 0) {
 					throw new Error(`Session file is not a valid ${APP_NAME} session: ${explicitPath}`);
 				}
-				this.newSession();
-				this.sessionFile = explicitPath;
+				// The explicit path is already granted above and keeps being written here:
+				// allocating a second path would take a grant no writer ever uses.
+				this._resetToNewSession();
 				this._rewriteFile();
 				this.flushed = true;
 				return;
@@ -973,13 +977,24 @@ export class SessionManager {
 			this.mutationCount++;
 			this.flushed = true;
 		} else {
-			const explicitPath = this.sessionFile;
-			this.newSession();
-			this.sessionFile = explicitPath; // preserve explicit path from --session flag
+			// Same here: the explicit path from --session stays the only granted one.
+			this._resetToNewSession();
 		}
 	}
 
 	newSession(options?: NewSessionOptions): string | undefined {
+		const timestamp = this._resetToNewSession(options);
+		if (this.persist) {
+			const fileTimestamp = timestamp.replace(/[:.]/g, "-");
+			const path = join(this.getSessionDir(), `${fileTimestamp}_${this.sessionId}.jsonl`);
+			reserveSessionWrite(path);
+			this.sessionFile = path;
+		}
+		return this.sessionFile;
+	}
+
+	/** Resets every in-memory field onto a fresh header. Allocates no session path. */
+	private _resetToNewSession(options?: NewSessionOptions): string {
 		if (options?.id !== undefined) {
 			assertValidSessionId(options.id);
 		}
@@ -1013,14 +1028,7 @@ export class SessionManager {
 		};
 		this.mutationCount++;
 		this.flushed = false;
-
-		if (this.persist) {
-			const fileTimestamp = timestamp.replace(/[:.]/g, "-");
-			const path = join(this.getSessionDir(), `${fileTimestamp}_${this.sessionId}.jsonl`);
-			reserveSessionWrite(path);
-			this.sessionFile = path;
-		}
-		return this.sessionFile;
+		return timestamp;
 	}
 
 	private _buildIndex(): void {

--- a/packages/coding-agent/src/core/session-write-reservation.ts
+++ b/packages/coding-agent/src/core/session-write-reservation.ts
@@ -10,3 +10,43 @@ export function installSessionWriteReservation(reservation: (path: string) => vo
 export function reserveSessionWrite(path: string): void {
 	reserve?.(path);
 }
+
+/** A session writer whose grant must live exactly as long as the writer itself. */
+export interface SessionWriterOwner {
+	getSessionFile(): string | undefined;
+	isPersisted(): boolean;
+}
+
+// Weak on purpose: a writer nobody references anymore writes nothing, so its grant must not
+// be kept alive by this registry. Identity removal needs the same ref the set holds.
+const liveWriters = new Set<WeakRef<SessionWriterOwner>>();
+const writerRefs = new WeakMap<SessionWriterOwner, WeakRef<SessionWriterOwner>>();
+
+export function registerSessionWriter(owner: SessionWriterOwner): void {
+	if (writerRefs.has(owner)) return;
+	const ref = new WeakRef(owner);
+	writerRefs.set(owner, ref);
+	liveWriters.add(ref);
+}
+
+export function unregisterSessionWriter(owner: SessionWriterOwner): void {
+	const ref = writerRefs.get(owner);
+	if (!ref) return;
+	writerRefs.delete(owner);
+	liveWriters.delete(ref);
+}
+
+/** Session files still owned by a live persisted writer; collected writers are pruned here. */
+export function liveSessionWritePaths(): string[] {
+	const paths: string[] = [];
+	for (const ref of liveWriters) {
+		const owner = ref.deref();
+		if (!owner) {
+			liveWriters.delete(ref);
+			continue;
+		}
+		const path = owner.isPersisted() ? owner.getSessionFile() : undefined;
+		if (path) paths.push(path);
+	}
+	return paths;
+}

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,48 @@
 # changes
 
+## 2026-09-12 - Release session-write grants a worker no longer holds (senpi#1612)
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/session-path-reservations.ts` is the new owner of canonical
+  path ownership: it grants, counts, reconciles against a worker's live writers, and reports
+  `granted` / `conflict` / `limit` with the wire code each denial maps to.
+- `packages/coding-agent/src/modes/rpc/worker-session-registry.ts` reconciles a fully open entry on
+  every snapshot (releasing superseded paths and re-keying the entry), reconciles once more before
+  denying a full budget, exposes `reservationCount(handle)`, and only maps an opening spelling to a
+  grant that is still held. Opening, closing and quarantined entries keep every path until exit.
+- `packages/coding-agent/src/modes/rpc/session-worker-protocol.ts` carries `liveSessionPaths` on
+  `WorkerSnapshot` and names the wait-signal codes (`WORKER_CREDIT_CODES`, `SessionWriteGrant`).
+- `packages/coding-agent/src/modes/rpc/session-worker.ts` publishes those live paths and delegates
+  its blocking host exchanges to the new
+  `packages/coding-agent/src/modes/rpc/session-worker-credit.ts`, which reports an exhausted budget
+  as `session_reservation_limit` and a held path as `session_path_in_use`.
+- `packages/coding-agent/src/modes/rpc/session-worker-client.ts` gains the `reconcile` callback,
+  answers a reservation with the host's grant, and encodes wait signals through the new
+  `packages/coding-agent/src/modes/rpc/session-worker-signals.ts`.
+- `packages/coding-agent/src/modes/rpc/rpc-types.ts` and `session-registry.ts` add the
+  `session_reservation_limit` error code; `packages/coding-agent/docs/rpc.md` documents the
+  release-on-supersede semantics and the new code.
+- `packages/coding-agent/test/suite/regressions/1612-rpc-session-grant-release.test.ts` pins 70
+  consecutive `new_session` commands on one worker, the superseded path reopening in a new worker,
+  the budget-versus-conflict denial codes, and the live-writer registry.
+
+### Why
+
+- Grants were held for a worker's whole lifetime, so a long-lived session died at the 64-path cap
+  with `session_path_in_use` and its earlier session files stayed unopenable for the host's life.
+
+### Why an extension could not handle it
+
+- Path grants, worker snapshots and the shared host's reservation budget live in the RPC transport
+  layer, above the worker isolate an extension runs in.
+
+### Expected merge conflict zones
+
+- MEDIUM: `worker-session-registry.ts` reserve/attach bookkeeping.
+- LOW: the `session-worker.ts` credit exchange, the client's `receive` switch, and the
+  `WorkerSnapshot` shape.
+
 ## 2026-09-12 - Keep a live host whose identity probe is starved
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -175,6 +175,7 @@ type RpcSessionCommand =
 export const RPC_ERROR_UNKNOWN_SESSION = "unknown_session";
 export const RPC_ERROR_SESSION_CLOSING = "session_closing";
 export const RPC_ERROR_SESSION_PATH_IN_USE = "session_path_in_use";
+export const RPC_ERROR_SESSION_RESERVATION_LIMIT = "session_reservation_limit";
 export const RPC_ERROR_MISSING_SESSION_ID = "missing_session_id";
 export const RPC_ERROR_MULTI_SESSION_DISABLED = "multi_session_disabled";
 export const RPC_ERROR_INVALID_PATH = "invalid_path";
@@ -191,6 +192,7 @@ export type RpcErrorCode =
 	| typeof RPC_ERROR_UNKNOWN_SESSION
 	| typeof RPC_ERROR_SESSION_CLOSING
 	| typeof RPC_ERROR_SESSION_PATH_IN_USE
+	| typeof RPC_ERROR_SESSION_RESERVATION_LIMIT
 	| typeof RPC_ERROR_MISSING_SESSION_ID
 	| typeof RPC_ERROR_MULTI_SESSION_DISABLED
 	| typeof RPC_ERROR_INVALID_PATH

--- a/packages/coding-agent/src/modes/rpc/session-path-reservations.ts
+++ b/packages/coding-agent/src/modes/rpc/session-path-reservations.ts
@@ -1,0 +1,61 @@
+import type { RpcSessionRegistryError } from "./session-registry.ts";
+import { SESSION_WORKER_LIMITS, type SessionWriteGrant } from "./session-worker-protocol.ts";
+
+/** What a worker still writes: the paths of its live session writers plus its current session path. */
+export interface LiveWorkerPaths {
+	readonly livePaths: readonly string[];
+	readonly sessionPath?: string;
+}
+
+/** Wire code each denial is reported with; distinct so clients can retry only the retryable one. */
+export const RESERVATION_DENIAL_CODES = {
+	conflict: "session_path_in_use",
+	limit: "session_reservation_limit",
+} as const satisfies Record<Exclude<SessionWriteGrant, "granted">, RpcSessionRegistryError["code"]>;
+
+/**
+ * Canonical session-path ownership for the shared host: one path, one worker handle.
+ *
+ * A grant lives as long as the writer that holds it. Reconciliation against a worker's
+ * reported live writers releases superseded paths, so a session replaced by /new, /resume
+ * or /fork no longer keeps its previous file hostage or spends the per-worker budget.
+ */
+export class SessionPathReservations {
+	private readonly owners = new Map<string, string>();
+
+	owner(path: string): string | undefined {
+		return this.owners.get(path);
+	}
+
+	count(handle: string): number {
+		let count = 0;
+		for (const owner of this.owners.values()) if (owner === handle) count++;
+		return count;
+	}
+
+	/** Grants `path` to `handle`; at the budget cap, the live view first releases superseded paths. */
+	reserve(handle: string, path: string, live?: LiveWorkerPaths): SessionWriteGrant {
+		const owner = this.owners.get(path);
+		if (owner) return owner === handle ? "granted" : "conflict";
+		if (this.count(handle) >= SESSION_WORKER_LIMITS.reservations) {
+			if (!live) return "limit";
+			this.reconcile(handle, live);
+			if (this.count(handle) >= SESSION_WORKER_LIMITS.reservations) return "limit";
+		}
+		this.owners.set(path, handle);
+		return "granted";
+	}
+
+	/** Releases every path of `handle` that none of its live writers owns anymore. */
+	reconcile(handle: string, live: LiveWorkerPaths): void {
+		for (const [path, owner] of this.owners) {
+			if (owner !== handle || path === live.sessionPath || live.livePaths.includes(path)) continue;
+			this.owners.delete(path);
+		}
+	}
+
+	/** Drops the whole budget of a handle; only a real worker exit may call this. */
+	releaseAll(handle: string): void {
+		for (const [path, owner] of this.owners) if (owner === handle) this.owners.delete(path);
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -34,6 +34,8 @@ export interface RpcSessionEntry {
 	sessionPath?: string;
 	/** Canonical reservation key for path-opened sessions; matches the reservations set. */
 	reservationKey?: string;
+	/** Key granted for the spelling this session was opened with; cleared once superseded. */
+	requestedPathKey?: string;
 	/** Current runtime cwd, which can change when a session is replaced. */
 	cwd: string;
 	/** Live attachments (open + later attaches). The runtime is disposed only when the last one closes. */
@@ -47,7 +49,13 @@ export interface RpcSessionEntry {
 }
 
 export class RpcSessionRegistryError extends Error {
-	readonly code: "unknown_session" | "session_closing" | "session_path_in_use" | "invalid_path" | "open_failed";
+	readonly code:
+		| "unknown_session"
+		| "session_closing"
+		| "session_path_in_use"
+		| "session_reservation_limit"
+		| "invalid_path"
+		| "open_failed";
 
 	constructor(code: RpcSessionRegistryError["code"], reason?: string) {
 		super(code === "open_failed" && reason ? `${code}: ${reason}` : code);

--- a/packages/coding-agent/src/modes/rpc/session-worker-client.ts
+++ b/packages/coding-agent/src/modes/rpc/session-worker-client.ts
@@ -9,11 +9,22 @@ import type { RpcSessionLaunchProfile } from "./session-registry.ts";
 import type {
 	HostToSessionWorker,
 	SessionWorkerToHost,
+	SessionWriteGrant,
 	WorkerDisplay,
 	WorkerSnapshot,
 } from "./session-worker-protocol.ts";
 
 import { SessionWorkerRequests, type WorkerRequestInput } from "./session-worker-requests.ts";
+import { acknowledge, acknowledgeGrant, respondDisplay } from "./session-worker-signals.ts";
+
+/** Lifecycle hooks the owning registry installs on every worker it allocates. */
+export interface SessionWorkerCallbacks {
+	reserve: (path: string) => SessionWriteGrant;
+	/** Every snapshot republishes which paths this worker still writes. */
+	reconcile: (livePaths: readonly string[]) => void;
+	exit: () => void;
+	failure: (error: string) => void;
+}
 
 /** Bun wrapper builders define the worker entry name relative to their explicit --root. */
 declare const SENPI_RPC_SESSION_WORKER_ENTRY: string | undefined;
@@ -47,13 +58,9 @@ export class SessionWorkerClient {
 	private readonly controls = new Set<"display" | "cancel_ui">();
 	private latestDisplay?: Extract<HostToSessionWorker, { type: "display" }>;
 
-	private readonly callbacks: {
-		reserve: (path: string) => boolean;
-		exit: () => void;
-		failure: (error: string) => void;
-	};
+	private readonly callbacks: SessionWorkerCallbacks;
 
-	constructor(callbacks: { reserve: (path: string) => boolean; exit: () => void; failure: (error: string) => void }) {
+	constructor(callbacks: SessionWorkerCallbacks) {
 		this.callbacks = callbacks;
 		this.exited = new Promise((resolve) => {
 			this.worker.once("exit", () => {
@@ -159,24 +166,9 @@ export class SessionWorkerClient {
 		this.worker.postMessage(message);
 	}
 
-	private acknowledge(signal: SharedArrayBuffer, granted: boolean): void {
-		const state = new Int32Array(signal);
-		Atomics.store(state, 0, granted ? 1 : 2);
-		Atomics.notify(state, 0);
-	}
-
-	private respondDisplay(signal: SharedArrayBuffer): void {
-		const display = this.display();
-		const values = new Float64Array(signal);
-		values[1] = display.width;
-		values[2] = display.revision;
-		Atomics.store(new Int32Array(signal), 1, display.rendered ? 1 : 0);
-		this.acknowledge(signal, true);
-	}
-
 	private receive(message: SessionWorkerToHost): void {
 		if (this.stopped) {
-			if ("signal" in message) this.acknowledge(message.signal, false);
+			if ("signal" in message) acknowledge(message.signal, false);
 			return;
 		}
 		switch (message.type) {
@@ -187,11 +179,12 @@ export class SessionWorkerClient {
 				return;
 			}
 			case "reserve":
-				this.acknowledge(message.signal, !this.stopped && this.callbacks.reserve(message.path));
+				acknowledgeGrant(message.signal, this.callbacks.reserve(message.path));
 				return;
 			case "snapshot":
 				this.snapshot = message.snapshot;
-				this.acknowledge(message.signal, !this.stopped);
+				this.callbacks.reconcile(message.snapshot.liveSessionPaths);
+				acknowledge(message.signal, true);
 				if (message.settled) for (const listener of [...this.listeners]) listener();
 				return;
 			case "control_done": {
@@ -207,12 +200,14 @@ export class SessionWorkerClient {
 				const writer = this.writer;
 				const sessionId = this.sessionId;
 				if (!writer || !sessionId || this.stopped) {
-					this.acknowledge(message.signal, false);
+					acknowledge(message.signal, false);
 					return;
 				}
 				// Identity and activity commit before publication; clients may attach or disconnect on that event.
-				if (message.snapshot) this.snapshot = message.snapshot;
-				else if (this.snapshot)
+				if (message.snapshot) {
+					this.snapshot = message.snapshot;
+					this.callbacks.reconcile(message.snapshot.liveSessionPaths);
+				} else if (this.snapshot)
 					this.snapshot = {
 						...this.snapshot,
 						...message.activity,
@@ -220,7 +215,7 @@ export class SessionWorkerClient {
 					};
 				const enqueue = () => {
 					if (!writer.enqueue(sessionId, message.record)) {
-						this.acknowledge(message.signal, false);
+						acknowledge(message.signal, false);
 						this.fail("session_output_overflow_or_closed");
 						return Promise.reject(new Error("session_output_overflow_or_closed"));
 					}
@@ -229,9 +224,9 @@ export class SessionWorkerClient {
 				const consumed =
 					message.connection === undefined ? enqueue() : writer.withConnection(message.connection, enqueue);
 				void consumed.then(
-					() => this.acknowledge(message.signal, true),
+					() => acknowledge(message.signal, true),
 					(cause: unknown) => {
-						this.acknowledge(message.signal, false);
+						acknowledge(message.signal, false);
 						this.fail(cause instanceof Error ? cause.message : String(cause));
 					},
 				);
@@ -240,11 +235,11 @@ export class SessionWorkerClient {
 			case "width":
 				this.options.sharedWidth?.setWidth(message.connection, message.width);
 				this.options.sharedWidth?.onChange?.();
-				this.respondDisplay(message.signal);
+				respondDisplay(message.signal, this.display());
 				return;
 			case "capabilities":
 				this.options.sharedWidth?.setCapabilities?.(message.connection, message.capabilities);
-				this.respondDisplay(message.signal);
+				respondDisplay(message.signal, this.display());
 				return;
 			case "request_close":
 				this.requestClose?.();

--- a/packages/coding-agent/src/modes/rpc/session-worker-credit.ts
+++ b/packages/coding-agent/src/modes/rpc/session-worker-credit.ts
@@ -1,0 +1,50 @@
+import { installSessionWriteReservation } from "../../core/session-write-reservation.ts";
+import { SESSION_WORKER_LIMITS, type SessionWorkerToHost, WORKER_CREDIT_CODES } from "./session-worker-protocol.ts";
+
+/** Builds the host message around the wait signal it must carry. */
+export type CreditRequest = (signal: SharedArrayBuffer) => SessionWorkerToHost;
+
+export interface WorkerCredit {
+	/** Blocks the worker until the host answers; a denial fails the worker with `deniedError`. */
+	exchange(message: CreditRequest, deniedError?: string, signal?: SharedArrayBuffer): void;
+	/** Installs the isolate's session-write grant, reporting denials as domain errors. */
+	installWriteReservation(canonical: (path: string) => string): void;
+}
+
+/**
+ * Synchronous host credit for a session worker.
+ *
+ * Every exchange blocks the worker thread on its own wait signal, so the host answers
+ * before the worker touches a writer, publishes output, or resizes a display.
+ */
+export function createWorkerCredit(
+	send: (message: SessionWorkerToHost) => void,
+	fail: (error: string) => never,
+): WorkerCredit {
+	const request = (message: CreditRequest, signal: SharedArrayBuffer): number => {
+		const state = new Int32Array(signal);
+		send(message(signal));
+		Atomics.wait(state, 0, 0, SESSION_WORKER_LIMITS.controlMs);
+		return Atomics.load(state, 0);
+	};
+	return {
+		exchange(message, deniedError = "session_worker_output_denied", signal = new SharedArrayBuffer(4)) {
+			const result = request(message, signal);
+			if (result === WORKER_CREDIT_CODES.conflict) fail(deniedError);
+			if (result !== WORKER_CREDIT_CODES.granted) fail("session_worker_credit_timeout");
+		},
+		installWriteReservation(canonical) {
+			installSessionWriteReservation((path) => {
+				const result = request(
+					(signal) => ({ type: "reserve", path: canonical(path), signal }),
+					new SharedArrayBuffer(4),
+				);
+				// Both denials are session-level failures the caller reports, never worker-fatal:
+				// another owner holds the path, or this worker's own budget is exhausted.
+				if (result === WORKER_CREDIT_CODES.conflict) throw new Error("session_path_in_use");
+				if (result === WORKER_CREDIT_CODES.limit) throw new Error("session_reservation_limit");
+				if (result !== WORKER_CREDIT_CODES.granted) fail("session_worker_credit_timeout");
+			});
+		},
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/session-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/rpc/session-worker-protocol.ts
@@ -14,10 +14,18 @@ export const SESSION_WORKER_LIMITS = {
 	controlMs: 5_000,
 } as const;
 
+/** Wire values the host writes into a worker's wait signal; `conflict` is the generic denial. */
+export const WORKER_CREDIT_CODES = { granted: 1, conflict: 2, limit: 3 } as const;
+
+/** Host decision on a worker's session-write path request. */
+export type SessionWriteGrant = keyof typeof WORKER_CREDIT_CODES;
+
 export interface WorkerSnapshot {
 	state: RpcSessionState;
 	/** Canonicalized by the owning worker, never by the transport thread. */
 	sessionPath?: string;
+	/** Every canonical path this worker's live session writers still own. */
+	liveSessionPaths: readonly string[];
 	busy: boolean;
 	streaming: boolean;
 }

--- a/packages/coding-agent/src/modes/rpc/session-worker-signals.ts
+++ b/packages/coding-agent/src/modes/rpc/session-worker-signals.ts
@@ -1,0 +1,21 @@
+import { type SessionWriteGrant, WORKER_CREDIT_CODES, type WorkerDisplay } from "./session-worker-protocol.ts";
+
+/** Releases a worker blocked in Atomics.wait with the host's decision. */
+export function acknowledgeGrant(signal: SharedArrayBuffer, grant: SessionWriteGrant): void {
+	const state = new Int32Array(signal);
+	Atomics.store(state, 0, WORKER_CREDIT_CODES[grant]);
+	Atomics.notify(state, 0);
+}
+
+export function acknowledge(signal: SharedArrayBuffer, granted: boolean): void {
+	acknowledgeGrant(signal, granted ? "granted" : "conflict");
+}
+
+/** Publishes the host's current width and revision into a display exchange, then releases it. */
+export function respondDisplay(signal: SharedArrayBuffer, display: WorkerDisplay): void {
+	const values = new Float64Array(signal);
+	values[1] = display.width;
+	values[2] = display.revision;
+	Atomics.store(new Int32Array(signal), 1, display.rendered ? 1 : 0);
+	acknowledge(signal, true);
+}

--- a/packages/coding-agent/src/modes/rpc/session-worker.ts
+++ b/packages/coding-agent/src/modes/rpc/session-worker.ts
@@ -6,7 +6,7 @@ import { runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope"
 import { WAKE_SOURCE_STATE_EVENT } from "../../core/extensions/builtin/monitor-state-event.ts";
 import { takeOverStdout } from "../../core/output-guard.ts";
 import { getDefaultSessionDir } from "../../core/session-manager.ts";
-import { installSessionWriteReservation } from "../../core/session-write-reservation.ts";
+import { liveSessionWritePaths } from "../../core/session-write-reservation.ts";
 import { SettingsManager } from "../../core/settings-manager.ts";
 import { createCliRuntimeFactory } from "../../main.ts";
 import { initTheme } from "../interactive/theme/theme.ts";
@@ -14,6 +14,7 @@ import { buildRpcSessionState } from "./connection-handler.ts";
 import { createRpcSessionBinding, type RpcSessionBinding } from "./session-binding.ts";
 import { SessionEventWriter } from "./session-event-writer.ts";
 import { type RpcSessionEntry, RpcSessionRegistry } from "./session-registry.ts";
+import { createWorkerCredit } from "./session-worker-credit.ts";
 import {
 	type HostToSessionWorker,
 	SESSION_WORKER_LIMITS,
@@ -37,25 +38,8 @@ function canonicalPath(path: string): string {
 	return existsSync(absolute) ? realpathSync(absolute) : join(realpathSync(dirname(absolute)), basename(absolute));
 }
 
-function exchange(
-	message: (signal: SharedArrayBuffer) => SessionWorkerToHost,
-	deniedError = "session_worker_output_denied",
-	signal = new SharedArrayBuffer(4),
-): void {
-	const state = new Int32Array(signal);
-	send(message(signal));
-	Atomics.wait(state, 0, 0, SESSION_WORKER_LIMITS.controlMs);
-	const result = Atomics.load(state, 0);
-	if (result === 2) {
-		if (deniedError === "session_path_in_use") throw new Error(deniedError);
-		failWorker(deniedError);
-	}
-	if (result !== 1) failWorker("session_worker_credit_timeout");
-}
-
-installSessionWriteReservation((path) =>
-	exchange((signal) => ({ type: "reserve", path: canonicalPath(path), signal }), "session_path_in_use"),
-);
+const { exchange, installWriteReservation } = createWorkerCredit(send, failWorker);
+installWriteReservation(canonicalPath);
 
 class WorkerEventWriter extends SessionEventWriter {
 	constructor() {
@@ -138,9 +122,15 @@ function subscribeSession(): void {
 function snapshot(): WorkerSnapshot {
 	if (!entry?.runtime) throw new Error("Session runtime is not ready");
 	const session = entry.runtime.session;
+	const sessionPath = session.sessionFile ? canonicalPath(session.sessionFile) : undefined;
+	// The host releases every granted path this list omits, so it must name each writer
+	// still alive in this isolate, plus the session the runtime currently writes.
+	const live = new Set(liveSessionWritePaths().map(canonicalPath));
+	if (sessionPath) live.add(sessionPath);
 	return {
 		state: buildRpcSessionState(session),
-		sessionPath: session.sessionFile ? canonicalPath(session.sessionFile) : undefined,
+		sessionPath,
+		liveSessionPaths: [...live],
 		busy: session.isSessionBusy,
 		streaming: session.isStreaming,
 	};

--- a/packages/coding-agent/src/modes/rpc/worker-session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/worker-session-registry.ts
@@ -2,18 +2,23 @@ import { isAbsolute } from "node:path";
 import { ProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import type { CliRuntimeConfiguration } from "../../main.ts";
 import {
+	type LiveWorkerPaths,
+	RESERVATION_DENIAL_CODES,
+	SessionPathReservations,
+} from "./session-path-reservations.ts";
+import {
 	type OpenRpcSession,
 	type RpcSessionEntry,
 	type RpcSessionLaunchProfile,
 	RpcSessionRegistryError,
 } from "./session-registry.ts";
 import { SessionWorkerClient } from "./session-worker-client.ts";
-import { SESSION_WORKER_LIMITS } from "./session-worker-protocol.ts";
+import { SESSION_WORKER_LIMITS, type SessionWriteGrant } from "./session-worker-protocol.ts";
 
 /** Transport-side lifecycle owner. Caller paths are never inspected on this event loop. */
 export class WorkerSessionRegistry {
 	private readonly entries = new Map<string, RpcSessionEntry>();
-	private readonly reservations = new Map<string, string>();
+	private readonly reservations = new SessionPathReservations();
 	private serial = 0;
 	readonly closeGraceMs: number;
 	private readonly now: () => number;
@@ -35,7 +40,7 @@ export class WorkerSessionRegistry {
 			throw new RpcSessionRegistryError("invalid_path");
 		if (profile.sessionPath) {
 			const key = this.knownReservationKey(profile.sessionPath);
-			const owner = key ? this.reservations.get(key) : undefined;
+			const owner = key ? this.reservations.owner(key) : undefined;
 			if (key && owner) return this.attach(owner, key);
 		}
 		if (this.size >= SESSION_WORKER_LIMITS.workers) throw new Error("too_many_sessions");
@@ -51,11 +56,12 @@ export class WorkerSessionRegistry {
 		};
 		const worker = new SessionWorkerClient({
 			reserve: (path) => this.reserve(handle, path),
+			reconcile: (livePaths) => this.reconcile(handle, livePaths),
 			exit: () => {
 				if (this.entries.get(handle) !== entry) return;
 				entry.state = "closed";
 				this.entries.delete(handle);
-				for (const [path, owner] of this.reservations) if (owner === handle) this.reservations.delete(path);
+				this.reservations.releaseAll(handle);
 				entry.closeResolve?.();
 			},
 			failure: (error) => {
@@ -67,15 +73,17 @@ export class WorkerSessionRegistry {
 		this.entries.set(handle, entry);
 		try {
 			const path = await worker.prepare(this.options.configuration, profile);
-			const owner = this.reservations.get(path);
+			const owner = this.reservations.owner(path);
 			if (owner) {
 				const attached = this.attach(owner, path);
 				entry.state = "quarantined";
 				worker.quarantine();
 				return attached;
 			}
-			if (!this.reserve(handle, path)) throw new RpcSessionRegistryError("session_path_in_use");
+			const grant = this.reserve(handle, path);
+			if (grant !== "granted") throw new RpcSessionRegistryError(RESERVATION_DENIAL_CODES[grant]);
 			entry.reservationKey = path;
+			entry.requestedPathKey = profile.sessionPath ? path : undefined;
 			entry.sessionPath = path;
 			const snapshot = await worker.commit();
 			if (entry.state !== "opening") throw new RpcSessionRegistryError("session_closing");
@@ -173,9 +181,16 @@ export class WorkerSessionRegistry {
 
 	/** Only compare spellings already tied to a granted identity; do not inspect caller paths here. */
 	private knownReservationKey(path: string): string | undefined {
-		if (this.reservations.has(path)) return path;
+		if (this.reservations.owner(path)) return path;
 		for (const entry of this.entries.values()) {
-			if (entry.profile.sessionPath === path && entry.reservationKey) return entry.reservationKey;
+			// An opening spelling maps only while the key granted for it is still held: a
+			// superseded path belongs to nobody and must open its own worker.
+			if (
+				entry.profile.sessionPath === path &&
+				entry.requestedPathKey &&
+				this.reservations.owner(entry.requestedPathKey)
+			)
+				return entry.requestedPathKey;
 			const snapshot = entry.worker?.snapshot;
 			if (snapshot?.state.sessionFile === path) return snapshot.sessionPath;
 		}
@@ -192,17 +207,41 @@ export class WorkerSessionRegistry {
 		return { ...result, attached: true };
 	}
 
-	private reserve(handle: string, path: string): boolean {
+	/** Granted paths currently held by a handle; the per-worker budget is bounded by it. */
+	reservationCount(handle: string): number {
+		return this.reservations.count(handle);
+	}
+
+	private reserve(handle: string, path: string): SessionWriteGrant {
 		const entry = this.entries.get(handle);
-		if (!entry) return false;
-		const owner = this.reservations.get(path);
-		if (owner) return owner === handle;
-		if (entry.state !== "opening" && entry.state !== "open") return false;
-		let count = 0;
-		for (const current of this.reservations.values()) if (current === handle) count++;
-		if (count >= SESSION_WORKER_LIMITS.reservations) return false;
-		this.reservations.set(path, handle);
-		return true;
+		if (!entry) return "conflict";
+		if (this.reservations.owner(path) === handle) return "granted";
+		if (entry.state !== "opening" && entry.state !== "open") return "conflict";
+		return this.reservations.reserve(handle, path, this.liveWorkerPaths(entry));
+	}
+
+	/**
+	 * Releases the grants a worker's latest snapshot no longer claims.
+	 *
+	 * Only a fully open entry reports live writers. An entry still opening, closing or
+	 * quarantined keeps every grant until its real exit, because a worker stuck in a
+	 * syscall can still be writing a path it can no longer report.
+	 */
+	private reconcile(handle: string, livePaths: readonly string[]): void {
+		const entry = this.entries.get(handle);
+		if (entry?.state !== "open") return;
+		const sessionPath = entry.worker?.snapshot?.sessionPath;
+		this.reservations.reconcile(handle, { livePaths, sessionPath });
+		if (!sessionPath) return;
+		entry.reservationKey = sessionPath;
+		entry.sessionPath = sessionPath;
+	}
+
+	/** The live view a full budget is reconciled against; absent while the entry cannot report one. */
+	private liveWorkerPaths(entry: RpcSessionEntry): LiveWorkerPaths | undefined {
+		const snapshot = entry.state === "open" ? entry.worker?.snapshot : undefined;
+		if (!snapshot) return undefined;
+		return { livePaths: snapshot.liveSessionPaths, sessionPath: snapshot.sessionPath };
 	}
 
 	private openResult(handle: string, entry: RpcSessionEntry): OpenRpcSession {

--- a/packages/coding-agent/test/suite/regressions/1612-rpc-session-grant-release.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1612-rpc-session-grant-release.test.ts
@@ -1,0 +1,188 @@
+// Regression for senpi issue #1612: shared-host session-write grants were held for the
+// worker's entire lifetime, so a long-lived session died at the 64-path reservation cap
+// with session_path_in_use, and a superseded path stayed unopenable forever.
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+	liveSessionWritePaths,
+	registerSessionWriter,
+	type SessionWriterOwner,
+	unregisterSessionWriter,
+} from "../../../src/core/session-write-reservation.ts";
+import { RESERVATION_DENIAL_CODES, SessionPathReservations } from "../../../src/modes/rpc/session-path-reservations.ts";
+import { SESSION_WORKER_LIMITS, type SessionWriteGrant } from "../../../src/modes/rpc/session-worker-protocol.ts";
+import { reservationPhase as phase, reservationHost } from "../rpc-worker-reservation-support.ts";
+
+const responseSchema = z.object({ id: z.string(), success: z.boolean(), error: z.string().optional() });
+
+/** Ids of the published responses that reported success, in publication order. */
+function acceptedResponseIds(records: readonly unknown[]): string[] {
+	return records.flatMap((record) => {
+		const parsed = responseSchema.safeParse(record);
+		return parsed.success && parsed.data.success ? [parsed.data.id] : [];
+	});
+}
+
+/** The wire code a grant is reported with; a granted path reports nothing. */
+function denialCode(grant: SessionWriteGrant): string | undefined {
+	return grant === "granted" ? undefined : RESERVATION_DENIAL_CODES[grant];
+}
+
+/** `<id>: <error>` for every published failure, so a rejection names its own cause. */
+function rejectedResponses(records: readonly unknown[]): string[] {
+	return records.flatMap((record) => {
+		const parsed = responseSchema.safeParse(record);
+		return parsed.success && !parsed.data.success ? [`${parsed.data.id}: ${parsed.data.error}`] : [];
+	});
+}
+
+const header = (id: string, cwd: string): string =>
+	`${JSON.stringify({ type: "session", version: 3, id, timestamp: new Date(0).toISOString(), cwd })}\n`;
+
+/** The router answers a routed command only when it fails; success is published to the writer. */
+function expectAccepted(response: unknown, label: string): void {
+	expect(response, `${label} was rejected`).toBeUndefined();
+}
+
+async function scratchHost(name: string) {
+	const scratch = await realpath(await mkdtemp(join(tmpdir(), `senpi-1612-${name}-`)));
+	const cwd = join(scratch, "cwd");
+	const agentDir = join(scratch, "agent");
+	await mkdir(cwd);
+	await mkdir(agentDir);
+	vi.stubEnv("SENPI_OFFLINE", "1");
+	return { scratch, cwd, agentDir, host: reservationHost(cwd, agentDir) };
+}
+
+it("keeps granting session files when one session is replaced past the reservation cap", async () => {
+	// Given: a single worker session opened on an existing session file.
+	const { scratch, cwd, host } = await scratchHost("cap");
+	const sessionPath = join(scratch, "long-lived.jsonl");
+	await writeFile(sessionPath, header("long-lived-durable", cwd));
+	host.connect("long-lived");
+	try {
+		expectAccepted(
+			await phase("open", host.send("long-lived", { id: "open", type: "open_session", cwd, sessionPath })),
+			"open_session",
+		);
+		const [opened] = host.registry.list();
+		if (!opened) throw new Error("open_session did not register a session");
+
+		// When: the client replaces that session more often than the per-worker cap.
+		const rounds = Array.from({ length: 70 }, (_value, index) => `new-${index}`);
+		for (const round of rounds) {
+			const response = await phase(
+				round,
+				host.send("long-lived", { id: round, type: "new_session", sessionId: opened.sessionId }),
+			);
+			// Then: every replacement is granted its new session file.
+			expectAccepted(response, `new_session ${round}`);
+		}
+		await host.writer.flush();
+		expect(rejectedResponses(host.records)).toEqual([]);
+		const accepted = new Set(acceptedResponseIds(host.records));
+		expect(rounds.filter((round) => !accepted.has(round))).toEqual([]);
+
+		// Then: superseded grants were released instead of accumulating.
+		expect(host.registry.reservationCount(opened.sessionId)).toBeLessThanOrEqual(3);
+	} finally {
+		await host.dispose();
+		vi.unstubAllEnvs();
+		await rm(scratch, { recursive: true, force: true });
+	}
+}, 180_000);
+
+it("releases a superseded session file to a new worker", async () => {
+	// Given: a session opened on an existing file that is then replaced by /new.
+	const { scratch, cwd, host } = await scratchHost("supersede");
+	const sessionPath = join(scratch, "superseded.jsonl");
+	await writeFile(sessionPath, header("superseded-durable", cwd));
+	host.connect("first");
+	host.connect("second");
+	try {
+		expectAccepted(
+			await phase("open", host.send("first", { id: "open", type: "open_session", cwd, sessionPath })),
+			"open_session",
+		);
+		const [opened] = host.registry.list();
+		if (!opened) throw new Error("open_session did not register a session");
+		expectAccepted(
+			await phase(
+				"supersede",
+				host.send("first", { id: "supersede", type: "new_session", sessionId: opened.sessionId }),
+			),
+			"new_session",
+		);
+
+		// When: another connection opens the file the first worker no longer writes.
+		const reopened = await phase(
+			"reopen",
+			host.send("second", { id: "reopen", type: "open_session", cwd, sessionPath }),
+		);
+
+		// Then: it gets its own worker instead of session_path_in_use or an attach.
+		expectAccepted(reopened, "second open_session");
+		const resumed = host.registry.list().find((entry) => entry.durableSessionId === "superseded-durable");
+		expect(resumed?.sessionId).toBeDefined();
+		expect(resumed?.sessionId).not.toBe(opened.sessionId);
+		expect(host.registry.size).toBe(2);
+		expect(host.workers.size).toBe(2);
+	} finally {
+		await host.dispose();
+		vi.unstubAllEnvs();
+		await rm(scratch, { recursive: true, force: true });
+	}
+}, 120_000);
+
+it("separates an exhausted reservation budget from a path another worker owns", () => {
+	// Given: one handle holding the whole per-worker budget, every path still live.
+	const reservations = new SessionPathReservations();
+	const live: string[] = [];
+	for (let index = 0; index < SESSION_WORKER_LIMITS.reservations; index++) {
+		const path = `/live/session-${index}.jsonl`;
+		live.push(path);
+		expect(reservations.reserve("rpc-1", path, { livePaths: live, sessionPath: path })).toBe("granted");
+	}
+
+	// When: that handle asks for one more path and another handle asks for a held one.
+	const exhausted = reservations.reserve("rpc-1", "/live/overflow.jsonl", { livePaths: live });
+	const taken = reservations.reserve("rpc-2", "/live/session-0.jsonl", { livePaths: [] });
+
+	// Then: the budget denial and the ownership denial map to distinct wire codes.
+	expect(exhausted).toBe("limit");
+	expect(taken).toBe("conflict");
+	expect(denialCode(exhausted)).toBe("session_reservation_limit");
+	expect(denialCode(taken)).toBe("session_path_in_use");
+	expect(reservations.count("rpc-1")).toBe(SESSION_WORKER_LIMITS.reservations);
+
+	// And: once the worker reports only one live writer, the budget frees itself.
+	const current = "/live/session-0.jsonl";
+	expect(
+		reservations.reserve("rpc-1", "/live/after-supersede.jsonl", { livePaths: [current], sessionPath: current }),
+	).toBe("granted");
+	expect(reservations.count("rpc-1")).toBe(2);
+});
+
+it("reports live persisted writers at their current session file", () => {
+	// Given: two registered writers under a prefix owned by this test.
+	const prefix = "/live-writers-1612/";
+	let movable = `${prefix}first.jsonl`;
+	const first: SessionWriterOwner = { getSessionFile: () => movable, isPersisted: () => true };
+	const second: SessionWriterOwner = { getSessionFile: () => `${prefix}second.jsonl`, isPersisted: () => true };
+	const owned = () => liveSessionWritePaths().filter((path) => path.startsWith(prefix));
+	registerSessionWriter(first);
+	registerSessionWriter(second);
+	expect(owned().sort()).toEqual([`${prefix}first.jsonl`, `${prefix}second.jsonl`]);
+
+	// When: one writer is unregistered and the other moves to a new file.
+	unregisterSessionWriter(second);
+	movable = `${prefix}first-replaced.jsonl`;
+
+	// Then: only the remaining writer is reported, at its current path.
+	expect(owned()).toEqual([`${prefix}first-replaced.jsonl`]);
+	unregisterSessionWriter(first);
+	expect(owned()).toEqual([]);
+});

--- a/packages/coding-agent/test/suite/regressions/1612-session-manager-single-reservation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1612-session-manager-single-reservation.test.ts
@@ -1,0 +1,49 @@
+// Regression for senpi issue #1612: opening an explicit session file allocated a second,
+// phantom session path whose host grant was taken and then discarded, burning the shared
+// host's per-worker reservation budget. The installer is process-wide, so this contract
+// owns its own test file.
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, expect, it } from "vitest";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { installSessionWriteReservation } from "../../../src/core/session-write-reservation.ts";
+
+const reserved: string[] = [];
+installSessionWriteReservation((path) => {
+	reserved.push(path);
+});
+
+const scratch = await realpath(await mkdtemp(join(tmpdir(), "senpi-1612-session-manager-")));
+
+beforeEach(() => {
+	reserved.length = 0;
+});
+
+afterAll(async () => {
+	await rm(scratch, { recursive: true, force: true });
+});
+
+it("reserves only the explicit path when the session file does not exist yet", () => {
+	// Given: an absolute session path with nothing on disk.
+	const sessionFile = join(scratch, "fresh.jsonl");
+
+	// When: the manager opens it the way --session and open_session do.
+	SessionManager.open(sessionFile);
+
+	// Then: no second session path was ever granted.
+	expect([...new Set(reserved)]).toEqual([sessionFile]);
+});
+
+it("reserves only the explicit path when the session file is empty", async () => {
+	// Given: an existing zero-byte session file.
+	const sessionFile = join(scratch, "empty.jsonl");
+	await writeFile(sessionFile, "");
+
+	// When: the manager opens it and initializes the header in place.
+	const manager = SessionManager.open(sessionFile);
+
+	// Then: the initialized session writes to the explicit path only.
+	expect([...new Set(reserved)]).toEqual([sessionFile]);
+	expect(manager.getSessionFile()).toBe(sessionFile);
+});


### PR DESCRIPTION
Fixes #1612

## The defect

`WorkerSessionRegistry` counts every session-write path a handle has ever been granted against `SESSION_WORKER_LIMITS.reservations` (64), and the only release was the worker exit callback. Every `new_session` / fork / resume / branch inside one long-lived handle consumed a grant for the life of the worker, so the 63rd creation failed permanently with `session_path_in_use` on a path nobody else owned. A fresh open also spent one grant on a path that was never created.

## Ideal state implemented

- **Grants bound live writers.** `SessionManager` instances register as live writers; the worker reports the set of live session-write paths on every snapshot; the host reconciles its grants against that set and releases superseded paths. `reserve()` at the cap reconciles first, so an exhausted handle self-heals.
- **No phantom grant.** New-session state reset is split from path allocation, so `_setSessionFile` reserves exactly the explicit path.
- **Distinct error code.** Capacity denial is `session_reservation_limit` end to end (worker exchange, registry error, `rpc-types`, `docs/rpc.md`), never `session_path_in_use`.

## Evidence

- RED on v2026.9.12 (c509106cd) with the issue's script, 70 attempts: `new_session #63 FAILED: session_path_in_use` (62 ok).
- GREEN on this branch, same script, 200 attempts: `{"attempts":200,"ok":200,"failedAt":0}`.
- Regression tests (RED before the fix, GREEN at HEAD): `test/suite/regressions/1612-rpc-session-grant-release.test.ts` (70 replacements on one worker; superseded path re-opened by a second worker), `test/suite/regressions/1612-session-manager-single-reservation.test.ts` (exactly one path reserved for a missing and for a 0-byte explicit file), plus `SessionPathReservations` limit-vs-conflict and live-writer registry cases. Focused run at HEAD: 6 files, 44 tests passed; `bun run check` exit 0.
- Docs: `docs/rpc.md` worker-ownership section updated (live-writer reconciliation, `session_reservation_limit`); trackers `src/core/changes.md`, `src/modes/rpc/changes.md`; `CHANGELOG.md` [Unreleased].

Full QA logs are held locally (evidence dir, not committed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1612: long-lived RPC sessions no longer die at the 64-path reservation cap with `session_path_in_use`. Session-write grants now follow live writers instead of lasting for the worker's lifetime, so replaced session files free up and can be reopened in new workers.

**Bug Fixes**
- Every snapshot a fully open worker publishes names its live session paths; the host releases grants the list no longer claims.
- Opening a missing or empty explicit session file reserves exactly one path, not a phantom second.
- An exhausted per-worker budget now returns `session_reservation_limit`, distinct from `session_path_in_use`.

<sup>Written for commit 4a1d4692d13978c22cc8041c772968564a37324c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

