### PR TITLE
fix(cursor): size admission from the effective context window and never delete turns

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Cursor model windows now follow the ceiling the server reports. Every conversation checkpoint carries `tokenDetails.maxTokens`, and that observation is recorded per model id, persisted beside the conversation rotation store and preferred over the committed capability table, so a family whose real window is smaller than the table claims no longer sizes requests against a window it does not have ([#1603](https://github.com/code-yeongyu/senpi/issues/1603)).
+
 ### Removed
 
 ## [2026.9.12] - 2026-09-12

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -4459,7 +4459,11 @@ function buildConversationTurns(
 }
 
 /** Returns the serialized byte cost of Cursor's complete stored history representation. */
-export { buildCursorHistoryWireBytesForTest, measureCursorHistorySerializedBytes } from "./cursor-agent/measure.ts";
+export {
+	buildCursorHistoryWireBytesForTest,
+	measureCursorHistorySerializedBytes,
+	measureCursorModelInputSerializedBytes,
+} from "./cursor-agent/measure.ts";
 
 /** Exported for tests: decodes Cursor history blobs built from conversation messages. */
 export function buildCursorHistoryForTest(

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -48,6 +48,7 @@ import {
 	kStreamingLastParseLen,
 	kStreamingPartialJson,
 } from "../utils/block-symbols.ts";
+import { recordCursorContextLimit } from "../utils/cursor-context-limit.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
@@ -940,6 +941,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 
 				const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
 					attemptSawCheckpoint = true;
+					// The server states this model's real ceiling here; the catalog only
+					// guesses it. The first checkpoint of a conversation reports 0.
+					recordCursorContextLimit(model.id, checkpoint.tokenDetails?.maxTokens);
 					conversationStateCache.set(conversationId!, checkpoint);
 				};
 				const healthFailThresholdMs =

--- a/packages/ai/src/api/cursor-agent/measure.ts
+++ b/packages/ai/src/api/cursor-agent/measure.ts
@@ -486,6 +486,28 @@ function extractImages(content: (TextContent | ImageContent)[]) {
 		);
 }
 
+/**
+ * Serialized byte cost of the MODEL INPUT alone: the `rootPromptMessagesJson`
+ * blobs Cursor's server replays as the prompt. `measureCursorHistorySerializedBytes`
+ * additionally counts the `turns[]` display copies of the same conversation, so
+ * it reports roughly twice this number and overstates what the model ingests.
+ * Each referenced blob is counted once per reference, because a blob replayed
+ * twice occupies the prompt twice.
+ *
+ * First proposed in #1614.
+ */
+export function measureCursorModelInputSerializedBytes(
+	messages: Message[],
+	activeUserMessageIndex = findLastUserMessageIndex(messages),
+): number {
+	const blobStore = new Map<string, Uint8Array>();
+	let total = 0;
+	for (const blobId of buildRootPromptMessagesJson(messages, [], blobStore, activeUserMessageIndex)) {
+		total += readCursorBlob(blobStore, blobId).byteLength;
+	}
+	return total;
+}
+
 export function measureCursorHistorySerializedBytes(
 	messages: Message[],
 	activeUserMessageIndex = findLastUserMessageIndex(messages),

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,30 @@
+## Cursor context ceilings come from the server, not the capability table (2026-09-12)
+
+### What changed
+
+- `packages/ai/src/cursor/context-limit-store.ts` (new): browser-safe in-memory store of the context ceiling Cursor reported per model id, with `recordCursorContextLimit`, `getCursorContextLimit`, `resolveCursorContextWindow` (observed, else catalog) and a persistence port. It is browser-safe on purpose: the catalog builders that read it are bundled for the browser by `scripts/check-browser-smoke.mjs`.
+- `packages/ai/src/utils/cursor-context-limit.ts` (new): the Node entry point. It owns the JSON file (`<agentDir>/cursor-context-limits.json`, same resolution as `packages/ai/src/api/cursor-conversation-rotation.ts`, override `CURSOR_CONTEXT_LIMIT_STORE`), loads it lazily once, writes atomically (tmp + rename), treats a missing or corrupt file as empty, and installs itself as the persistence port on first use rather than as an import side effect. It lives under `utils/` because `./utils/*` is the only subpath pattern `packages/ai` exports that a Node-only module reachable from the coding agent can use.
+- `packages/ai/src/api/cursor-agent.ts`: `onConversationCheckpoint` records `checkpoint.tokenDetails?.maxTokens` for the streaming model. The first checkpoint of a conversation reports 0 and is ignored. Also re-exports `measureCursorModelInputSerializedBytes`.
+- `packages/ai/src/api/cursor-agent/measure.ts`: `measureCursorModelInputSerializedBytes` sums only the `rootPromptMessagesJson` blobs - what Cursor replays to the model - where `measureCursorHistorySerializedBytes` also counts the `turns[]` display copies and reports roughly twice that. First proposed in #1614 by DevNewbie1826.
+- `packages/ai/src/index.ts`: exports the new measurement.
+- `packages/ai/src/cursor/store-migration.ts` and `packages/ai/src/providers/cursor.ts`: a catalog entry materializes its `contextWindow` through `resolveCursorContextWindow(entry.id, entry.window)`, so an observed ceiling wins over the capability table. With an empty store both are unchanged.
+- Tests: `packages/ai/test/cursor-context-limit-store.test.ts` (new) and a checkpoint case in `packages/ai/test/cursor-conversation-rotation-stream.test.ts`.
+
+### Why
+
+- `GetUsableModels` carries no window, so `CURSOR_MODEL_CAPABILITIES` is a committed guess. When the guess is larger than the account's real ceiling, every sizing decision downstream - context usage, compaction thresholds, request admission - is made against a window the server will not honour, and the turn fails as a 0-token `resource_exhausted` instead of compacting in time (senpi#1603).
+- The aggregate admission budget in the coding agent needs a measurement of what the model actually ingests; sizing against root plus display copies double-counted the same conversation.
+
+### Why an extension could not handle it
+
+- The checkpoint callback lives inside the builtin `cursor-agent` stream implementation, and the catalog builders are `packages/ai` internals; an extension can neither observe `tokenDetails` nor change how a Cursor `Model` is materialized.
+
+### Expected merge conflict zones
+
+- LOW: the new `packages/ai/src/cursor/context-limit-store.ts` and `packages/ai/src/utils/cursor-context-limit.ts` have no upstream counterpart.
+- MEDIUM: `packages/ai/src/api/cursor-agent.ts` around `onConversationCheckpoint` and the measure re-export block.
+- LOW: the single `contextWindow` line in `packages/ai/src/cursor/store-migration.ts` and `packages/ai/src/providers/cursor.ts`.
+
 ## Devin Cascade transport parity with the released CLI (2026-09-12)
 
 ### What changed

--- a/packages/ai/src/cursor/context-limit-store.ts
+++ b/packages/ai/src/cursor/context-limit-store.ts
@@ -1,0 +1,69 @@
+/**
+ * Context ceilings Cursor itself reported, keyed by model id.
+ *
+ * `GetUsableModels` carries no window, so `CURSOR_MODEL_CAPABILITIES` is a
+ * committed guess at what each family accepts. The server states the truth on
+ * every conversation checkpoint (`tokenDetails.maxTokens`), so once a model has
+ * been observed, that value outranks the catalog for every later request.
+ *
+ * This module stays browser-safe: `providers/cursor.ts` and
+ * `cursor/store-migration.ts` materialize catalog windows and are bundled for
+ * the browser. Node processes install file persistence through
+ * `installCursorContextLimitPersistence` - see `utils/cursor-context-limit.ts`.
+ */
+
+export type CursorContextLimitPersistence = {
+	/** Limits observed by earlier processes. Called at most once per install. */
+	readonly load: () => ReadonlyMap<string, number>;
+	/** Called only when a recorded limit actually changed the store. */
+	readonly save: (limits: ReadonlyMap<string, number>) => void;
+};
+
+const observedLimits = new Map<string, number>();
+let persistence: CursorContextLimitPersistence | undefined;
+let hydrated = false;
+
+/** Installs the process-wide persistence port. Idempotent per port identity. */
+export function installCursorContextLimitPersistence(port: CursorContextLimitPersistence): void {
+	if (persistence === port) return;
+	persistence = port;
+	hydrated = false;
+}
+
+function hydrate(): void {
+	if (hydrated) return;
+	// Set before loading: a load that observes nothing must not retry per read.
+	hydrated = true;
+	if (!persistence) return;
+	for (const [modelId, maxTokens] of persistence.load()) {
+		if (!observedLimits.has(modelId)) observedLimits.set(modelId, maxTokens);
+	}
+}
+
+/**
+ * Records the server-reported ceiling for `modelId`. The first checkpoint of a
+ * conversation reports 0, so non-positive and non-finite values are ignored.
+ */
+export function recordCursorContextLimit(modelId: string, maxTokens: number | undefined): void {
+	if (maxTokens === undefined || !Number.isFinite(maxTokens) || maxTokens <= 0) return;
+	hydrate();
+	if (observedLimits.get(modelId) === maxTokens) return;
+	observedLimits.set(modelId, maxTokens);
+	persistence?.save(observedLimits);
+}
+
+export function getCursorContextLimit(modelId: string): number | undefined {
+	hydrate();
+	return observedLimits.get(modelId);
+}
+
+/** The window to trust for `modelId`: what the server reported, else the catalog. */
+export function resolveCursorContextWindow(modelId: string, catalogWindow: number): number {
+	return getCursorContextLimit(modelId) ?? catalogWindow;
+}
+
+/** Drops in-memory state so the next read re-hydrates from the installed port. */
+export function resetCursorContextLimitStoreForTest(): void {
+	observedLimits.clear();
+	hydrated = false;
+}

--- a/packages/ai/src/cursor/store-migration.ts
+++ b/packages/ai/src/cursor/store-migration.ts
@@ -1,5 +1,6 @@
 import type { Model } from "../types.ts";
 import { type CursorCatalogEntry, normalizeCursorCatalog } from "./catalog-grouping.ts";
+import { resolveCursorContextWindow } from "./context-limit-store.ts";
 import { getCursorVariantAlias } from "./model-capabilities.ts";
 
 function isGroupedShape(model: Model<"cursor-agent">): boolean {
@@ -19,7 +20,7 @@ function entryToModel(entry: CursorCatalogEntry, maxTokensById: ReadonlyMap<stri
 		...(entry.thinkingLevelMap ? { thinkingLevelMap: entry.thinkingLevelMap } : {}),
 		input: entry.input,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: entry.window,
+		contextWindow: resolveCursorContextWindow(entry.id, entry.window),
 		maxTokens,
 		...(entry.representativeVariantId !== undefined && entry.representativeVariantId !== entry.id
 			? { upstreamModelId: entry.representativeVariantId }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -9,7 +9,10 @@ export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from
 export { sanitizeAnthropicToolPairs } from "./api/anthropic-tool-pairs.ts";
 export type { AzureOpenAIResponsesOptions } from "./api/azure-openai-responses.ts";
 export type { BedrockOptions, BedrockThinkingDisplay } from "./api/bedrock-converse-stream.ts";
-export { measureCursorHistorySerializedBytes } from "./api/cursor-agent/measure.ts";
+export {
+	measureCursorHistorySerializedBytes,
+	measureCursorModelInputSerializedBytes,
+} from "./api/cursor-agent/measure.ts";
 export {
 	composeShellCommand as composeCursorShellCommand,
 	omitUndefinedArgs as omitUndefinedCursorArgs,

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2,6 +2,7 @@ import { cursorAgentApi, loadCursorAgentModule } from "../api/cursor-agent.lazy.
 import { lazyOAuth } from "../auth/helpers.ts";
 import { loadCursorOAuth } from "../auth/oauth/load.ts";
 import { normalizeCursorCatalog } from "../cursor/catalog-grouping.ts";
+import { resolveCursorContextWindow } from "../cursor/context-limit-store.ts";
 import { regroupStoredCursorModels } from "../cursor/store-migration.ts";
 import { createProvider, type Provider, type RefreshModelsContext } from "../models.ts";
 import type { Model } from "../types.ts";
@@ -47,7 +48,7 @@ async function fetchCursorModels(context: RefreshModelsContext): Promise<Model<"
 			input: entry.input,
 			// Subscription-billed: Cursor reports no per-token pricing here.
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: entry.window,
+			contextWindow: resolveCursorContextWindow(entry.id, entry.window),
 			maxTokens,
 			...(entry.representativeVariantId !== undefined && entry.representativeVariantId !== entry.id
 				? { upstreamModelId: entry.representativeVariantId }

--- a/packages/ai/src/utils/cursor-context-limit.ts
+++ b/packages/ai/src/utils/cursor-context-limit.ts
@@ -1,0 +1,101 @@
+/**
+ * Node entry point for the observed Cursor context limits.
+ *
+ * The store itself (`cursor/context-limit-store.ts`) is browser-safe because the
+ * catalog builders that read it are bundled for the browser. Persistence needs
+ * `node:fs`, so it lives here and is installed on first use rather than as an
+ * import side effect, which a bundler is free to drop for a package declared
+ * side-effect-free. Node callers - the `cursor-agent` stream and the coding
+ * agent - use this module; browser-facing code uses the store directly.
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+	type CursorContextLimitPersistence,
+	installCursorContextLimitPersistence,
+	getCursorContextLimit as readObservedLimit,
+	recordCursorContextLimit as recordObservedLimit,
+	resetCursorContextLimitStoreForTest as resetObservedLimits,
+	resolveCursorContextWindow as resolveObservedWindow,
+} from "../cursor/context-limit-store.ts";
+
+/**
+ * Same resolution as the conversation rotation store: an explicit override
+ * first, then the agent directory the host configured, then the default one.
+ */
+export function resolveCursorContextLimitStorePath(env: NodeJS.ProcessEnv = process.env): string {
+	if (env.CURSOR_CONTEXT_LIMIT_STORE) {
+		return env.CURSOR_CONTEXT_LIMIT_STORE;
+	}
+	const agentDir =
+		env.SENPI_CODING_AGENT_DIR ?? env.CODING_AGENT_DIR ?? `${(env.HOME ?? ".").replace(/\/$/, "")}/.senpi/agent`;
+	return `${agentDir.replace(/\/$/, "")}/cursor-context-limits.json`;
+}
+
+let savingEnabled = true;
+
+const filePersistence: CursorContextLimitPersistence = {
+	load: () => {
+		const limits = new Map<string, number>();
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(readFileSync(resolveCursorContextLimitStorePath(), "utf8"));
+		} catch (error) {
+			// No file on first run, and a truncated or hand-edited one is the same
+			// situation for a cache: the catalog window is the documented fallback.
+			if (error instanceof Error) return limits;
+			throw error;
+		}
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return limits;
+		for (const [modelId, maxTokens] of Object.entries(parsed)) {
+			if (typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0) {
+				limits.set(modelId, maxTokens);
+			}
+		}
+		return limits;
+	},
+	save: (limits) => {
+		if (!savingEnabled) return;
+		const path = resolveCursorContextLimitStorePath();
+		const record: Record<string, number> = {};
+		for (const [modelId, maxTokens] of limits) record[modelId] = maxTokens;
+		try {
+			mkdirSync(dirname(path), { recursive: true });
+			const temporaryPath = `${path}.${process.pid}.tmp`;
+			writeFileSync(temporaryPath, `${JSON.stringify(record, null, 2)}\n`);
+			renameSync(temporaryPath, path);
+		} catch (error) {
+			// This file is a cache for the next process. A read-only agent directory
+			// must not fail the live turn that observed the limit, and one failure
+			// disables saving so a broken path cannot cost a write per checkpoint.
+			if (!(error instanceof Error)) throw error;
+			savingEnabled = false;
+		}
+	},
+};
+
+function ensurePersistenceInstalled(): void {
+	installCursorContextLimitPersistence(filePersistence);
+}
+
+/** Records the ceiling Cursor reported for `modelId`; ignores non-positive values. */
+export function recordCursorContextLimit(modelId: string, maxTokens: number | undefined): void {
+	ensurePersistenceInstalled();
+	recordObservedLimit(modelId, maxTokens);
+}
+
+export function getCursorContextLimit(modelId: string): number | undefined {
+	ensurePersistenceInstalled();
+	return readObservedLimit(modelId);
+}
+
+/** The window to trust for `modelId`: what the server reported, else the catalog. */
+export function resolveCursorContextWindow(modelId: string, catalogWindow: number): number {
+	ensurePersistenceInstalled();
+	return resolveObservedWindow(modelId, catalogWindow);
+}
+
+export function resetCursorContextLimitStoreForTest(): void {
+	savingEnabled = true;
+	resetObservedLimits();
+}

--- a/packages/ai/test/cursor-context-limit-store.test.ts
+++ b/packages/ai/test/cursor-context-limit-store.test.ts
@@ -1,0 +1,110 @@
+// Cursor reports the real context ceiling per conversation checkpoint
+// (senpi#1603). The store keeps that observation for the model id and survives
+// process restarts, so the next session sizes admission against the truth.
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	getCursorContextLimit,
+	recordCursorContextLimit,
+	resetCursorContextLimitStoreForTest,
+	resolveCursorContextLimitStorePath,
+	resolveCursorContextWindow,
+} from "../src/utils/cursor-context-limit.ts";
+
+let storeDir: string;
+let storePath: string;
+const previousStoreEnv = process.env.CURSOR_CONTEXT_LIMIT_STORE;
+
+beforeEach(() => {
+	storeDir = mkdtempSync(join(tmpdir(), "cursor-context-limit-"));
+	storePath = join(storeDir, "cursor-context-limits.json");
+	process.env.CURSOR_CONTEXT_LIMIT_STORE = storePath;
+	resetCursorContextLimitStoreForTest();
+});
+
+afterEach(() => {
+	resetCursorContextLimitStoreForTest();
+	if (previousStoreEnv === undefined) delete process.env.CURSOR_CONTEXT_LIMIT_STORE;
+	else process.env.CURSOR_CONTEXT_LIMIT_STORE = previousStoreEnv;
+	rmSync(storeDir, { recursive: true, force: true });
+});
+
+describe("cursor context limit store", () => {
+	it("serves a recorded ceiling to a process that lost its in-memory state", () => {
+		// Given: a ceiling observed by an earlier process.
+		recordCursorContextLimit("kimi-k3", 200_000);
+
+		// When: in-memory state is dropped the way a restart drops it.
+		resetCursorContextLimitStoreForTest();
+
+		// Then: the persisted observation is still the model's ceiling.
+		expect(getCursorContextLimit("kimi-k3")).toBe(200_000);
+		expect(resolveCursorContextWindow("kimi-k3", 1_048_576)).toBe(200_000);
+	});
+
+	it("falls back to the catalog window for a model that was never observed", () => {
+		// Given: a store holding another model only.
+		recordCursorContextLimit("kimi-k3", 200_000);
+
+		// When/Then: an unobserved model keeps its catalog window.
+		expect(getCursorContextLimit("gemini-3.5-flash")).toBeUndefined();
+		expect(resolveCursorContextWindow("gemini-3.5-flash", 1_048_576)).toBe(1_048_576);
+	});
+
+	it("treats a corrupt store file as empty", () => {
+		// Given: a truncated store file.
+		writeFileSync(storePath, '{"kimi-k3": 200');
+
+		// When: a fresh read hydrates from it.
+		resetCursorContextLimitStoreForTest();
+
+		// Then: nothing is observed and the catalog window wins.
+		expect(getCursorContextLimit("kimi-k3")).toBeUndefined();
+		expect(resolveCursorContextWindow("kimi-k3", 1_048_576)).toBe(1_048_576);
+	});
+
+	it("ignores the non-positive ceilings the first checkpoint of a turn reports", () => {
+		// Given/When: the values Cursor sends before it knows the conversation size.
+		recordCursorContextLimit("kimi-k3", 0);
+		recordCursorContextLimit("kimi-k3", -1);
+		recordCursorContextLimit("kimi-k3", Number.NaN);
+		recordCursorContextLimit("kimi-k3", undefined);
+
+		// Then: nothing is observed and nothing is persisted.
+		expect(getCursorContextLimit("kimi-k3")).toBeUndefined();
+		expect(existsSync(storePath)).toBe(false);
+	});
+
+	it("persists only when the observed ceiling changes", () => {
+		// Given: an already persisted ceiling whose file was removed.
+		recordCursorContextLimit("kimi-k3", 200_000);
+		rmSync(storePath);
+
+		// When: the same ceiling is observed again.
+		recordCursorContextLimit("kimi-k3", 200_000);
+
+		// Then: no rewrite happened; a different ceiling does write.
+		expect(existsSync(storePath)).toBe(false);
+		recordCursorContextLimit("kimi-k3", 262_144);
+		expect(existsSync(storePath)).toBe(true);
+		resetCursorContextLimitStoreForTest();
+		expect(getCursorContextLimit("kimi-k3")).toBe(262_144);
+	});
+
+	it("resolves the store path the way the conversation rotation store does", () => {
+		expect(resolveCursorContextLimitStorePath({ CURSOR_CONTEXT_LIMIT_STORE: "/tmp/explicit.json" })).toBe(
+			"/tmp/explicit.json",
+		);
+		expect(
+			resolveCursorContextLimitStorePath({ SENPI_CODING_AGENT_DIR: "/tmp/senpi-agent", CODING_AGENT_DIR: "/tmp/x" }),
+		).toBe("/tmp/senpi-agent/cursor-context-limits.json");
+		expect(resolveCursorContextLimitStorePath({ CODING_AGENT_DIR: "/tmp/legacy-agent/" })).toBe(
+			"/tmp/legacy-agent/cursor-context-limits.json",
+		);
+		expect(resolveCursorContextLimitStorePath({ HOME: "/home/tester" })).toBe(
+			"/home/tester/.senpi/agent/cursor-context-limits.json",
+		);
+	});
+});

--- a/packages/ai/test/cursor-conversation-rotation-stream.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation-stream.test.ts
@@ -9,8 +9,11 @@ import { AgentServerMessageSchema } from "../src/api/cursor-agent/gen/agent_pb.t
 import { frameConnectMessage, stream as streamCursorAgent } from "../src/api/cursor-agent.ts";
 import { CURSOR_CONVERSATION_POISONED_MESSAGE } from "../src/api/cursor-conversation-rotation.ts";
 import type { Model } from "../src/types.ts";
+import { getCursorContextLimit, resetCursorContextLimitStoreForTest } from "../src/utils/cursor-context-limit.ts";
 
 process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-rotate-")), "ids.json");
+// The stream records observed context ceilings; keep them out of the real agent dir.
+process.env.CURSOR_CONTEXT_LIMIT_STORE = join(mkdtempSync(join(tmpdir(), "cursor-limits-")), "limits.json");
 
 const neverAbortedSignal = new AbortController().signal;
 const CONNECT_END_STREAM_FLAG = 0b00000010;
@@ -36,6 +39,20 @@ function turnEndedFrame(): Buffer {
 			AgentServerMessageSchema,
 			create(AgentServerMessageSchema, {
 				message: { case: "interactionUpdate", value: { message: { case: "turnEnded", value: {} } } },
+			}),
+		),
+	);
+}
+
+function checkpointFrame(usedTokens: number, maxTokens: number): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "conversationCheckpointUpdate",
+					value: { tokenDetails: { usedTokens, maxTokens } },
+				},
 			}),
 		),
 	);
@@ -136,6 +153,25 @@ describe("cursor-agent zero-token RE retry", () => {
 		const second = await runStream(baseUrl, "sess-rotate-stream");
 		expect(runs).toBe(3);
 		expect(second.stopReason).not.toBe("error");
+	});
+
+	// senpi#1603: the catalog only guesses a Cursor window. The checkpoint states
+	// the server's real ceiling, and admission has to size history against it.
+	it("records the checkpoint context ceiling for the streaming model", async () => {
+		// Given: a stream whose checkpoint reports a 200K ceiling.
+		resetCursorContextLimitStoreForTest();
+		const baseUrl = await startServer((stream) => {
+			stream.write(checkpointFrame(17_962, 200_000));
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+
+		// When: the turn completes.
+		const message = await runStream(baseUrl, "sess-context-ceiling");
+
+		// Then: the ceiling is stored under the streaming model id.
+		expect(message.stopReason).not.toBe("error");
+		expect(getCursorContextLimit("claude-4.6-opus-high")).toBe(200_000);
 	});
 
 	it("surfaces the poisoned-conversation error after the rotation cap", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed Cursor requests losing whole conversation turns: admission enforced a fixed 50 KB aggregate cap and deleted the oldest turns when blanking tool results was not enough, so a 1M-token model kept roughly 6K tokens of history and an early instruction could disappear before the model saw it. The aggregate budget now follows the model context window (measured over what Cursor actually replays to the model), only tool result bodies are shrunk, and a history that still exceeds the budget is sent as-is for the existing overflow-to-compaction path to handle ([#1603](https://github.com/code-yeongyu/senpi/issues/1603)).
+
 ### Removed
 
 ## [2026.9.12] - 2026-09-12

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -35,7 +35,6 @@ import type {
 import { ProviderRetryWatchdogAbortError, prepareAgentToolCall } from "@earendil-works/pi-agent-core";
 import {
 	contentText,
-	measureCursorHistorySerializedBytes,
 	providerNotConfiguredMessage,
 	SERVER_FALLBACK_ABORTED_DIAGNOSTIC,
 	type ThinkingSelection,
@@ -71,6 +70,7 @@ import {
 	shouldRetryOverflowWithoutCompact,
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
+import { getCursorContextLimit } from "@earendil-works/pi-ai/utils/cursor-context-limit";
 import { extract429RetryAfterMs, parseRetryAfterMsMarker } from "@earendil-works/pi-ai/utils/retry-hint";
 import { retryBackoffDelayMs } from "@earendil-works/pi-ai/utils/retry-profile/backoff";
 import { getAgentDir } from "../config.ts";
@@ -105,6 +105,7 @@ import {
 import { CompactionLifecycleCoordinator, type CompactionLifecycleState } from "./compaction/lifecycle.ts";
 import { isTurnStuckOnContextOverflow } from "./compaction/stuck-overflow.ts";
 import { isWarmSummaryAnchorValid } from "./compaction/warm-anchor.ts";
+import { admitCursorHistory, cursorAdmissionBudgetBytes } from "./cursor-history-admission.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "./dynamic-prompt/index.ts";
 import {
@@ -190,12 +191,7 @@ import {
 	MANUAL_CONTINUE_CUSTOM_TYPE,
 	MANUAL_CONTINUE_DIRECTIVE,
 } from "./manual-continue.ts";
-import {
-	type BashExecutionMessage,
-	type CustomMessage,
-	convertToLlm,
-	filterContextExcludedMessages,
-} from "./messages.ts";
+import { type BashExecutionMessage, type CustomMessage, filterContextExcludedMessages } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import { type AvailableModelsSource, getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.ts";
 import type { ModelRuntime } from "./model-runtime.ts";
@@ -945,121 +941,11 @@ const THINKING_LEVELS_WITH_MAX: ThinkingLevel[] = ["off", "minimal", "low", "med
 /** Caps explicit skill expansion so one prompt cannot consume unbounded context. */
 export const MAX_SKILL_EXPANSIONS_PER_PROMPT = 5;
 
-/** Cursor ingest rejects large verbatim tool payloads. The bound is UTF-8 bytes. */
-export const CURSOR_TOOL_RESULT_MAX_CHARS = 2000;
-export const CURSOR_TOOL_RESULT_MAX_BYTES = 50_000;
-const CURSOR_TRUNCATION_MARKER = "\n...[truncated]";
-
-export function truncateToolResultBodies(
-	messages: AgentMessage[] | undefined,
-	maxChars = CURSOR_TOOL_RESULT_MAX_CHARS,
-	maxBytes = CURSOR_TOOL_RESULT_MAX_BYTES,
-	convert = (candidate: AgentMessage[]) => convertToLlm(candidate),
-): { messages: AgentMessage[] | undefined; changed: boolean } {
-	if (!Array.isArray(messages) || messages.length === 0) return { messages, changed: false };
-	const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-	const markerChars = [...segmenter.segment(CURSOR_TRUNCATION_MARKER)].length;
-	const result = messages.slice();
-	let changed = false;
-
-	// Apply the per-result character cap first, independent of the aggregate wire cap.
-	for (let messageIndex = result.length - 1; messageIndex >= 0; messageIndex--) {
-		const message = result[messageIndex];
-		if (message.role !== "toolResult" || !Array.isArray(message.content)) continue;
-		let content = message.content;
-		for (let partIndex = content.length - 1; partIndex >= 0; partIndex--) {
-			const part = content[partIndex];
-			if (part.type === "image" && typeof part.data === "string") continue;
-			if (part.type !== "text" || typeof part.text !== "string") continue;
-			const graphemes = [...segmenter.segment(part.text)].map((item) => item.segment);
-			if (graphemes.length <= maxChars) continue;
-			const kept = graphemes.slice(0, Math.max(0, maxChars - markerChars)).join("");
-			const nextText = kept + CURSOR_TRUNCATION_MARKER;
-			content = content === message.content ? content.slice() : content;
-			content[partIndex] = { ...part, text: nextText };
-			result[messageIndex] = { ...message, content };
-			changed = true;
-		}
-	}
-
-	const measure = (candidate: AgentMessage[]): number => {
-		const converted = convert(candidate);
-		const activeUserMessageIndex = converted.at(-1)?.role === "user" ? converted.length - 1 : -1;
-		return measureCursorHistorySerializedBytes(converted, activeUserMessageIndex);
-	};
-	const fits = (candidate = result) => measure(candidate) <= maxBytes;
-	if (fits()) return { messages: changed ? result : messages, changed };
-
-	// Empty the oldest result bodies. Search the monotonic prefix of candidates
-	// rather than serializing once for every result (admission must stay bounded).
-	const emptyToolResult = (message: AgentMessage): AgentMessage => {
-		if (message.role !== "toolResult" || !Array.isArray(message.content)) return message;
-		const emptiedContent = message.content.map((part) =>
-			part.type === "text" ? { ...part, text: "" } : part.type === "image" ? { ...part, data: "" } : part,
-		);
-		const content = emptiedContent.filter((part, index) => {
-			if (index === 0) return true;
-			const previous = emptiedContent[index - 1];
-			const empty = part.type === "text" ? part.text === "" : part.type === "image" && part.data === "";
-			const previousEmpty =
-				previous.type === "text" ? previous.text === "" : previous.type === "image" && previous.data === "";
-			return !empty || !previousEmpty;
-		});
-		return { ...message, content };
-	};
-	const toolResultIndexes = result.flatMap((message, index) =>
-		message.role === "toolResult" && Array.isArray(message.content) ? [index] : [],
-	);
-	const withEmptyPrefix = (count: number): AgentMessage[] => {
-		const candidate = result.slice();
-		for (let i = 0; i < count; i++)
-			candidate[toolResultIndexes[i]] = emptyToolResult(candidate[toolResultIndexes[i]]);
-		return candidate;
-	};
-	let low = 0;
-	let high = toolResultIndexes.length;
-	while (low < high) {
-		const middle = Math.floor((low + high) / 2);
-		if (fits(withEmptyPrefix(middle + 1))) high = middle;
-		else low = middle + 1;
-	}
-	const emptyCount = Math.min(low + 1, toolResultIndexes.length);
-	if (emptyCount > 0) {
-		result.splice(0, result.length, ...withEmptyPrefix(emptyCount));
-		changed = true;
-	}
-	if (fits()) return { messages: changed ? result : messages, changed };
-
-	// If metadata alone exceeds the cap, discard the oldest complete turns. This
-	// search is also monotonic and avoids quadratic whole-history reserialization.
-	const turnRanges: Array<[number, number]> = [];
-	const isConvertedUser = (message: AgentMessage): boolean => convert([message])[0]?.role === "user";
-	for (let index = 0; index < result.length; index++) {
-		if (!isConvertedUser(result[index])) continue;
-		const nextUser = result.findIndex((message, nextIndex) => nextIndex > index && isConvertedUser(message));
-		turnRanges.push([index, nextUser < 0 ? result.length : nextUser]);
-	}
-	const withoutTurns = (count: number): AgentMessage[] => {
-		if (count === 0) return result;
-		const start = turnRanges[0]?.[0] ?? 0;
-		const end = turnRanges[count - 1]?.[1] ?? start;
-		return [...result.slice(0, start), ...result.slice(end)];
-	};
-	low = 0;
-	high = turnRanges.length;
-	while (low < high) {
-		const middle = Math.floor((low + high) / 2);
-		if (fits(withoutTurns(middle + 1))) high = middle;
-		else low = middle + 1;
-	}
-	const turnCount = Math.min(low + 1, turnRanges.length);
-	if (turnCount > 0) {
-		const next = withoutTurns(turnCount);
-		result.splice(0, result.length, ...next);
-		changed = true;
-	}
-	return { messages: changed ? result : messages, changed };
-}
+/**
+ * Cursor admission lives in its own module; the names stay exported here so
+ * existing importers keep resolving them.
+ */
+export { CURSOR_TOOL_RESULT_MAX_CHARS, truncateToolResultBodies } from "./cursor-history-admission.ts";
 
 // ============================================================================
 // AgentSession Class
@@ -1607,6 +1493,20 @@ export class AgentSession {
 		};
 	}
 
+	/**
+	 * Cursor states a model's real context ceiling on every conversation
+	 * checkpoint. Once observed, it replaces the catalog guess on the live model
+	 * so context usage, compaction thresholds and admission all size against the
+	 * window the server will actually enforce.
+	 */
+	private _applyObservedCursorContextWindow(model: Model<Api>): void {
+		const observed = getCursorContextLimit(model.id);
+		if (observed === undefined || observed <= 0 || observed === model.contextWindow) return;
+		const previous = model.contextWindow;
+		model.contextWindow = observed;
+		this._sessionLogger.info("cursor_context_window_observed", { modelId: model.id, previous, observed });
+	}
+
 	private _installAgentNextTurnRefresh(): void {
 		const previousPrepareNextTurnWithContext =
 			this.agent.prepareNextTurnWithContext ??
@@ -1616,19 +1516,32 @@ export class AgentSession {
 		const previousTransformContext = this.agent.transformContext;
 		this.agent.transformContext = async (messages, signal) => {
 			const transformed = previousTransformContext ? await previousTransformContext(messages, signal) : messages;
-			if (this.model?.provider === "cursor" || this.model?.provider === "cursor-cli-oauth") {
-				return (
-					(
-						await truncateToolResultBodies(
-							transformed,
-							CURSOR_TOOL_RESULT_MAX_CHARS,
-							CURSOR_TOOL_RESULT_MAX_BYTES,
-							(candidate) => this.agent.convertToLlm(candidate) as Message[],
-						)
-					).messages ?? transformed
-				);
+			const model = this.model;
+			if (model?.provider !== "cursor" && model?.provider !== "cursor-cli-oauth") return transformed;
+			this._applyObservedCursorContextWindow(model);
+			const budgetBytes = cursorAdmissionBudgetBytes(model.contextWindow);
+			const admission = admitCursorHistory({
+				messages: transformed,
+				budgetBytes,
+				convert: (candidate) => this.agent.convertToLlm(candidate) as Message[],
+			});
+			if (admission.blankedToolResults > 0) {
+				this._sessionLogger.info("cursor_admission_truncated", {
+					blankedToolResults: admission.blankedToolResults,
+					bytesBefore: admission.bytesBefore,
+					bytesAfter: admission.bytesAfter,
+					budgetBytes,
+				});
 			}
-			return transformed;
+			if (admission.overBudget) {
+				// The request is still admitted: Cursor answers an oversized history
+				// with a 0-token resource_exhausted, which the session layer compacts.
+				this._sessionLogger.warn("cursor_admission_over_budget", {
+					bytes: admission.bytesAfter,
+					budgetBytes,
+				});
+			}
+			return admission.messages ?? transformed;
 		};
 
 		this.agent.prepareNextTurnWithContext = async (turn, signal) => {
@@ -6184,7 +6097,11 @@ export class AgentSession {
 		// Size the same retained context that will be admitted to Cursor. Persisted JSONL
 		// remains verbatim, but the in-memory request representation is bounded first.
 		if (model.provider === "cursor" || model.provider === "cursor-cli-oauth") {
-			simulatedMessages = truncateToolResultBodies(simulatedMessages).messages ?? simulatedMessages;
+			simulatedMessages =
+				admitCursorHistory({
+					messages: simulatedMessages,
+					budgetBytes: cursorAdmissionBudgetBytes(model.contextWindow),
+				}).messages ?? simulatedMessages;
 		}
 		const contextTokens = estimateMessagesTokens(filterContextExcludedMessages(simulatedMessages));
 		const settings = this._getCompactionSettings();

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## 2026-09-12 - Cursor admission never deletes a turn (senpi#1603)
+
+### What changed
+
+- `packages/coding-agent/src/core/cursor-history-admission.ts` (new): owns Cursor request admission - the per-tool-result grapheme cap, blanking the oldest tool result bodies against an explicit byte budget, and `cursorAdmissionBudgetBytes` (effective context window x 4 chars per token, matching `core/compaction` `estimateTokens`). `admitCursorHistory` reports `blankedToolResults`, `bytesBefore`, `bytesAfter` and `overBudget`; `truncateToolResultBodies` stays as the positional entry point.
+- `packages/coding-agent/src/core/agent-session.ts`: the admission pass moved out of this file and the old names are re-exported from it. The third pass, which deleted the oldest whole turns when blanking was not enough, is gone: an over-budget history is admitted as-is. The `transformContext` closure now applies the observed Cursor ceiling to the live model (`cursor_context_window_observed`), derives the budget from `model.contextWindow`, and logs `cursor_admission_truncated` / `cursor_admission_over_budget`. `_wouldCompactionOverflow` sizes its simulated Cursor context with the same window-derived budget.
+- `packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/models.ts`: catalog entries materialize `contextWindow` through `resolveCursorContextWindow`.
+- Tests: `packages/coding-agent/test/suite/regressions/1603-cursor-history-budget.test.ts` (new) and the rewritten aggregate cases in `packages/coding-agent/test/suite/regressions/1043-cursor-toolresult-truncate.test.ts`, which now pass explicit budgets and assert that bodies shrink while messages do not.
+
+### Why
+
+- Admission enforced a fixed 50,000-byte cap that had nothing to do with the model window, and measured it over both the prompt blobs and Cursor's display copies of the same conversation. A 1M-token model therefore admitted roughly 6K tokens, and a tool-free history - where there is no body to blank - lost its oldest turns outright, so a codeword or instruction from the first turn was gone before the model ever saw it.
+- Cursor rebuilds the conversation each hop, so the pass cannot compact mid-run; the correct answer to an oversized history is to admit it and let the existing 0-token `resource_exhausted` overflow path compact with the session's own policy.
+
+### Why an extension could not handle it
+
+- The pass runs inside `AgentSession`'s installed `transformContext` and feeds the same session-owned compaction and context-usage accounting; an extension context hook cannot see the model window admission is budgeting against, and cannot mutate the live model.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/agent-session.ts` - the constants block above the class and the `transformContext` closure inside `_installAgentNextTurnRefresh`.
+- LOW: the new `packages/coding-agent/src/core/cursor-history-admission.ts`.
+- LOW: the `contextWindow` line in `packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/models.ts`.
+
 ## 2026-09-11 - Batch persisted entry hydration after resident-string eviction (senpi#1407)
 
 ### What changed

--- a/packages/coding-agent/src/core/cursor-history-admission.ts
+++ b/packages/coding-agent/src/core/cursor-history-admission.ts
@@ -1,0 +1,177 @@
+/**
+ * Cursor request admission: what the transport is allowed to send in one turn.
+ *
+ * Cursor rebuilds the whole conversation on every hop and rejects large
+ * verbatim tool payloads, so a turn is bounded twice - each tool result is
+ * capped on its own, and the aggregate model input is held under the model's
+ * context window. Admission NEVER deletes a turn (senpi#1603): dropping the
+ * oldest turns to reach a byte cap silently amputated the conversation, and a
+ * history that still exceeds the budget after blanking is admitted as-is so the
+ * existing Cursor overflow path (a 0-token `resource_exhausted` surfaced to the
+ * session layer) compacts it with the session's own policy.
+ */
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { measureCursorModelInputSerializedBytes } from "@earendil-works/pi-ai";
+import type { Message } from "@earendil-works/pi-ai/compat";
+import { convertToLlm } from "./messages.ts";
+
+/** Cursor ingest rejects large verbatim tool payloads. The bound is graphemes. */
+export const CURSOR_TOOL_RESULT_MAX_CHARS = 2000;
+const CURSOR_TRUNCATION_MARKER = "\n...[truncated]";
+/** Repo-wide estimate, matching `estimateTokens` in core/compaction. */
+const CHARS_PER_TOKEN = 4;
+
+/** Aggregate admission budget for a model whose window is `contextWindowTokens`. */
+export function cursorAdmissionBudgetBytes(contextWindowTokens: number): number {
+	if (!Number.isFinite(contextWindowTokens) || contextWindowTokens <= 0) return 0;
+	return Math.floor(contextWindowTokens) * CHARS_PER_TOKEN;
+}
+
+export type CursorAdmissionRequest = {
+	readonly messages: AgentMessage[] | undefined;
+	/** Serialized model-input bytes this turn may occupy. */
+	readonly budgetBytes: number;
+	readonly maxChars?: number;
+	readonly convert?: (candidate: AgentMessage[]) => Message[];
+};
+
+export type CursorAdmissionResult = {
+	readonly messages: AgentMessage[] | undefined;
+	readonly changed: boolean;
+	readonly blankedToolResults: number;
+	readonly bytesBefore: number;
+	readonly bytesAfter: number;
+	/** True when the history still exceeds the budget; the request is still sent. */
+	readonly overBudget: boolean;
+};
+
+function capToolResultBodies(
+	messages: AgentMessage[],
+	maxChars: number,
+): { readonly messages: AgentMessage[]; readonly changed: boolean } {
+	const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+	const markerChars = [...segmenter.segment(CURSOR_TRUNCATION_MARKER)].length;
+	const result = messages.slice();
+	let changed = false;
+	for (let messageIndex = result.length - 1; messageIndex >= 0; messageIndex--) {
+		const message = result[messageIndex];
+		if (message.role !== "toolResult" || !Array.isArray(message.content)) continue;
+		let content = message.content;
+		for (let partIndex = content.length - 1; partIndex >= 0; partIndex--) {
+			const part = content[partIndex];
+			if (part.type === "image" && typeof part.data === "string") continue;
+			if (part.type !== "text" || typeof part.text !== "string") continue;
+			const graphemes = [...segmenter.segment(part.text)].map((item) => item.segment);
+			if (graphemes.length <= maxChars) continue;
+			const kept = graphemes.slice(0, Math.max(0, maxChars - markerChars)).join("");
+			content = content === message.content ? content.slice() : content;
+			content[partIndex] = { ...part, text: kept + CURSOR_TRUNCATION_MARKER };
+			result[messageIndex] = { ...message, content };
+			changed = true;
+		}
+	}
+	return { messages: result, changed };
+}
+
+function emptyToolResult(message: AgentMessage): AgentMessage {
+	if (message.role !== "toolResult" || !Array.isArray(message.content)) return message;
+	const emptiedContent = message.content.map((part) =>
+		part.type === "text" ? { ...part, text: "" } : part.type === "image" ? { ...part, data: "" } : part,
+	);
+	const content = emptiedContent.filter((part, index) => {
+		if (index === 0) return true;
+		const previous = emptiedContent[index - 1];
+		const empty = part.type === "text" ? part.text === "" : part.type === "image" && part.data === "";
+		const previousEmpty =
+			previous.type === "text" ? previous.text === "" : previous.type === "image" && previous.data === "";
+		return !empty || !previousEmpty;
+	});
+	return { ...message, content };
+}
+
+/**
+ * Empties the oldest result bodies until the rest fits. The prefix search is
+ * monotonic, so admission stays bounded instead of reserializing the whole
+ * history once per tool result.
+ */
+function blankOldestToolResults(
+	messages: AgentMessage[],
+	fits: (candidate: AgentMessage[]) => boolean,
+): { readonly messages: AgentMessage[]; readonly count: number } {
+	const toolResultIndexes = messages.flatMap((message, index) =>
+		message.role === "toolResult" && Array.isArray(message.content) ? [index] : [],
+	);
+	const withEmptyPrefix = (count: number): AgentMessage[] => {
+		const candidate = messages.slice();
+		for (let i = 0; i < count; i++)
+			candidate[toolResultIndexes[i]] = emptyToolResult(candidate[toolResultIndexes[i]]);
+		return candidate;
+	};
+	let low = 0;
+	let high = toolResultIndexes.length;
+	while (low < high) {
+		const middle = Math.floor((low + high) / 2);
+		if (fits(withEmptyPrefix(middle + 1))) high = middle;
+		else low = middle + 1;
+	}
+	const count = Math.min(low + 1, toolResultIndexes.length);
+	return { messages: count > 0 ? withEmptyPrefix(count) : messages, count };
+}
+
+/**
+ * Bounds one Cursor request: per-result caps first, then blanking the oldest
+ * tool result bodies while the model input exceeds `budgetBytes`. Conversation
+ * turns are never removed.
+ */
+export function admitCursorHistory(request: CursorAdmissionRequest): CursorAdmissionResult {
+	const { messages, budgetBytes } = request;
+	if (!Array.isArray(messages) || messages.length === 0) {
+		return { messages, changed: false, blankedToolResults: 0, bytesBefore: 0, bytesAfter: 0, overBudget: false };
+	}
+	const convert = request.convert ?? ((candidate: AgentMessage[]) => convertToLlm(candidate));
+	const capped = capToolResultBodies(messages, request.maxChars ?? CURSOR_TOOL_RESULT_MAX_CHARS);
+	const measure = (candidate: AgentMessage[]): number => {
+		const converted = convert(candidate);
+		const activeUserMessageIndex = converted.at(-1)?.role === "user" ? converted.length - 1 : -1;
+		return measureCursorModelInputSerializedBytes(converted, activeUserMessageIndex);
+	};
+
+	const bytesBefore = measure(capped.messages);
+	if (bytesBefore <= budgetBytes) {
+		return {
+			messages: capped.changed ? capped.messages : messages,
+			changed: capped.changed,
+			blankedToolResults: 0,
+			bytesBefore,
+			bytesAfter: bytesBefore,
+			overBudget: false,
+		};
+	}
+
+	const blanked = blankOldestToolResults(capped.messages, (candidate) => measure(candidate) <= budgetBytes);
+	const bytesAfter = blanked.count > 0 ? measure(blanked.messages) : bytesBefore;
+	const changed = capped.changed || blanked.count > 0;
+	return {
+		messages: changed ? blanked.messages : messages,
+		changed,
+		blankedToolResults: blanked.count,
+		bytesBefore,
+		bytesAfter,
+		overBudget: bytesAfter > budgetBytes,
+	};
+}
+
+/**
+ * Positional entry point kept for existing callers. An omitted `maxBytes`
+ * applies the per-result cap only; the aggregate budget belongs to the caller
+ * that knows the model window.
+ */
+export function truncateToolResultBodies(
+	messages: AgentMessage[] | undefined,
+	maxChars = CURSOR_TOOL_RESULT_MAX_CHARS,
+	maxBytes = Number.POSITIVE_INFINITY,
+	convert = (candidate: AgentMessage[]) => convertToLlm(candidate),
+): { messages: AgentMessage[] | undefined; changed: boolean } {
+	const admission = admitCursorHistory({ messages, budgetBytes: maxBytes, maxChars, convert });
+	return { messages: admission.messages, changed: admission.changed };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/models.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/models.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "node:fs/p
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { normalizeCursorCatalog } from "@earendil-works/pi-ai";
+import { resolveCursorContextWindow } from "@earendil-works/pi-ai/utils/cursor-context-limit";
 import type { ProviderModelConfig } from "../../types.ts";
 import { defaultCursorAgentExecutableDeps, resolveCursorAgentExecutable } from "./executable.ts";
 
@@ -78,7 +79,7 @@ function normalizeEntries(raw: readonly { id: string; label: string }[]): Provid
 		...(entry.thinkingLevelMap ? { thinkingLevelMap: entry.thinkingLevelMap } : {}),
 		input: ["text"] as ("text" | "image")[],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: entry.window,
+		contextWindow: resolveCursorContextWindow(entry.id, entry.window),
 		maxTokens: 64_000,
 		...(entry.representativeVariantId !== undefined && entry.representativeVariantId !== entry.id
 			? { upstreamModelId: entry.representativeVariantId }

--- a/packages/coding-agent/test/suite/regressions/1043-cursor-toolresult-truncate.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1043-cursor-toolresult-truncate.test.ts
@@ -1,15 +1,25 @@
+// Cursor admission bounds a request two ways: every tool result is capped on
+// its own, and the aggregate model input is held under an explicit budget by
+// blanking the oldest tool result bodies. Since senpi#1603 the budget comes
+// from the model window and admission never removes a message, so each case
+// below states the budget it exercises.
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { buildCursorHistoryWireBytesForTest } from "@earendil-works/pi-ai/api/cursor-agent";
+import { fauxAssistantMessage, fauxToolCall, measureCursorModelInputSerializedBytes } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-	CURSOR_TOOL_RESULT_MAX_BYTES,
-	CURSOR_TOOL_RESULT_MAX_CHARS,
-	truncateToolResultBodies,
-} from "../../../src/core/agent-session.ts";
-import { convertToLlmForTransport } from "../../../src/core/messages.ts";
+import { CURSOR_TOOL_RESULT_MAX_CHARS, truncateToolResultBodies } from "../../../src/core/agent-session.ts";
+import { admitCursorHistory } from "../../../src/core/cursor-history-admission.ts";
+import { convertToLlm, convertToLlmForTransport } from "../../../src/core/messages.ts";
 import { createHarness, type Harness } from "../harness.ts";
+
+// Observed Cursor context ceilings persist; keep them out of the real agent dir.
+process.env.CURSOR_CONTEXT_LIMIT_STORE = join(mkdtempSync(join(tmpdir(), "cursor-limits-")), "limits.json");
+
+/** Explicit aggregate budget these cases exercise, in serialized model-input bytes. */
+const BUDGET_BYTES = 50_000;
 
 function textMessage(role: AgentMessage["role"], text: string): AgentMessage {
 	return { role, content: [{ type: "text", text }] } as AgentMessage;
@@ -77,8 +87,23 @@ function cursorPairedMessages(resultTexts: string[]): AgentMessage[] {
 	return messages;
 }
 
-function serializedCursorHistoryBytes(messages: AgentMessage[]): number {
-	return buildCursorHistoryWireBytesForTest(messages as never).reduce((total, bytes) => total + bytes.byteLength, 0);
+/** Serialized bytes of what Cursor replays to the model, as admission measures it. */
+function modelInputBytes(messages: AgentMessage[], convert = convertToLlm): number {
+	const converted = convert(messages);
+	const activeUserMessageIndex = converted.at(-1)?.role === "user" ? converted.length - 1 : -1;
+	return measureCursorModelInputSerializedBytes(converted as never, activeUserMessageIndex);
+}
+
+function textBytes(messages: AgentMessage[]): number {
+	return new TextEncoder().encode(
+		messages
+			.flatMap((message) =>
+				message.role === "toolResult"
+					? message.content.filter((part) => part.type === "text").map((part) => part.text)
+					: [],
+			)
+			.join(""),
+	).byteLength;
 }
 
 describe("1043 cursor toolResult truncate", () => {
@@ -107,17 +132,20 @@ describe("1043 cursor toolResult truncate", () => {
 		expect(toolText).not.toContain("\ud800");
 	});
 
-	it("bounds the aggregate UTF-8 payload across all tool results", () => {
+	it("bounds the aggregate payload across all tool results without dropping one", () => {
 		const messages = Array.from({ length: 100 }, (_, index) =>
 			textMessage("toolResult", `${index}:${"가".repeat(2000)}`),
 		);
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const admission = admitCursorHistory({ messages, budgetBytes: BUDGET_BYTES });
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
+		expect(next.length).toBe(messages.length);
+		expect(admission.blankedToolResults).toBeGreaterThan(0);
 		expect(messageText(next[99])).toMatch(/^99:가+\n\.\.\.\[truncated\]$/);
 		expect(messageText(next[0])).toBe("");
-		const bytes = new TextEncoder().encode(next.map(messageText).join("")).byteLength;
-		expect(bytes).toBeLessThanOrEqual(50_000);
+		expect(textBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
+		expect(admission.bytesAfter).toBeLessThanOrEqual(BUDGET_BYTES);
 	});
 
 	it("reserves marker budget before the full-part fast path (review reproduction)", () => {
@@ -133,18 +161,10 @@ describe("1043 cursor toolResult truncate", () => {
 			toolResult("가".repeat(2000), "cjk-7"),
 			toolResult("n".repeat(1990), "newest"),
 		];
-		const { messages: next } = truncateToolResultBodies(messages);
+		const { messages: next } = truncateToolResultBodies(messages, CURSOR_TOOL_RESULT_MAX_CHARS, BUDGET_BYTES);
 		if (!next) throw new Error("expected messages");
-		const bytes = new TextEncoder().encode(
-			next
-				.flatMap((message) =>
-					message.role === "toolResult"
-						? message.content.filter((part) => part.type === "text").map((part) => part.text)
-						: [],
-				)
-				.join(""),
-		).byteLength;
-		expect(bytes).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(textBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
 	});
 
 	it("truncates Cursor admission while persisting the full tool result through AgentSession", async () => {
@@ -185,29 +205,41 @@ describe("1043 cursor toolResult truncate", () => {
 		).toBe("payload ".repeat(20_000));
 	});
 
-	it("bounds the duplicated decoded Cursor root and turn history for CJK results", () => {
+	it("bounds the decoded Cursor model input for CJK results", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 8 }, () => "界".repeat(2000)));
 		const rawBytes = new TextEncoder().encode(JSON.stringify(messages)).byteLength;
 		expect(rawBytes).toBeGreaterThan(48_000);
-		const { messages: next } = truncateToolResultBodies(messages);
+		const { messages: next } = truncateToolResultBodies(messages, CURSOR_TOOL_RESULT_MAX_CHARS, BUDGET_BYTES);
 		if (!next) throw new Error("expected messages");
-		expect(serializedCursorHistoryBytes(next)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
 	});
 
-	it("truncates newline-heavy parts before their serialized Cursor payload exceeds the cap", () => {
+	it("truncates newline-heavy parts before their serialized Cursor payload exceeds the budget", () => {
+		// 16,000 raw newline characters serialize to twice that once escaped, so the
+		// budget has to be compared against the serialized form, not the text length.
 		const messages = cursorPairedMessages(Array.from({ length: 8 }, () => "\n".repeat(2000)));
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const budgetBytes = 20_000;
+		const admission = admitCursorHistory({ messages, budgetBytes });
+		expect(admission.bytesBefore).toBeGreaterThan(budgetBytes);
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
-		expect(serializedCursorHistoryBytes(next)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next)).toBeLessThanOrEqual(budgetBytes);
 	});
 
-	it("truncates NUL-heavy parts before their serialized Cursor payload exceeds the cap", () => {
+	it("truncates NUL-heavy parts before their serialized Cursor payload exceeds the budget", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 8 }, () => "\0".repeat(2000)));
-		const { messages: next, changed } = truncateToolResultBodies(messages);
+		const { messages: next, changed } = truncateToolResultBodies(
+			messages,
+			CURSOR_TOOL_RESULT_MAX_CHARS,
+			BUDGET_BYTES,
+		);
 		expect(changed).toBe(true);
 		if (!next) throw new Error("expected messages");
-		expect(serializedCursorHistoryBytes(next)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
 	});
 
 	it("bounds 1,450 emptied image parts including their envelopes", () => {
@@ -215,18 +247,18 @@ describe("1043 cursor toolResult truncate", () => {
 		const result = messages.find((message) => message.role === "toolResult");
 		if (result?.role !== "toolResult") throw new Error("expected tool result");
 		result.content = (imageToolResult(1450) as Extract<AgentMessage, { role: "toolResult" }>).content;
-		const before = serializedCursorHistoryBytes(messages);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
+		const budgetBytes = 20_000;
+		expect(modelInputBytes(messages)).toBeGreaterThan(budgetBytes);
 
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const admission = admitCursorHistory({ messages, budgetBytes });
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
-		expect(
-			buildCursorHistoryWireBytesForTest(next as never).reduce((total, bytes) => total + bytes.byteLength, 0),
-		).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next)).toBeLessThanOrEqual(budgetBytes);
 	});
 
-	it("accounts for adversarial tool names in Cursor wire history", () => {
+	it("accounts for adversarial tool names in Cursor model input", () => {
 		const messages = cursorPairedMessages(["ok"]);
 		const result = messages.find((message) => message.role === "toolResult");
 		if (result?.role !== "toolResult") throw new Error("expected tool result");
@@ -236,14 +268,16 @@ describe("1043 cursor toolResult truncate", () => {
 		const toolCall = call.content.find((part) => part.type === "toolCall");
 		if (toolCall?.type !== "toolCall") throw new Error("expected tool call");
 		toolCall.name = result.toolName;
-		const before = serializedCursorHistoryBytes(messages);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const budgetBytes = 20_000;
+		expect(modelInputBytes(messages)).toBeGreaterThan(budgetBytes);
+		const admission = admitCursorHistory({ messages, budgetBytes });
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
-		expect(
-			buildCursorHistoryWireBytesForTest(next as never).reduce((total, bytes) => total + bytes.byteLength, 0),
-		).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		// A tool name is not a body: it cannot be blanked, so the request stays
+		// over budget and goes out anyway for the overflow path to handle.
+		expect(next.length).toBe(messages.length);
+		expect(admission.blankedToolResults).toBeGreaterThan(0);
 	});
 
 	it("uses the full history when admission ends in a resumed tool result", () => {
@@ -257,9 +291,10 @@ describe("1043 cursor toolResult truncate", () => {
 		const result = messages.find((message) => message.role === "toolResult");
 		if (result?.role !== "toolResult") throw new Error("expected tool result");
 		result.toolName = toolCall.name;
-		const { messages: next, changed } = truncateToolResultBodies(messages);
+		const { messages: next, changed } = truncateToolResultBodies(messages, CURSOR_TOOL_RESULT_MAX_CHARS, 20_000);
 		expect(changed).toBe(true);
-		expect(next).toBeDefined();
+		if (!next) throw new Error("expected messages");
+		expect(next.length).toBe(messages.length);
 	});
 
 	it("measures converted custom messages in Cursor admission", () => {
@@ -267,78 +302,100 @@ describe("1043 cursor toolResult truncate", () => {
 			{ role: "custom", customType: "note", content: "x".repeat(60_000), timestamp: 0 },
 			...cursorPairedMessages(["ok"]),
 		] as AgentMessage[];
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
-		expect(next).toBeDefined();
+		const admission = admitCursorHistory({ messages, budgetBytes: BUDGET_BYTES });
+		expect(admission.bytesBefore).toBeGreaterThan(BUDGET_BYTES);
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
+		if (!next) throw new Error("expected messages");
+		expect(next.length).toBe(messages.length);
 	});
 
-	it("keeps 200-turn Cursor admission bounded", () => {
+	it("keeps 200-turn Cursor admission bounded and complete", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 200 }, () => "x".repeat(2000)));
 		const started = performance.now();
-		truncateToolResultBodies(messages);
+		const admission = admitCursorHistory({ messages, budgetBytes: BUDGET_BYTES });
 		expect(performance.now() - started).toBeLessThan(1000);
+		// 200 turns of envelopes alone exceed this budget. Every body is blanked and
+		// the over-budget request still goes out whole - no turn is deleted (#1603).
+		expect(admission.messages?.length).toBe(messages.length);
+		expect(admission.blankedToolResults).toBe(200);
+		expect(admission.bytesAfter).toBeLessThan(admission.bytesBefore);
+		expect(admission.overBudget).toBe(true);
 	});
 
-	it("accounts for adversarial tool-call arguments in Cursor wire history", () => {
+	it("accounts for adversarial tool-call arguments in Cursor model input", () => {
 		const messages = cursorPairedMessages(["ok"]);
 		const call = messages.find((message) => message.role === "assistant");
 		if (call?.role !== "assistant") throw new Error("expected assistant message");
 		const toolCall = call.content.find((part) => part.type === "toolCall");
 		if (toolCall?.type !== "toolCall") throw new Error("expected tool call");
 		toolCall.arguments = { value: "a".repeat(25_000) };
-		const before = serializedCursorHistoryBytes(messages);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const budgetBytes = 20_000;
+		expect(modelInputBytes(messages)).toBeGreaterThan(budgetBytes);
+		const admission = admitCursorHistory({ messages, budgetBytes });
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
-		expect(
-			buildCursorHistoryWireBytesForTest(next as never).reduce((total, bytes) => total + bytes.byteLength, 0),
-		).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		// Tool-call arguments are history, not a body: the turn survives intact.
+		expect(next.length).toBe(messages.length);
+		expect(next.filter((message) => message.role === "user").length).toBe(
+			messages.filter((message) => message.role === "user").length,
+		);
 	});
 
-	it("does not evict fitting 68 paired tool turns", () => {
+	it("does not touch fitting 68 paired tool turns", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 68 }, () => "1234567890"));
-		const { messages: next, changed } = truncateToolResultBodies(messages);
+		const { messages: next, changed } = truncateToolResultBodies(
+			messages,
+			CURSOR_TOOL_RESULT_MAX_CHARS,
+			BUDGET_BYTES,
+		);
 		expect(changed).toBe(false);
 		expect(next).toBe(messages);
 	});
 
-	it("does not evict fitting 97 paired tool turns", () => {
+	it("does not touch fitting 97 paired tool turns", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 97 }, () => "1234567890"));
-		expect(serializedCursorHistoryBytes(messages)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
-		const { messages: next, changed } = truncateToolResultBodies(messages);
+		expect(modelInputBytes(messages)).toBeLessThanOrEqual(BUDGET_BYTES);
+		const { messages: next, changed } = truncateToolResultBodies(
+			messages,
+			CURSOR_TOOL_RESULT_MAX_CHARS,
+			BUDGET_BYTES,
+		);
 		expect(changed).toBe(false);
 		expect(next).toBe(messages);
 	});
 
-	it("bounds aggregate envelopes across 98 paired tool turns", () => {
+	it("blanks bodies rather than turns when 98 paired tool turns exceed the budget", () => {
 		const messages = cursorPairedMessages(Array.from({ length: 98 }, () => "1234567890"));
-		const before = serializedCursorHistoryBytes(messages);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
+		const budgetBytes = Math.floor(modelInputBytes(messages) / 2);
 
-		const { messages: next, changed } = truncateToolResultBodies(messages);
-		expect(changed).toBe(true);
+		const admission = admitCursorHistory({ messages, budgetBytes });
+		expect(admission.changed).toBe(true);
+		const next = admission.messages;
 		if (!next) throw new Error("expected messages");
-		expect(
-			buildCursorHistoryWireBytesForTest(next as never).reduce((total, bytes) => total + bytes.byteLength, 0),
-		).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(admission.blankedToolResults).toBeGreaterThan(0);
+		expect(admission.bytesAfter).toBeLessThan(admission.bytesBefore);
+		// Bodies are all this pass may empty; the remaining envelopes keep the
+		// request over budget, and it is admitted rather than trimmed.
+		expect(admission.overBudget).toBe(true);
 	});
 
 	for (const partCount of [7424, 7500]) {
-		it(`keeps the ${partCount}-part Cursor wire representation within the bound`, () => {
+		it(`keeps the ${partCount}-part Cursor model input within the budget`, () => {
 			const messages = cursorPairedMessages(["placeholder"]);
 			const result = messages.find((message) => message.role === "toolResult");
 			if (result?.role !== "toolResult") throw new Error("expected tool result");
 			result.content = Array.from({ length: partCount }, () => ({ type: "text" as const, text: "abcdefghij" }));
 
-			const { messages: next } = truncateToolResultBodies(messages);
+			const { messages: next } = truncateToolResultBodies(messages, CURSOR_TOOL_RESULT_MAX_CHARS, BUDGET_BYTES);
 			if (!next) throw new Error("expected messages");
+			expect(next.length).toBe(messages.length);
 			const transformed = next.find((message) => message.role === "toolResult");
 			if (transformed?.role !== "toolResult") throw new Error("expected transformed tool result");
 			expect(transformed.toolCallId).toBe(result.toolCallId);
-			expect(
-				buildCursorHistoryWireBytesForTest(next as never).reduce((total, bytes) => total + bytes.byteLength, 0),
-			).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+			expect(modelInputBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
 			expect(
 				transformed.content.filter((part) => part.type === "text" && part.text === "").length,
 			).toBeLessThanOrEqual(1);
@@ -353,17 +410,9 @@ describe("1043 cursor toolResult truncate", () => {
 					content: Array.from({ length: partCount }, () => ({ type: "text" as const, text: "abcdefghij" })),
 				},
 			];
-			const { messages: next } = truncateToolResultBodies(messages);
+			const { messages: next } = truncateToolResultBodies(messages, CURSOR_TOOL_RESULT_MAX_CHARS, BUDGET_BYTES);
 			if (!next) throw new Error("expected messages");
-			const bytes = new TextEncoder().encode(
-				next[0].role === "toolResult"
-					? next[0].content
-							.filter((part) => part.type === "text")
-							.map((part) => part.text)
-							.join("")
-					: "",
-			).byteLength;
-			expect(bytes).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+			expect(textBytes(next)).toBeLessThanOrEqual(BUDGET_BYTES);
 		});
 	}
 
@@ -378,17 +427,18 @@ describe("1043 cursor toolResult truncate", () => {
 		);
 		const convert = (candidate: AgentMessage[]) =>
 			convertToLlmForTransport(candidate, { blockImages: true, alwaysKeepNewest: 1 });
-		const before = serializedCursorHistoryBytes(convert(messages) as never);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
+		const budgetBytes = 15_000;
+		expect(modelInputBytes(messages, convert)).toBeGreaterThan(budgetBytes);
 		const { messages: next, changed } = truncateToolResultBodies(
 			messages,
 			CURSOR_TOOL_RESULT_MAX_CHARS,
-			CURSOR_TOOL_RESULT_MAX_BYTES,
+			budgetBytes,
 			convert,
 		);
 		expect(changed).toBe(true);
 		if (!next) throw new Error("expected messages");
-		expect(serializedCursorHistoryBytes(convert(next) as never)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next, convert)).toBeLessThanOrEqual(budgetBytes);
 	});
 
 	it("measures maxHistoricalImages elision with the configured transport converter (R9-1)", () => {
@@ -403,17 +453,17 @@ describe("1043 cursor toolResult truncate", () => {
 		messages.splice(messages.length - 1, 0, textMessage("assistant", "completed"));
 		const convert = (candidate: AgentMessage[]) =>
 			convertToLlmForTransport(candidate, { blockImages: false, maxHistoricalImages: 0, alwaysKeepNewest: 1 });
-		const before = serializedCursorHistoryBytes(convert(messages) as never);
-		expect(before).toBeGreaterThan(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(modelInputBytes(messages, convert)).toBeGreaterThan(BUDGET_BYTES);
 		const { messages: next, changed } = truncateToolResultBodies(
 			messages,
 			CURSOR_TOOL_RESULT_MAX_CHARS,
-			CURSOR_TOOL_RESULT_MAX_BYTES,
+			BUDGET_BYTES,
 			convert,
 		);
 		expect(changed).toBe(true);
 		if (!next) throw new Error("expected messages");
-		expect(serializedCursorHistoryBytes(convert(next) as never)).toBeLessThanOrEqual(CURSOR_TOOL_RESULT_MAX_BYTES);
+		expect(next.length).toBe(messages.length);
+		expect(modelInputBytes(next, convert)).toBeLessThanOrEqual(BUDGET_BYTES);
 	});
 
 	it("keeps grapheme clusters intact and retains a marker when only marker space remains", () => {

--- a/packages/coding-agent/test/suite/regressions/1043-cursor-toolresult-truncate.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1043-cursor-toolresult-truncate.test.ts
@@ -91,7 +91,7 @@ function cursorPairedMessages(resultTexts: string[]): AgentMessage[] {
 function modelInputBytes(messages: AgentMessage[], convert = convertToLlm): number {
 	const converted = convert(messages);
 	const activeUserMessageIndex = converted.at(-1)?.role === "user" ? converted.length - 1 : -1;
-	return measureCursorModelInputSerializedBytes(converted as never, activeUserMessageIndex);
+	return measureCursorModelInputSerializedBytes(converted, activeUserMessageIndex);
 }
 
 function textBytes(messages: AgentMessage[]): number {

--- a/packages/coding-agent/test/suite/regressions/1603-cursor-history-budget.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1603-cursor-history-budget.test.ts
@@ -1,0 +1,206 @@
+// Regression coverage for senpi issue #1603: the Cursor admission pass used a
+// fixed 50 KB aggregate budget and deleted whole conversation turns to reach
+// it, so a 1M-token window kept ~6K tokens of history. Admission must never
+// delete a turn; it caps tool result bodies against the model's real window and
+// hands an over-budget history to the existing overflow -> compaction path.
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import {
+	recordCursorContextLimit,
+	resetCursorContextLimitStoreForTest,
+} from "@earendil-works/pi-ai/utils/cursor-context-limit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { admitCursorHistory, cursorAdmissionBudgetBytes } from "../../../src/core/cursor-history-admission.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+// Observed ceilings persist to disk; keep this suite out of the real agent dir.
+process.env.CURSOR_CONTEXT_LIMIT_STORE = join(mkdtempSync(join(tmpdir(), "cursor-limits-")), "limits.json");
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: text, timestamp: 0 } as AgentMessage;
+}
+
+function assistantMessage(text: string, toolCallId?: string): AgentMessage {
+	return {
+		role: "assistant",
+		content:
+			toolCallId === undefined
+				? [{ type: "text", text }]
+				: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "a.ts" } }],
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "kimi-k3",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: toolCallId === undefined ? "stop" : "toolUse",
+		timestamp: 0,
+	} as AgentMessage;
+}
+
+function toolResultMessage(text: string, toolCallId: string): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	} as AgentMessage;
+}
+
+/** `turnCount` turns of `user -> assistant(toolCall) -> toolResult`, plus a live user turn. */
+function pairedToolTurns(turnCount: number, resultText: string): AgentMessage[] {
+	const messages: AgentMessage[] = [];
+	for (let index = 0; index < turnCount; index++) {
+		const toolCallId = `call-${index}`;
+		messages.push(userMessage(`request ${index}`));
+		messages.push(assistantMessage("", toolCallId));
+		messages.push(toolResultMessage(resultText, toolCallId));
+	}
+	messages.push(userMessage("continue"));
+	return messages;
+}
+
+function toolResultTexts(messages: AgentMessage[]): string[] {
+	return messages.flatMap((message) =>
+		message.role === "toolResult"
+			? message.content.filter((part) => part.type === "text").map((part) => part.text)
+			: [],
+	);
+}
+
+function userTexts(messages: AgentMessage[]): string[] {
+	return messages.flatMap((message) =>
+		message.role === "user" && typeof message.content === "string" ? [message.content] : [],
+	);
+}
+
+async function createCursorHarness(contextWindow: number): Promise<Harness> {
+	const harness = await createHarness({ provider: "cursor", models: [{ id: "kimi-k3", contextWindow }] });
+	harness.agent.sessionId = harness.sessionManager.getSessionId();
+	return harness;
+}
+
+function installedTransform(harness: Harness): (messages: AgentMessage[]) => Promise<AgentMessage[]> {
+	const transform = harness.agent.transformContext;
+	if (!transform) throw new Error("expected the Cursor admission transform to be installed");
+	return (messages) => transform(messages);
+}
+
+describe("1603 cursor history budget", () => {
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		resetCursorContextLimitStoreForTest();
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+		resetCursorContextLimitStoreForTest();
+	});
+
+	it("keeps a 30 KB user turn in a 1M-token window instead of deleting it", async () => {
+		// Given: a 1M-token Cursor model and a history whose first turn is 30 KB.
+		const harness = await createCursorHarness(1_048_576);
+		harnesses.push(harness);
+		const messages = [
+			userMessage(`${"filler ".repeat(4286)}Remember this codeword: BANANA7.`),
+			assistantMessage("OK"),
+			userMessage("What codeword did I ask you to remember?"),
+		];
+
+		// When: the installed Cursor admission transform runs.
+		const admitted = await installedTransform(harness)(messages);
+
+		// Then: every turn survives and the codeword still reaches the provider.
+		expect(admitted.length).toBe(messages.length);
+		expect(JSON.stringify(admitted)).toContain("BANANA7");
+	});
+
+	it("leaves a tool-free 60-turn history untouched inside a 1M-token window", async () => {
+		// Given: 60 turns of 10 KB user text and no tool results at all.
+		const harness = await createCursorHarness(1_048_576);
+		harnesses.push(harness);
+		const messages = Array.from({ length: 60 }, (_, index) => [
+			userMessage(`turn ${index}: ${"y".repeat(10_000)}`),
+			assistantMessage(`reply ${index}`),
+		]).flat();
+
+		// When: admission runs against the window-derived budget.
+		const admitted = await installedTransform(harness)(messages);
+		const admission = admitCursorHistory({ messages, budgetBytes: cursorAdmissionBudgetBytes(1_048_576) });
+
+		// Then: nothing is rewritten and nothing is dropped.
+		expect(admitted.length).toBe(messages.length);
+		expect(admission.changed).toBe(false);
+		expect(admission.blankedToolResults).toBe(0);
+		expect(admission.overBudget).toBe(false);
+	});
+
+	it("blanks the oldest tool bodies instead of turns when the window is small", async () => {
+		// Given: a 8,000-token window (32,000 bytes) and 40 paired tool turns.
+		const harness = await createCursorHarness(8_000);
+		harnesses.push(harness);
+		const messages = pairedToolTurns(40, "z".repeat(3_000));
+
+		// When: the installed transform admits them.
+		const admitted = await installedTransform(harness)(messages);
+		const admission = admitCursorHistory({ messages, budgetBytes: cursorAdmissionBudgetBytes(8_000) });
+
+		// Then: bodies shrink, conversation structure does not.
+		expect(admitted.length).toBe(messages.length);
+		expect(userTexts(admitted)).toEqual(userTexts(messages));
+		expect(admitted.filter((message) => message.role === "assistant").length).toBe(40);
+		const admittedResults = toolResultTexts(admitted);
+		expect(admittedResults.length).toBe(40);
+		expect(admittedResults.at(-1)).toMatch(/^z+\n\.\.\.\[truncated\]$/);
+		expect(Math.max(...admittedResults.map((text) => [...text].length))).toBeLessThanOrEqual(2000);
+		expect(admittedResults[0]).toBe("");
+		expect(admission.blankedToolResults).toBeGreaterThan(0);
+		expect(cursorAdmissionBudgetBytes(8_000)).toBe(32_000);
+	});
+
+	it("admits a history that is still over budget after blanking", async () => {
+		// Given: a 1,000-token window (4,000 bytes) and 20 KB of pure user text.
+		const harness = await createCursorHarness(1_000);
+		harnesses.push(harness);
+		const messages = [userMessage("w".repeat(20_000)), assistantMessage("OK"), userMessage("and now?")];
+
+		// When: admission runs with nothing blankable.
+		const admitted = await installedTransform(harness)(messages);
+		const admission = admitCursorHistory({ messages, budgetBytes: cursorAdmissionBudgetBytes(1_000) });
+
+		// Then: the history is handed on untouched for the overflow path to compact.
+		expect(admitted.length).toBe(messages.length);
+		expect(userTexts(admitted)).toEqual(userTexts(messages));
+		expect(admission.messages).toBe(messages);
+		expect(admission.changed).toBe(false);
+		expect(admission.blankedToolResults).toBe(0);
+		expect(admission.overBudget).toBe(true);
+	});
+
+	it("sizes context and budget from the ceiling Cursor reported for the model", async () => {
+		// Given: a catalog window of 1M and a server-observed ceiling of 200K.
+		const harness = await createCursorHarness(1_048_576);
+		harnesses.push(harness);
+		recordCursorContextLimit("kimi-k3", 200_000);
+
+		// When: a turn is admitted.
+		await installedTransform(harness)([userMessage("hi"), assistantMessage("hello"), userMessage("again")]);
+
+		// Then: the live model, its reported usage and the budget all use 200K.
+		const model = harness.session.model;
+		if (!model) throw new Error("expected a selected model");
+		expect(model.contextWindow).toBe(200_000);
+		expect(harness.session.getContextUsage()?.contextWindow).toBe(200_000);
+		expect(cursorAdmissionBudgetBytes(model.contextWindow)).toBe(800_000);
+	});
+});


### PR DESCRIPTION
Fixes #1603
Supersedes #1614 (builds on its measurements; see credits below).

## The defect

Cursor admission (`truncateToolResultBodies`) enforced a hardcoded 50,000-byte aggregate cap on every request and, when the cap was exceeded, deleted the oldest whole turns. It fired on conversations with zero tool results (a 30 KB tool-free first turn was evicted), the loss was silent (no marker, no log), and the constant had no relation to the model window, so compaction (80% of the window) never got a chance.

## Ideal state implemented

- **No whole-turn deletion, ever.** Pass 3 is removed. The per-result 2000-char cap and the oldest-tool-body blanking (the #1043 fix) stay. If history still exceeds the budget after blanking, the request is admitted as-is and the existing Cursor overflow -> compaction path summarizes it; nothing is dropped silently.
- **Budget from the effective context window.** `budgetBytes = effectiveWindowTokens * 4`, measured on the model input (`rootPromptMessagesJson` only). Effective window = the server-reported `ConversationTokenDetails.maxTokens` observed for that model id, persisted in `<agentDir>/cursor-context-limits.json` (override: `CURSOR_CONTEXT_LIMIT_STORE`), else the catalog `contextWindow`. The observed limit also corrects `model.contextWindow`, so compaction thresholds and overflow detection use the real ceiling.
- **Observable.** Session log entries `cursor_context_window_observed`, `cursor_admission_truncated`, `cursor_admission_over_budget`.

## Evidence

- RED on v2026.9.12 (c509106cd), live Cursor, the issue's two-process repro (`cursor/composer-2.5`, the account used has no `kimi-k3`): turn 1 `OK` (`builtRunRequest bytes 31779`), turn 2 answered that no codeword exists in the conversation.
- GREEN on this branch, same commands: turn 2 -> `BANANA7` (`builtRunRequest bytes 390`). The observed-limit store was written by the live run (`composer-2.5: 200000` against a 200K catalog window; the same file also recorded `claude-4.6-opus-high: 200000` against a 1M catalog window, confirming the catalog/server mismatch reported in #1614).
- Regression tests (RED before the fix, GREEN at HEAD): `packages/coding-agent/test/suite/regressions/1603-cursor-history-budget.test.ts` (issue repro through the installed transform, tool-free many-turn history untouched, blanking without deletion on a small window, over-budget admitted, observed limit corrects the window/budget), `packages/ai/test/cursor-context-limit-store.test.ts` (persistence, corrupt file, non-positive ignored), a checkpoint case in `cursor-conversation-rotation-stream.test.ts`; the #1043 suite rewritten to the no-deletion contract. Focused runs at HEAD: coding-agent 29/29, ai 16/16; `bun run check` exit 0; `scripts/check-pr-changelog.mjs` PASS locally.
- Trackers: `packages/ai/src/changes.md`, `packages/coding-agent/src/core/changes.md`; `CHANGELOG.md` [Unreleased] in both packages.

Full QA logs are held locally (evidence dir, not committed).

## Credits

The model-input measurement (`measureCursorModelInputSerializedBytes`) and the observation that Cursor's checkpoints report a smaller window than the catalog come from @DevNewbie1826's investigation in #1603 / #1614.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1603: Cursor request admission no longer enforces a hardcoded 50,000-byte cap that silently deleted the oldest whole turns. The budget now comes from the model's effective context window, only tool-result bodies are shrunk, and any history that still exceeds the budget is sent intact for the existing overflow-to-compaction path to handle.

- Records the context ceiling Cursor reports per conversation checkpoint (`tokenDetails.maxTokens`) and uses it instead of the catalog guess for `model.contextWindow`, compaction, and admission.
- Measures the model input alone (the `rootPromptMessagesJson` blobs) rather than the duplicated display copies, so the budget matches what Cursor actually ingests.
- Adds session logs for observed window, truncation, and over-budget admission.
- Persists observed limits in `<agentDir>/cursor-context-limits.json` (override with `CURSOR_CONTEXT_LIMIT_STORE`); a missing or corrupt file falls back to the catalog window.

<sup>Written for commit ee0a759ecb1887a2473845f6a6327b3df3d8d01a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

