### PR TITLE
feat(coding-agent): show the pending question in the async ask-user widget and make its shortcut rebindable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 ### Added
 
+- Added two chord-free ways to open a pending async ask-user question: Enter on an empty editor and the `/answer` command (which reports `No question is pending.` when there is nothing to open), so the question stays reachable when a terminal, multiplexer or another keymap swallows the shortcut.
+- Added the `app.question.answer` keybinding (default `alt+a`, `option+a` on macOS): the async ask-user shortcut can now be rebound in `keybindings.json`, is listed in `/hotkeys` and `docs/keybindings.md`, and the widget hint follows the configured chord (fixes #1623).
+
 ### Changed
+
+- The async ask-user widget above the editor now shows the pending question itself: the first unanswered question with its options (and how many more wait behind it), one truncated line each, moving on to the next unanswered question when a partial draft collapses; on macOS the Option-composed glyph accepted for the shortcut follows the bound letter instead of being fixed to `å`/`Å`.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -161,6 +161,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | `app.message.copy` | `ctrl+x` | Copy the selected message in `/tree`; otherwise copy the last assistant message, or the active fullscreen text selection when `fullscreenCopyOnSelect` is disabled |
 | `app.message.followUp` | `alt+enter` | Queue follow-up message |
 | `app.message.dequeue` | `alt+up` | Restore queued messages to editor |
+| `app.question.answer` | `alt+a` | Open the pending async question (Enter on an empty editor and `/answer` do the same without a chord; on macOS the Option-composed glyph of the bound letter is accepted too, except for the dead keys e, i, n, u) |
 
 ### Tree Navigation
 

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -180,7 +180,7 @@ Use `handle.unfocus()` when a visible overlay should stop owning input and let T
 
 When the agent asks a blocking question (`waitForAnswer: true`), a full-screen overlay appears with a tab for each question and a final Submit tab. Use digits or arrows to choose options, Space to toggle multi-select choices, and Enter to confirm and advance. The Submit tab contains the optional comment editor and accepts partial answers after confirmation; unanswered questions are reported back as unanswered. Esc backs out of an editor or asks for confirmation before discarding a draft.
 
-For async questions (`waitForAnswer: false`), a one-line widget appears above the editor showing the question count and a countdown. The agent keeps working while you decide. Type your reply in the editor at any time and press Enter to send it as a comment, or open the full overlay with the shortcut shown in the widget.
+For async questions (`waitForAnswer: false`), a widget appears above the editor while the agent keeps working: the unanswered count with a countdown, the first unanswered question with its options (and how many more questions wait behind it), and a hint listing every way in. Open the full overlay with Enter on an empty editor, with `/answer`, or with the `app.question.answer` shortcut (default `alt+a`, shown as `option+a` on macOS, rebindable in `keybindings.json`; on macOS the Option-composed glyph of the bound letter also works, so the shortcut needs no terminal settings change). Esc collapses the overlay back to the widget with your draft kept. Typing a reply in the editor and pressing Enter sends it as a comment instead.
 
 ### Overlay Lifecycle
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,34 @@
 # changes
 
+## 2026-09-12 - `app.question.answer` keybinding and `/answer` command for the async ask-user widget (senpi#1623)
+
+### What changed
+
+- `packages/coding-agent/src/core/keybindings.ts`: new `AppKeybindings` id `app.question.answer`
+  (`defaultKeys: "alt+a"`, "Open the pending question"), so the chord that expands a pending async
+  question is configurable in `keybindings.json` and visible to `/hotkeys` and the hint system.
+- `packages/coding-agent/src/core/extensions/builtin/ask-user/extension.ts`: registers the `/answer`
+  command ("Open the pending question") so it is listed and autocompleted; in TUI mode interactive-mode's
+  text dispatch handles it first (the `/keybindings` pattern), outside the TUI it notifies that the
+  command belongs to the TUI.
+
+### Why
+
+- The shortcut lived as a constant in the interactive widget and could not be rebound when another
+  keymap claimed Option/Alt+A; `/answer` gives a chord-free path that every terminal delivers.
+
+### Why an extension could not handle it
+
+- Keybinding ids are declared once in `KEYBINDINGS` and merged into the `pi-tui` `Keybindings`
+  augmentation; an extension cannot add an app-level id that `KeybindingsManager`, `/hotkeys` and
+  `keyText` resolve. The `/answer` command is registered through the extension API, but its TUI
+  behavior (mounting the overlay) is interactive-mode state that no extension hook reaches.
+
+### Expected merge conflict zones
+
+- LOW: the `AppKeybindings` interface and `KEYBINDINGS` table in `keybindings.ts` (fork-only ids sit
+  beside upstream ones); the ask-user extension is fork-only.
+
 ## 2026-09-12 - Cursor admission never deletes a turn (senpi#1603)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/extension.ts
@@ -1,3 +1,4 @@
+import { APP_NAME } from "../../../../config.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { pickVariant, TOOL_NAMES } from "./family.ts";
 import { getPendingQuestions } from "./registry.ts";
@@ -9,6 +10,19 @@ export default function askUserExtension(pi: ExtensionAPI): void {
 		description: "Disable the built-in question tool.",
 		type: "boolean",
 		default: false,
+	});
+	pi.registerCommand("answer", {
+		description: "Open the pending question",
+		handler: async (_args, ctx) => {
+			if (ctx.mode !== "tui") {
+				ctx.ui.notify(
+					`/answer opens the pending question in the TUI; run ${APP_NAME} in TUI mode to use it.`,
+					"info",
+				);
+				return;
+			}
+			// In TUI mode interactive-mode's text dispatch handles /answer first.
+		},
 	});
 	const state: AskUserState = { timedOut: false, unavailable: false };
 	let registered = false;

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -28,6 +28,7 @@ export interface AppKeybindings {
 	"app.message.copy": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
+	"app.question.answer": true;
 	"app.clipboard.pasteImage": true;
 	"app.session.new": true;
 	"app.session.tree": true;
@@ -137,6 +138,10 @@ export const KEYBINDINGS = {
 	"app.message.dequeue": {
 		defaultKeys: windowsKeybindings ? "alt+q" : "alt+up",
 		description: "Restore queued messages",
+	},
+	"app.question.answer": {
+		defaultKeys: "alt+a",
+		description: "Open the pending question",
 	},
 	"app.clipboard.pasteImage": {
 		defaultKeys: windowsKeybindings ? "alt+v" : "ctrl+v",

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,48 @@
+## 2026-09-12 - Async ask-user widget shows the question; rebindable shortcut and key-free paths (senpi#1623)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts`: the collapsed
+  widget renders four lines instead of one: `? Question pending (N unanswered) · <countdown>`, the
+  first unanswered question as `<header> — <question>`, its options as `1 A · 2 B · own answer`
+  (plus `+K more question(s)` when more wait), one `TruncatedText` line each, and a hint naming
+  every way in (`enter or <shortcut> to answer · /answer · or just type your reply`). The widget takes
+  the `QuestionRequest` and the live `QuestionDraft`, so a partial draft that collapses shows the next
+  unanswered question. `ASK_USER_ANSWER_KEY`, `renderAsyncQuestionLine` and `setUnanswered` are gone.
+- `packages/coding-agent/src/modes/interactive/components/ask-user-answer-key.ts` (new):
+  `ASK_USER_ANSWER_KEYBINDING = "app.question.answer"`, `matchesAskUserAnswerKey(data, platform,
+  keybindings)` resolving the chord through the `KeybindingsManager`, and `darwinOptionGlyphs(keys)`
+  mapping every bound `alt+<letter>` to its US-layout Option glyph pair (dead keys e/i/n/u excluded),
+  which generalizes the senpi#1620 `å`/`Å` acceptance to whatever letter the user binds.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `handleAskUserShortcut` delegates
+  to a new `expandPendingQuestion()`; the editor `onSubmit` calls it for an empty submission (Enter on
+  an empty editor opens the pending question, a no-op when nothing is pending); `/answer` is handled in
+  the text dispatch beside `/keybindings` and reports `No question is pending.` through `showStatus`;
+  `/hotkeys` lists `app.question.answer`.
+- `packages/coding-agent/src/modes/interactive/tips/catalog/input-tips.ts`: new `open-pending-question`
+  tip bound to `app.question.answer`.
+- Docs: `docs/tui.md` async-widget paragraph, `docs/keybindings.md` row for `app.question.answer`.
+
+### Why
+
+- The one-line widget only said that a question existed, so a pending question could sit through its
+  whole idle countdown unnoticed. The single `alt+a` chord was a constant outside the keybinding
+  system: not rebindable, absent from `/hotkeys`, and dead whenever a terminal, multiplexer or workspace
+  prefix claimed Option/Alt+A, with no chord-free way to open the overlay.
+
+### Why an extension could not handle it
+
+- The async widget, the pending-question state and the editor submit path are interactive-mode
+  internals; extensions reach neither the editor's empty-submission branch nor the overlay mount.
+  `/answer` itself is registered by the builtin ask-user extension (see `src/core/changes.md`) and
+  intercepted by interactive-mode the way `/keybindings` is.
+
+### Expected merge conflict zones
+
+- LOW: the ask-user import block, `refreshAsyncWidget`, `handleAskUserShortcut`, the empty-text guard
+  in `setupEditorSubmitHandler`, the `/keybindings` dispatch neighbour and the `/hotkeys` table in
+  `interactive-mode.ts` (fork-only code paths).
+
 ## 2026-09-12 - Async ask-user shortcut accepts macOS Option-composed glyphs (senpi#1620)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-answer-key.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-answer-key.ts
@@ -1,0 +1,69 @@
+/**
+ * The editor shortcut that expands a pending async (waitForAnswer=false)
+ * question into the full AskUserQuestionComponent: a rebindable keybinding
+ * action plus the macOS Option-compose glyphs that stand in for it when the
+ * terminal does not report Option as Alt.
+ */
+
+import { decodeKittyPrintable, getKeybindings, type KeybindingsManager, type KeyId } from "@earendil-works/pi-tui";
+
+/** Keybinding action (default `alt+a`, rebindable in keybindings.json) that expands the pending question. */
+export const ASK_USER_ANSWER_KEYBINDING = "app.question.answer";
+
+/**
+ * What each letter key types on a US-layout macOS keyboard while Option is
+ * held and the terminal lets Option compose characters instead of sending
+ * Alt (the default in Terminal.app, iTerm2, Ghostty and kitty), as
+ * `[Option+letter, Option+Shift+letter]`. Accepting the glyphs of the bound
+ * `alt+<letter>` chords keeps the advertised shortcut working without a
+ * terminal-settings detour; other platforms never see Option this way, so
+ * they keep treating the glyphs as text. The dead keys `e`, `i`, `n` and `u`
+ * compose with the next keystroke instead of typing a glyph, so a binding on
+ * one of them needs the terminal's Option-as-Meta setting.
+ */
+const DARWIN_OPTION_GLYPHS: Readonly<Record<string, readonly [string, string]>> = {
+	a: ["å", "Å"],
+	b: ["∫", "ı"],
+	c: ["ç", "Ç"],
+	d: ["∂", "Î"],
+	f: ["ƒ", "Ï"],
+	g: ["©", "˝"],
+	h: ["˙", "Ó"],
+	j: ["∆", "Ô"],
+	k: ["˚", "\uf8ff"],
+	l: ["¬", "Ò"],
+	m: ["µ", "Â"],
+	o: ["ø", "Ø"],
+	p: ["π", "∏"],
+	q: ["œ", "Œ"],
+	r: ["®", "‰"],
+	s: ["ß", "Í"],
+	t: ["†", "ˇ"],
+	v: ["√", "◊"],
+	w: ["∑", "„"],
+	x: ["≈", "˛"],
+	y: ["¥", "Á"],
+	z: ["Ω", "¸"],
+};
+
+/** Glyphs the bound `alt+<letter>` chords type on darwin when Option composes. */
+export function darwinOptionGlyphs(keys: readonly KeyId[]): ReadonlySet<string> {
+	const glyphs = new Set<string>();
+	for (const key of keys) {
+		const letter = /^alt\+([a-z])$/i.exec(key)?.[1]?.toLowerCase();
+		if (letter === undefined) continue;
+		for (const glyph of DARWIN_OPTION_GLYPHS[letter] ?? []) glyphs.add(glyph);
+	}
+	return glyphs;
+}
+
+/** True when `data` is the editor input that expands the pending question on `platform`. */
+export function matchesAskUserAnswerKey(
+	data: string,
+	platform: NodeJS.Platform = process.platform,
+	keybindings: KeybindingsManager = getKeybindings(),
+): boolean {
+	if (keybindings.matches(data, ASK_USER_ANSWER_KEYBINDING)) return true;
+	if (platform !== "darwin") return false;
+	return darwinOptionGlyphs(keybindings.getKeys(ASK_USER_ANSWER_KEYBINDING)).has(decodeKittyPrintable(data) ?? data);
+}

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
@@ -91,8 +91,12 @@ export function renderOptionsLine(question: Question, remaining: number): string
 /** Hint naming every way into the pending question; the shortcut segment follows the effective binding. */
 export function renderAnswerHint(): string {
 	const shortcut = keyText(ASK_USER_ANSWER_KEYBINDING);
-	if (shortcut === "") return theme.fg("muted", "type your reply to answer");
-	return theme.fg("dim", shortcut) + theme.fg("muted", " to answer, or just type your reply");
+	const keys = shortcut === "" ? "enter" : `enter or ${shortcut}`;
+	return [
+		theme.fg("dim", keys) + theme.fg("muted", " to answer"),
+		theme.fg("dim", "/answer"),
+		theme.fg("muted", "or just type your reply"),
+	].join(theme.fg("muted", " · "));
 }
 
 export interface AskUserAsyncWidgetOptions {

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
@@ -6,31 +6,81 @@
  * interactive-mode can turn ordinary composer text into the comment answer.
  */
 
-import { Container, decodeKittyPrintable, matchesKey, Text, type TUI } from "@earendil-works/pi-tui";
+import {
+	Container,
+	decodeKittyPrintable,
+	getKeybindings,
+	type KeybindingsManager,
+	type KeyId,
+	Text,
+	type TUI,
+} from "@earendil-works/pi-tui";
 import type { QuestionRequest, QuestionResponse } from "../../../core/extensions/types.ts";
 import { theme } from "../theme/theme.ts";
 import { formatCountdownLabel, type QuestionDraft } from "./ask-user-question-state.ts";
 import { CountdownTimer } from "./countdown-timer.ts";
-import { rawKeyHint } from "./keybinding-hints.ts";
+import { keyText } from "./keybinding-hints.ts";
 
 /** Widget slot key used with `setWidget`; one pending async question at a time. */
 export const ASK_USER_WIDGET_KEY = "ask-user";
-/** Editor shortcut that expands the pending question into the full component. */
-export const ASK_USER_ANSWER_KEY = "alt+a";
+/** Keybinding action (default `alt+a`, rebindable in keybindings.json) that expands the pending question. */
+export const ASK_USER_ANSWER_KEYBINDING = "app.question.answer";
 /**
- * What the `a` key types on macOS when the terminal lets Option compose
- * characters instead of sending it as Alt (the default in Terminal.app,
- * iTerm2, Ghostty and kitty). Accepting these keeps the advertised `option+a`
- * working without a terminal-settings detour; other platforms never see
- * Option this way, so they keep treating the glyphs as text.
+ * What each letter key types on a US-layout macOS keyboard while Option is
+ * held and the terminal lets Option compose characters instead of sending
+ * Alt (the default in Terminal.app, iTerm2, Ghostty and kitty), as
+ * `[Option+letter, Option+Shift+letter]`. Accepting the glyphs of the bound
+ * `alt+<letter>` chords keeps the advertised shortcut working without a
+ * terminal-settings detour; other platforms never see Option this way, so
+ * they keep treating the glyphs as text. The dead keys `e`, `i`, `n` and `u`
+ * compose with the next keystroke instead of typing a glyph, so a binding on
+ * one of them needs the terminal's Option-as-Meta setting.
  */
-const DARWIN_OPTION_A_GLYPHS: ReadonlySet<string> = new Set(["å", "Å"]);
+const DARWIN_OPTION_GLYPHS: Readonly<Record<string, readonly [string, string]>> = {
+	a: ["å", "Å"],
+	b: ["∫", "ı"],
+	c: ["ç", "Ç"],
+	d: ["∂", "Î"],
+	f: ["ƒ", "Ï"],
+	g: ["©", "˝"],
+	h: ["˙", "Ó"],
+	j: ["∆", "Ô"],
+	k: ["˚", "\uf8ff"],
+	l: ["¬", "Ò"],
+	m: ["µ", "Â"],
+	o: ["ø", "Ø"],
+	p: ["π", "∏"],
+	q: ["œ", "Œ"],
+	r: ["®", "‰"],
+	s: ["ß", "Í"],
+	t: ["†", "ˇ"],
+	v: ["√", "◊"],
+	w: ["∑", "„"],
+	x: ["≈", "˛"],
+	y: ["¥", "Á"],
+	z: ["Ω", "¸"],
+};
+
+/** Glyphs the bound `alt+<letter>` chords type on darwin when Option composes. */
+export function darwinOptionGlyphs(keys: readonly KeyId[]): ReadonlySet<string> {
+	const glyphs = new Set<string>();
+	for (const key of keys) {
+		const letter = /^alt\+([a-z])$/i.exec(key)?.[1]?.toLowerCase();
+		if (letter === undefined) continue;
+		for (const glyph of DARWIN_OPTION_GLYPHS[letter] ?? []) glyphs.add(glyph);
+	}
+	return glyphs;
+}
 
 /** True when `data` is the editor input that expands the pending question on `platform`. */
-export function matchesAskUserAnswerKey(data: string, platform: NodeJS.Platform = process.platform): boolean {
-	if (matchesKey(data, ASK_USER_ANSWER_KEY)) return true;
+export function matchesAskUserAnswerKey(
+	data: string,
+	platform: NodeJS.Platform = process.platform,
+	keybindings: KeybindingsManager = getKeybindings(),
+): boolean {
+	if (keybindings.matches(data, ASK_USER_ANSWER_KEYBINDING)) return true;
 	if (platform !== "darwin") return false;
-	return DARWIN_OPTION_A_GLYPHS.has(decodeKittyPrintable(data) ?? data);
+	return darwinOptionGlyphs(keybindings.getKeys(ASK_USER_ANSWER_KEYBINDING)).has(decodeKittyPrintable(data) ?? data);
 }
 
 function hasAnswer(answer: QuestionResponse["answers"][string] | undefined): boolean {
@@ -74,13 +124,20 @@ export function buildTimedOutResponse(
 	};
 }
 
+/** Hint naming every way into the pending question; the shortcut segment follows the effective binding. */
+export function renderAnswerHint(): string {
+	const shortcut = keyText(ASK_USER_ANSWER_KEYBINDING);
+	if (shortcut === "") return theme.fg("muted", "type your reply to answer");
+	return theme.fg("dim", shortcut) + theme.fg("muted", " to answer, or just type your reply");
+}
+
 export function renderAsyncQuestionLine(unanswered: number, countdownLabel: string): string {
 	const countdown = countdownLabel === "" ? "" : theme.fg("muted", ` · ${countdownLabel}`);
 	return (
 		theme.fg("accent", theme.bold("?")) +
 		theme.fg("text", ` Question pending (${unanswered} unanswered)`) +
 		theme.fg("muted", " - ") +
-		rawKeyHint(ASK_USER_ANSWER_KEY, "to answer, or just type your reply") +
+		renderAnswerHint() +
 		countdown
 	);
 }

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts
@@ -1,87 +1,26 @@
 /**
- * Collapsed one-line widget for a pending async (waitForAnswer=false)
- * question: it sits above the editor, shows the unanswered count and the
- * idle countdown, and names the shortcut that expands the full
- * AskUserQuestionComponent. The response-building helpers here are pure so
- * interactive-mode can turn ordinary composer text into the comment answer.
+ * Collapsed widget for a pending async (waitForAnswer=false) question: it
+ * sits above the editor and shows the unanswered count with the idle
+ * countdown, the first unanswered question with its options, and every way
+ * into the full AskUserQuestionComponent. The response-building helpers here
+ * are pure so interactive-mode can turn ordinary composer text into the
+ * comment answer.
  */
 
-import {
-	Container,
-	decodeKittyPrintable,
-	getKeybindings,
-	type KeybindingsManager,
-	type KeyId,
-	Text,
-	type TUI,
-} from "@earendil-works/pi-tui";
+import { Container, Text, TruncatedText, type TUI } from "@earendil-works/pi-tui";
 import type { QuestionRequest, QuestionResponse } from "../../../core/extensions/types.ts";
 import { theme } from "../theme/theme.ts";
+import { ASK_USER_ANSWER_KEYBINDING } from "./ask-user-answer-key.ts";
 import { formatCountdownLabel, type QuestionDraft } from "./ask-user-question-state.ts";
 import { CountdownTimer } from "./countdown-timer.ts";
 import { keyText } from "./keybinding-hints.ts";
 
 /** Widget slot key used with `setWidget`; one pending async question at a time. */
 export const ASK_USER_WIDGET_KEY = "ask-user";
-/** Keybinding action (default `alt+a`, rebindable in keybindings.json) that expands the pending question. */
-export const ASK_USER_ANSWER_KEYBINDING = "app.question.answer";
-/**
- * What each letter key types on a US-layout macOS keyboard while Option is
- * held and the terminal lets Option compose characters instead of sending
- * Alt (the default in Terminal.app, iTerm2, Ghostty and kitty), as
- * `[Option+letter, Option+Shift+letter]`. Accepting the glyphs of the bound
- * `alt+<letter>` chords keeps the advertised shortcut working without a
- * terminal-settings detour; other platforms never see Option this way, so
- * they keep treating the glyphs as text. The dead keys `e`, `i`, `n` and `u`
- * compose with the next keystroke instead of typing a glyph, so a binding on
- * one of them needs the terminal's Option-as-Meta setting.
- */
-const DARWIN_OPTION_GLYPHS: Readonly<Record<string, readonly [string, string]>> = {
-	a: ["å", "Å"],
-	b: ["∫", "ı"],
-	c: ["ç", "Ç"],
-	d: ["∂", "Î"],
-	f: ["ƒ", "Ï"],
-	g: ["©", "˝"],
-	h: ["˙", "Ó"],
-	j: ["∆", "Ô"],
-	k: ["˚", "\uf8ff"],
-	l: ["¬", "Ò"],
-	m: ["µ", "Â"],
-	o: ["ø", "Ø"],
-	p: ["π", "∏"],
-	q: ["œ", "Œ"],
-	r: ["®", "‰"],
-	s: ["ß", "Í"],
-	t: ["†", "ˇ"],
-	v: ["√", "◊"],
-	w: ["∑", "„"],
-	x: ["≈", "˛"],
-	y: ["¥", "Á"],
-	z: ["Ω", "¸"],
-};
 
-/** Glyphs the bound `alt+<letter>` chords type on darwin when Option composes. */
-export function darwinOptionGlyphs(keys: readonly KeyId[]): ReadonlySet<string> {
-	const glyphs = new Set<string>();
-	for (const key of keys) {
-		const letter = /^alt\+([a-z])$/i.exec(key)?.[1]?.toLowerCase();
-		if (letter === undefined) continue;
-		for (const glyph of DARWIN_OPTION_GLYPHS[letter] ?? []) glyphs.add(glyph);
-	}
-	return glyphs;
-}
+type Question = QuestionRequest["questions"][number];
 
-/** True when `data` is the editor input that expands the pending question on `platform`. */
-export function matchesAskUserAnswerKey(
-	data: string,
-	platform: NodeJS.Platform = process.platform,
-	keybindings: KeybindingsManager = getKeybindings(),
-): boolean {
-	if (keybindings.matches(data, ASK_USER_ANSWER_KEYBINDING)) return true;
-	if (platform !== "darwin") return false;
-	return darwinOptionGlyphs(keybindings.getKeys(ASK_USER_ANSWER_KEYBINDING)).has(decodeKittyPrintable(data) ?? data);
-}
+const INDENT = "  ";
 
 function hasAnswer(answer: QuestionResponse["answers"][string] | undefined): boolean {
 	if (!answer) return false;
@@ -124,6 +63,31 @@ export function buildTimedOutResponse(
 	};
 }
 
+export function renderStatusLine(unanswered: number, countdownLabel: string): string {
+	const countdown = countdownLabel === "" ? "" : theme.fg("muted", ` · ${countdownLabel}`);
+	return (
+		theme.fg("accent", theme.bold("?")) + theme.fg("text", ` Question pending (${unanswered} unanswered)`) + countdown
+	);
+}
+
+export function renderQuestionLine(question: Question): string {
+	return (
+		INDENT +
+		theme.fg("text", theme.bold(question.header)) +
+		theme.fg("muted", " — ") +
+		theme.fg("text", question.question)
+	);
+}
+
+export function renderOptionsLine(question: Question, remaining: number): string {
+	const parts = question.options.map(
+		(option, index) => theme.fg("dim", `${index + 1}`) + theme.fg("muted", ` ${option.label}`),
+	);
+	parts.push(theme.fg("muted", "own answer"));
+	if (remaining > 0) parts.push(theme.fg("muted", `+${remaining} more question${remaining === 1 ? "" : "s"}`));
+	return INDENT + parts.join(theme.fg("muted", " · "));
+}
+
 /** Hint naming every way into the pending question; the shortcut segment follows the effective binding. */
 export function renderAnswerHint(): string {
 	const shortcut = keyText(ASK_USER_ANSWER_KEYBINDING);
@@ -131,19 +95,9 @@ export function renderAnswerHint(): string {
 	return theme.fg("dim", shortcut) + theme.fg("muted", " to answer, or just type your reply");
 }
 
-export function renderAsyncQuestionLine(unanswered: number, countdownLabel: string): string {
-	const countdown = countdownLabel === "" ? "" : theme.fg("muted", ` · ${countdownLabel}`);
-	return (
-		theme.fg("accent", theme.bold("?")) +
-		theme.fg("text", ` Question pending (${unanswered} unanswered)`) +
-		theme.fg("muted", " - ") +
-		renderAnswerHint() +
-		countdown
-	);
-}
-
 export interface AskUserAsyncWidgetOptions {
-	unanswered: number;
+	request: QuestionRequest;
+	draft: QuestionDraft;
 	/** Idle countdown shown in the line; 0 disables it. */
 	timeoutMs: number;
 	tui?: TUI;
@@ -151,15 +105,15 @@ export interface AskUserAsyncWidgetOptions {
 }
 
 export class AskUserAsyncWidget extends Container {
-	private readonly line = new Text("", 1, 0);
+	private readonly request: QuestionRequest;
+	private readonly draft: QuestionDraft;
 	private readonly countdown: CountdownTimer | undefined;
-	private unanswered: number;
 	private countdownLabel = "";
 
 	constructor(options: AskUserAsyncWidgetOptions) {
 		super();
-		this.unanswered = options.unanswered;
-		this.addChild(this.line);
+		this.request = options.request;
+		this.draft = options.draft;
 		if (options.timeoutMs > 0) {
 			this.countdown = new CountdownTimer(
 				options.timeoutMs,
@@ -174,16 +128,20 @@ export class AskUserAsyncWidget extends Container {
 		this.update();
 	}
 
-	setUnanswered(count: number): void {
-		this.unanswered = count;
-		this.update();
-	}
-
 	dispose(): void {
 		this.countdown?.dispose();
+		super.dispose();
 	}
 
 	private update(): void {
-		this.line.setText(renderAsyncQuestionLine(this.unanswered, this.countdownLabel));
+		const pending = unansweredIds(this.request, this.draft);
+		const shown = this.request.questions.find((question) => question.id === pending[0]);
+		this.clear();
+		this.addChild(new Text(renderStatusLine(pending.length, this.countdownLabel), 1, 0));
+		if (shown) {
+			this.addChild(new TruncatedText(renderQuestionLine(shown), 1, 0));
+			this.addChild(new TruncatedText(renderOptionsLine(shown, pending.length - 1), 1, 0));
+		}
+		this.addChild(new Text(INDENT + renderAnswerHint(), 1, 0));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9047,6 +9047,7 @@ export class InteractiveMode {
 		const copyMessage = this.getAppKeyDisplay("app.message.copy");
 		const followUp = this.getAppKeyDisplay("app.message.followUp");
 		const dequeue = this.getAppKeyDisplay("app.message.dequeue");
+		const answerQuestion = this.getAppKeyDisplay("app.question.answer");
 		const pasteImage = this.getAppKeyDisplay("app.clipboard.pasteImage");
 
 		let hotkeys = `
@@ -9091,6 +9092,7 @@ export class InteractiveMode {
 | \`${copyMessage}\` | Copy last assistant message |
 | \`${followUp}\` | Queue follow-up message |
 | \`${dequeue}\` | Restore queued messages |
+| \`${answerQuestion}\` | Open the pending question (also: Enter on an empty editor, or /answer) |
 | \`${pasteImage}\` | Paste image or text from clipboard |
 | \`/\` | Slash commands |
 | \`!\` | Run bash command |

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3945,8 +3945,18 @@ export class InteractiveMode {
 
 	/** Editor shortcut: expand the pending async question into the full component. */
 	private handleAskUserShortcut(data: string): boolean {
+		if (!this.asyncQuestion || this.askUserQuestion || !matchesAskUserAnswerKey(data)) return false;
+		return this.expandPendingQuestion();
+	}
+
+	/**
+	 * Key-free entry into the pending async question (empty Enter, /answer):
+	 * mounts the full component in place of the editor. Returns false when
+	 * nothing is pending or the component is already open.
+	 */
+	private expandPendingQuestion(): boolean {
 		const state = this.asyncQuestion;
-		if (!state || this.askUserQuestion || !matchesAskUserAnswerKey(data)) return false;
+		if (!state || this.askUserQuestion) return false;
 		const component = new AskUserQuestionComponent(
 			state.request,
 			(response) => {
@@ -4507,7 +4517,12 @@ export class InteractiveMode {
 				this.hideShortcutOverlay();
 				this.lastEditorText = "";
 				text = text.trim();
-				if (!text) return;
+				if (!text) {
+					// Enter on an empty editor opens the pending async question; it needs
+					// no chord, so it works under every terminal and keymap.
+					this.expandPendingQuestion();
+					return;
+				}
 
 				// A pending async question claims ordinary text as its comment answer;
 				// slash and bash commands keep their normal routing.
@@ -4579,6 +4594,11 @@ export class InteractiveMode {
 				if (text === "/keybindings") {
 					this.editor.setText("");
 					await this.handleKeybindingsCommand();
+					return;
+				}
+				if (text === "/answer") {
+					this.editor.setText("");
+					if (!this.expandPendingQuestion()) this.showStatus("No question is pending.");
 					return;
 				}
 				if (text === "/hotkeys") {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -148,13 +148,12 @@ import {
 	waitForPromptDisposition,
 } from "./compaction-queue-transfer.ts";
 import { ArminComponent } from "./components/armin.ts";
+import { matchesAskUserAnswerKey } from "./components/ask-user-answer-key.ts";
 import {
 	ASK_USER_WIDGET_KEY,
 	AskUserAsyncWidget,
 	buildCommentResponse,
 	buildTimedOutResponse,
-	matchesAskUserAnswerKey,
-	unansweredIds,
 } from "./components/ask-user-async-widget.ts";
 import { AskUserQuestionComponent } from "./components/ask-user-question.ts";
 import type { QuestionDraft } from "./components/ask-user-question-state.ts";
@@ -3935,7 +3934,8 @@ export class InteractiveMode {
 		this.setExtensionWidget(ASK_USER_WIDGET_KEY, (tui) => {
 			const startedAt = Date.now();
 			return new AskUserAsyncWidget({
-				unanswered: unansweredIds(state.request, state.draft).length,
+				request: state.request,
+				draft: state.draft,
 				timeoutMs: state.timeoutMs,
 				tui,
 				onExpire: () => state.finish(buildTimedOutResponse(state.request, state.draft, Date.now() - startedAt)),

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/input-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/input-tips.ts
@@ -91,4 +91,10 @@ export const INPUT_TIPS = [
 		render: () =>
 			"When the agent asks you a question, pick options with digits or arrows, press Enter to advance, and use the final Submit tab for a comment or partial answers; anything unanswered is reported back as unanswered.",
 	},
+	{
+		id: "open-pending-question",
+		bindings: ["app.question.answer"],
+		render: (keys) =>
+			`A question parked above the editor while the agent works shows what it asks; open it with Enter on an empty editor, /answer, or ${keys("app.question.answer")}.`,
+	},
 ] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/test/suite/ask-user-async-key-free-paths.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-key-free-paths.test.ts
@@ -1,0 +1,114 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { QuestionRequest } from "../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../src/core/keybindings.ts";
+import { ASK_USER_WIDGET_KEY } from "../../src/modes/interactive/components/ask-user-async-widget.ts";
+import { AskUserQuestionComponent } from "../../src/modes/interactive/components/ask-user-question.ts";
+import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../src/utils/ansi.ts";
+import { createFakeInteractiveMode, type FakeInteractiveMode } from "./helpers/ask-user-async-fake-mode.ts";
+
+const ESC = "\x1b";
+
+function buildRequest(): QuestionRequest {
+	return {
+		requestId: "req-key-free",
+		questions: [
+			{
+				id: "auth",
+				header: "Auth",
+				question: "Which auth method?",
+				options: [{ label: "OAuth" }, { label: "API key" }],
+				multiSelect: false,
+			},
+		],
+		waitForAnswer: false,
+		timeoutMs: 30 * 60_000,
+	};
+}
+
+function askPending(fake: FakeInteractiveMode): Promise<unknown> {
+	const pending = fake.createExtensionUIContext().question?.(buildRequest(), { timeout: 30 * 60_000 });
+	if (!pending) throw new Error("question() returned nothing");
+	return pending;
+}
+
+function overlay(fake: FakeInteractiveMode): AskUserQuestionComponent | undefined {
+	return fake.editorContainer.children.find((child) => child instanceof AskUserQuestionComponent);
+}
+
+describe("key-free ways into a pending async question", () => {
+	beforeAll(() => {
+		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("opens the pending question on Enter with an empty editor", async () => {
+		const fake = createFakeInteractiveMode({ isStreaming: true });
+		void askPending(fake);
+
+		await fake.submitEditorText("");
+
+		const component = overlay(fake);
+		expect(component).toBeInstanceOf(AskUserQuestionComponent);
+		expect(fake.ui.setFocus).toHaveBeenLastCalledWith(component);
+		expect(fake.session.prompt).not.toHaveBeenCalled();
+		expect(fake.session.sendUserMessage).not.toHaveBeenCalled();
+	});
+
+	it("collapses back to the widget on Esc after an empty-Enter expansion", async () => {
+		const fake = createFakeInteractiveMode({ isStreaming: true });
+		void askPending(fake);
+		await fake.submitEditorText("");
+
+		overlay(fake)?.handleInput(ESC);
+
+		expect(overlay(fake)).toBeUndefined();
+		expect(fake.editorContainer.children).toContain(fake.editor);
+		expect(fake.widgetText(ASK_USER_WIDGET_KEY)).toContain("Question pending (1 unanswered)");
+	});
+
+	it("keeps an empty Enter a no-op when nothing is pending", async () => {
+		const fake = createFakeInteractiveMode({ isStreaming: false });
+
+		await fake.submitEditorText("");
+
+		expect(overlay(fake)).toBeUndefined();
+		expect(fake.session.prompt).not.toHaveBeenCalled();
+		expect(fake.session.sendUserMessage).not.toHaveBeenCalled();
+		expect(fake.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("opens the pending question on /answer", async () => {
+		const fake = createFakeInteractiveMode({ isStreaming: true });
+		void askPending(fake);
+
+		await fake.submitEditorText("/answer");
+
+		expect(overlay(fake)).toBeInstanceOf(AskUserQuestionComponent);
+		expect(fake.editor.setText).toHaveBeenCalledWith("");
+		expect(fake.session.prompt).not.toHaveBeenCalled();
+		expect(fake.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("reports that nothing is pending on /answer without a question", async () => {
+		const fake = createFakeInteractiveMode({ isStreaming: false });
+
+		await fake.submitEditorText("/answer");
+
+		expect(overlay(fake)).toBeUndefined();
+		expect(fake.showStatus).toHaveBeenCalledWith("No question is pending.");
+		expect(fake.editor.setText).toHaveBeenCalledWith("");
+		expect(fake.session.prompt).not.toHaveBeenCalled();
+	});
+
+	it("names Enter and /answer in the widget hint beside the shortcut", () => {
+		const fake = createFakeInteractiveMode();
+		void askPending(fake);
+
+		const text = stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "");
+		expect(text).toContain("enter");
+		expect(text).toContain("/answer");
+		expect(text).toContain("to answer");
+	});
+});

--- a/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
@@ -1,5 +1,7 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { QuestionRequest } from "../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../src/core/keybindings.ts";
 import {
 	ASK_USER_WIDGET_KEY,
 	matchesAskUserAnswerKey,
@@ -15,6 +17,11 @@ const OPTION_A_GLYPH = "å";
 const OPTION_SHIFT_A_GLYPH = "Å";
 /** The same glyph reported as a CSI-u printable while the kitty keyboard protocol is active. */
 const KITTY_OPTION_A_GLYPH = "\x1b[229u";
+const ALT_Q = "\x1bq";
+/** What Option+Q / Option+Shift+Q type on the same macOS terminals. */
+const OPTION_Q_GLYPH = "\u0153";
+const OPTION_SHIFT_Q_GLYPH = "\u0152";
+const KITTY_OPTION_Q_GLYPH = "\x1b[339u";
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -51,11 +58,13 @@ function askPending(fake: FakeInteractiveMode): void {
 afterEach(() => {
 	if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
 	else Reflect.deleteProperty(process, "platform");
+	setKeybindings(new KeybindingsManager());
 });
 
 describe("OS-aware async ask-user answer shortcut", () => {
 	beforeAll(() => {
 		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
 	});
 
 	describe("matchesAskUserAnswerKey", () => {
@@ -121,6 +130,74 @@ describe("OS-aware async ask-user answer shortcut", () => {
 			askPending(fake);
 
 			expect(stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "")).toContain(`${label} to answer`);
+		});
+	});
+
+	describe("rebinding app.question.answer", () => {
+		it.each<NodeJS.Platform>(["darwin", "linux", "win32"])("follows the configured chord on %s", (platform) => {
+			const keybindings = new KeybindingsManager({ "app.question.answer": "alt+q" });
+
+			expect(matchesAskUserAnswerKey(ALT_Q, platform, keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(ALT_A, platform, keybindings)).toBe(false);
+		});
+
+		it("accepts the Option-composed glyphs of the bound letter on darwin only", () => {
+			const keybindings = new KeybindingsManager({ "app.question.answer": "alt+q" });
+
+			expect(matchesAskUserAnswerKey(OPTION_Q_GLYPH, "darwin", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_SHIFT_Q_GLYPH, "darwin", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(KITTY_OPTION_Q_GLYPH, "darwin", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "darwin", keybindings)).toBe(false);
+			expect(matchesAskUserAnswerKey(OPTION_Q_GLYPH, "linux", keybindings)).toBe(false);
+		});
+
+		it("accepts every chord and every composed glyph when the binding lists several", () => {
+			const keybindings = new KeybindingsManager({ "app.question.answer": ["alt+a", "alt+q"] });
+
+			expect(matchesAskUserAnswerKey(ALT_A, "linux", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(ALT_Q, "linux", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "darwin", keybindings)).toBe(true);
+			expect(matchesAskUserAnswerKey(OPTION_Q_GLYPH, "darwin", keybindings)).toBe(true);
+		});
+
+		it("matches nothing and drops the shortcut from the widget when unbound", () => {
+			const keybindings = new KeybindingsManager({ "app.question.answer": [] });
+			setKeybindings(keybindings);
+			setPlatform("darwin");
+
+			expect(matchesAskUserAnswerKey(ALT_A, "darwin", keybindings)).toBe(false);
+			expect(matchesAskUserAnswerKey(OPTION_A_GLYPH, "darwin", keybindings)).toBe(false);
+			const fake = createFakeInteractiveMode();
+			askPending(fake);
+			const text = stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "");
+			expect(text).not.toMatch(/(option|alt)\+/);
+			expect(text).toContain("to answer");
+		});
+
+		it.each<[NodeJS.Platform, string]>([
+			["darwin", "option+q"],
+			["linux", "alt+q"],
+		])("labels the widget with the configured chord on %s", (platform, label) => {
+			setKeybindings(new KeybindingsManager({ "app.question.answer": "alt+q" }));
+			setPlatform(platform);
+			const fake = createFakeInteractiveMode();
+			askPending(fake);
+
+			const text = stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "");
+			expect(text).toContain(`${label} to answer`);
+			expect(text).not.toContain("+a");
+		});
+
+		it("expands the pending question through the rebound chord in the editor", () => {
+			setKeybindings(new KeybindingsManager({ "app.question.answer": "alt+q" }));
+			setPlatform("darwin");
+			const fake = createFakeInteractiveMode({ isStreaming: true });
+			askPending(fake);
+
+			expect(fake.pressEditorKey(ALT_A)).toBe(false);
+			expect(overlay(fake)).toBeUndefined();
+			expect(fake.pressEditorKey(OPTION_Q_GLYPH)).toBe(true);
+			expect(overlay(fake)).toBeInstanceOf(AskUserQuestionComponent);
 		});
 	});
 });

--- a/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-shortcut-platform.test.ts
@@ -2,10 +2,8 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { QuestionRequest } from "../../src/core/extensions/types.ts";
 import { KeybindingsManager } from "../../src/core/keybindings.ts";
-import {
-	ASK_USER_WIDGET_KEY,
-	matchesAskUserAnswerKey,
-} from "../../src/modes/interactive/components/ask-user-async-widget.ts";
+import { matchesAskUserAnswerKey } from "../../src/modes/interactive/components/ask-user-answer-key.ts";
+import { ASK_USER_WIDGET_KEY } from "../../src/modes/interactive/components/ask-user-async-widget.ts";
 import { AskUserQuestionComponent } from "../../src/modes/interactive/components/ask-user-question.ts";
 import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../src/utils/ansi.ts";

--- a/packages/coding-agent/test/suite/ask-user-async-tui.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-tui.test.ts
@@ -1,9 +1,8 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { QuestionRequest } from "../../src/core/extensions/types.ts";
-import {
-	ASK_USER_ANSWER_KEY,
-	ASK_USER_WIDGET_KEY,
-} from "../../src/modes/interactive/components/ask-user-async-widget.ts";
+import { KeybindingsManager } from "../../src/core/keybindings.ts";
+import { ASK_USER_WIDGET_KEY } from "../../src/modes/interactive/components/ask-user-async-widget.ts";
 import { AskUserQuestionComponent } from "../../src/modes/interactive/components/ask-user-question.ts";
 import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
 import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
@@ -55,6 +54,7 @@ afterEach(() => {
 describe("async ask-user question in the interactive TUI", () => {
 	beforeAll(() => {
 		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
 	});
 
 	it("shows the collapsed widget above the editor and no overlay", async () => {
@@ -265,7 +265,7 @@ describe("async ask-user question in the interactive TUI", () => {
 		const fake = createFakeInteractiveMode();
 		void fake.createExtensionUIContext().question?.(buildRequest(), { timeout: 30 * 60_000 });
 		expect(stripAnsi(fake.widgetText(ASK_USER_WIDGET_KEY) ?? "")).toContain(
-			ASK_USER_ANSWER_KEY.replace("alt", process.platform === "darwin" ? "option" : "alt"),
+			process.platform === "darwin" ? "option+a" : "alt+a",
 		);
 	});
 });

--- a/packages/coding-agent/test/suite/ask-user-async-widget-visibility.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-async-widget-visibility.test.ts
@@ -1,0 +1,133 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { QuestionRequest } from "../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../src/core/keybindings.ts";
+import { ASK_USER_WIDGET_KEY } from "../../src/modes/interactive/components/ask-user-async-widget.ts";
+import { AskUserQuestionComponent } from "../../src/modes/interactive/components/ask-user-question.ts";
+import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
+import { createFakeInteractiveMode, type FakeInteractiveMode } from "./helpers/ask-user-async-fake-mode.ts";
+
+const ESC = "\x1b";
+const ALT_A = "\x1ba";
+const WIDGET_WIDTH = 120;
+
+const QUESTIONS: QuestionRequest["questions"] = [
+	{
+		id: "auth",
+		header: "Auth",
+		question: "Which auth method?",
+		options: [
+			{ label: "OAuth", description: "Token login" },
+			{ label: "API key", description: "Static key" },
+		],
+		multiSelect: false,
+	},
+	{
+		id: "deploy",
+		header: "Deploy",
+		question: "Where should it deploy?",
+		options: [{ label: "Staging" }, { label: "Production" }],
+		multiSelect: false,
+	},
+	{
+		id: "extras",
+		header: "Extras",
+		question: "Anything else?",
+		options: [{ label: "Docs" }, { label: "Tests" }],
+		multiSelect: true,
+	},
+];
+
+function buildRequest(questions: QuestionRequest["questions"]): QuestionRequest {
+	return { requestId: "req-visible", questions, waitForAnswer: false, timeoutMs: 30 * 60_000 };
+}
+
+function askPending(fake: FakeInteractiveMode, questions: QuestionRequest["questions"]): void {
+	const pending = fake.createExtensionUIContext().question?.(buildRequest(questions), { timeout: 30 * 60_000 });
+	if (!pending) throw new Error("question() returned nothing");
+}
+
+function overlay(fake: FakeInteractiveMode): AskUserQuestionComponent {
+	const component = fake.editorContainer.children.find((child) => child instanceof AskUserQuestionComponent);
+	if (!(component instanceof AskUserQuestionComponent)) throw new Error("the question overlay is not mounted");
+	return component;
+}
+
+function widgetLines(fake: FakeInteractiveMode): string[] {
+	const text = fake.widgetText(ASK_USER_WIDGET_KEY);
+	if (text === undefined) throw new Error("the async widget is not mounted");
+	return text.split("\n");
+}
+
+describe("collapsed async ask-user widget content", () => {
+	beforeAll(() => {
+		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("shows the pending question and its options, not only the count", () => {
+		const fake = createFakeInteractiveMode();
+		askPending(fake, QUESTIONS.slice(0, 1));
+
+		const text = widgetLines(fake).join("\n");
+		expect(text).toContain("Question pending (1 unanswered)");
+		expect(text).toContain("Auth — Which auth method?");
+		expect(text).toContain("1 OAuth · 2 API key · own answer");
+	});
+
+	it("counts the questions that wait behind the shown one", () => {
+		const two = createFakeInteractiveMode();
+		askPending(two, QUESTIONS.slice(0, 2));
+		expect(widgetLines(two).join("\n")).toContain("own answer · +1 more question");
+
+		const three = createFakeInteractiveMode();
+		askPending(three, QUESTIONS);
+		expect(widgetLines(three).join("\n")).toContain("own answer · +2 more questions");
+	});
+
+	it("moves on to the next unanswered question when a partial draft collapses", () => {
+		const fake = createFakeInteractiveMode({ isStreaming: true });
+		askPending(fake, QUESTIONS.slice(0, 2));
+
+		expect(fake.pressEditorKey(ALT_A)).toBe(true);
+		overlay(fake).handleInput("1");
+		overlay(fake).handleInput(ESC);
+
+		const text = widgetLines(fake).join("\n");
+		expect(text).toContain("Question pending (1 unanswered)");
+		expect(text).toContain("Deploy — Where should it deploy?");
+		expect(text).toContain("1 Staging · 2 Production · own answer");
+		expect(text).not.toContain("Auth —");
+		expect(text).not.toContain("more question");
+	});
+
+	it("drops the question lines once every question carries a draft answer", () => {
+		const fake = createFakeInteractiveMode({ isStreaming: true });
+		askPending(fake, QUESTIONS.slice(0, 1));
+
+		fake.pressEditorKey(ALT_A);
+		overlay(fake).handleInput("2");
+		overlay(fake).handleInput(ESC);
+
+		const text = widgetLines(fake).join("\n");
+		expect(text).toContain("Question pending (0 unanswered)");
+		expect(text).not.toContain("Auth —");
+		expect(text).toContain("to answer");
+	});
+
+	it("keeps a long question and a long option list to one truncated line each", () => {
+		const question =
+			"Which of the many equally plausible database engines should this service standardize on? ".repeat(3);
+		const options = Array.from({ length: 30 }, (_, index) => ({ label: `Engine number ${index + 1}` }));
+		const fake = createFakeInteractiveMode();
+		askPending(fake, [{ id: "db", header: "Database", question, options, multiSelect: false }]);
+
+		const lines = widgetLines(fake);
+		expect(lines).toHaveLength(4);
+		for (const line of lines) expect(line.length).toBeLessThanOrEqual(WIDGET_WIDTH);
+		expect(lines[1]).toContain("Database — Which of the many equally plausible");
+		expect(lines[1]?.match(/standardize on\?/g)).toHaveLength(1);
+		expect(lines[2]).toContain("1 Engine number 1 · 2 Engine number 2");
+		expect(lines[2]).not.toContain("Engine number 30");
+	});
+});

--- a/packages/coding-agent/test/suite/ask-user-resume.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-resume.test.ts
@@ -80,6 +80,7 @@ function install(sessionManager: SessionManager) {
 	const handlers = new Map<string, StartHandler[]>();
 	const pi = {
 		registerFlag() {},
+		registerCommand() {},
 		registerTool() {},
 		getFlag() {
 			return false;

--- a/packages/coding-agent/test/suite/helpers/ask-user-async-fake-mode.ts
+++ b/packages/coding-agent/test/suite/helpers/ask-user-async-fake-mode.ts
@@ -35,6 +35,7 @@ export type FakeInteractiveMode = {
 	runtimeHost: { session: FakeSession; sendHostUiProgress?: Mock<(record: unknown) => void> };
 	onInputCallback: Mock<(input: unknown) => void>;
 	handleDebugCommand: Mock<() => void>;
+	showStatus: Mock<(message: string) => void>;
 	createExtensionUIContext(): ExtensionUIContext;
 	handleAskUserShortcut(data: string): boolean;
 	setupEditorSubmitHandler(): void;
@@ -64,6 +65,7 @@ export function createFakeInteractiveMode(options: { isStreaming?: boolean } = {
 		runtimeHost: { session },
 		onInputCallback: vi.fn(),
 		handleDebugCommand: vi.fn(),
+		showStatus: vi.fn(),
 		askUserQuestion: undefined,
 		asyncQuestion: undefined,
 		lastEditorText: "",


### PR DESCRIPTION
## Summary

The async (`waitForAnswer: false`) ask-user widget above the editor only said that a question existed, and the only way in was a hardcoded `alt+a`. Both are gone:

- **The widget shows the question.** Four lines instead of one: `? Question pending (N unanswered) · <countdown>`, the first unanswered question as `<header> — <question>`, its options inline (`1 PostgreSQL · 2 SQLite · own answer · +1 more question`), one truncated line each, and a hint naming every way in. When a partial draft collapses, the widget moves on to the next unanswered question.
- **The shortcut is a keybinding.** New `app.question.answer` action (default `alt+a`, `option+a` on macOS) in `core/keybindings.ts`, rebindable in `keybindings.json`, listed in `/hotkeys`, `docs/keybindings.md` and a startup tip; the widget hint follows the effective binding and drops the segment when unbound. The macOS Option-compose acceptance from #1621 now follows the bound letter through a US-layout Option glyph table (`alt+q` → `œ`/`Œ`), dead keys e/i/n/u documented.
- **Two chord-free paths.** Enter on an empty editor opens the pending question (a no-op when nothing is pending); the ask-user extension registers `/answer`, which interactive-mode dispatches to the same expansion and answers `No question is pending.` when there is nothing to open. Esc still collapses back to the widget with the draft kept; typed text still resolves as the comment; slash and bash commands keep their routing.

Fixes #1623

## Changes

- `packages/coding-agent/src/core/keybindings.ts`: `app.question.answer`
- `packages/coding-agent/src/core/extensions/builtin/ask-user/extension.ts`: `/answer` command registration (help-extension `/keybindings` pattern)
- `packages/coding-agent/src/modes/interactive/components/ask-user-answer-key.ts` (new): keybinding-aware matcher + `darwinOptionGlyphs`
- `packages/coding-agent/src/modes/interactive/components/ask-user-async-widget.ts`: multi-line widget bound to the request + draft
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `expandPendingQuestion()` shared by the shortcut, empty Enter and `/answer`; `/hotkeys` row
- Tests: `ask-user-async-shortcut-platform.test.ts` (rebinding, unbound, multi-chord, label), `ask-user-async-widget-visibility.test.ts` (new), `ask-user-async-key-free-paths.test.ts` (new), fake-mode helper, `ask-user-resume.test.ts` fixture
- Docs/trackers: `docs/tui.md`, `docs/keybindings.md`, `tips/catalog/input-tips.ts`, `src/modes/interactive/changes.md`, `src/core/changes.md`, `CHANGELOG.md` [Unreleased]

## Verification

Every unit went RED before GREEN on a macOS host with the CI Bun (1.4.2), vitest 4.1.11:

- Rebinding: `ask-user-async-shortcut-platform.test.ts` RED 9 failed / 11 passed (`expected false to be true` on the `alt+q` matcher, label still `option+a`) → GREEN.
- Visibility: `ask-user-async-widget-visibility.test.ts` RED 4 failed / 1 passed (`expected "? Question pending (1 unanswered) - …" to contain "Auth — Which auth method?"`, `expected [ Array(1) ] to have a length of 4 but got 1`) → GREEN.
- Key-free paths: `ask-user-async-key-free-paths.test.ts` RED 4 failed / 2 passed (no overlay on empty Enter / `/answer`, no `No question is pending.` status) → GREEN.
- Final: 5 ask-user suites 62/62; 22 affected files (keybindings, rpc-commands-changed, ask-user-*, help-content, tips, regressions/5943) 177/177; `bunx tsgo --noEmit` exit 0; biome clean; root static check in every pre-commit; `bun scripts/check-pr-changelog.mjs --base origin/main` PASS.
- Real surface (macOS, real pty 120x34, screen parsed through @xterm/headless after PTY quiescence, TUI from source with the ask-user QA fixture): default binding 18/18 checks and `keybindings.json` `alt+q` 17/17 checks — widget shows the question/options/queued count and the hint, `/answer` without a question reports it, empty Enter and `/answer` open the overlay, Esc collapses with no residue, `å` / `ESC a` open under the default and are inert under `alt+q` while `ESC q` / `œ` open, partial draft moves the widget to the next question. Frames and renders are posted on #1623.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the async ask-user widget only revealing that a question exists: it now shows the first unanswered question, its inline options, and how many more wait behind it (fixes #1623). The shortcut is now the rebindable `app.question.answer` keybinding (default `alt+a`/`option+a`), with Enter on an empty editor and `/answer` as chord-free ways in.

- macOS Option-compose glyphs follow the bound letter through a US-layout table; dead keys e/i/n/u need the terminal's Option-as-Meta setting.
- The widget hint follows the effective binding and drops the shortcut segment when unbound.
- Esc still collapses to the widget with the draft kept; typed text still resolves as a comment.
- The keybinding is listed in `/hotkeys`, `docs/keybindings.md`, and a startup tip.

<sup>Written for commit 169a27e3267f36d1eb237fa316b7561275f6a8ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

