### PR TITLE
fix(prompt-preset): route Devin SWE-2 variants to Kimi K3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Fixed native prompt-preset matching for Devin SWE-2 effort variants so `swe-2-high`, `swe-2-max`, `swe-2-low`, and `swe-2-high-lite` resolve to the Kimi K3 preset; the rejected bare `swe-2` id remains unmatched.
+
 ### Removed
 
 ## [2026.9.12-2] - 2026-09-12

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -104,6 +104,14 @@ function isKimiK3Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasKimiK3Signal(model.id) || (model.name !== undefined && hasKimiK3Signal(model.name));
 }
 
+function hasSWE2Signal(value: string): boolean {
+	return /(?:^|[/@:._-])swe-2-(?:high|max|low|high-lite)(?:$|[/@:._-])/.test(normalizeModelId(value));
+}
+
+function isSWE2Model(model: ModelWithPromptPresetMetadata): boolean {
+	return hasSWE2Signal(model.id) || (model.name !== undefined && hasSWE2Signal(model.name));
+}
+
 // DeepSeek V4 id shapes verified against the OpenRouter live API, models.dev,
 // and senpi's generated provider catalogs (2026-07-31): deepseek-v4-flash,
 // deepseek/deepseek-v4-flash-0731, deepseek-ai/DeepSeek-V4-Pro,
@@ -260,7 +268,7 @@ export function resolvePresetName(
 	if (gpt5Version) {
 		return gpt5Version;
 	}
-	if (isKimiK3Model(model)) {
+	if (isSWE2Model(model) || isKimiK3Model(model)) {
 		return "kimi-k3";
 	}
 	if (isKimiK27Model(model)) {

--- a/packages/coding-agent/test/suite/prompt-presets-grok-4-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-grok-4-5.test.ts
@@ -117,3 +117,17 @@ describe("Grok 4.5 prompt preset", () => {
 		expect(misses).toEqual([]);
 	});
 });
+
+describe("Devin SWE-2 prompt preset", () => {
+	it.each(["swe-2-high", "swe-2-max", "swe-2-low", "swe-2-high-lite", "devin/swe-2-high"])(
+		"resolves %s to K3",
+		(id) => {
+			const preset = resolvePreset(createModel(id, "devin"), { promptPreset: "auto" });
+			expect(preset?.name).toBe("kimi-k3");
+		},
+	);
+
+	it("does not route the rejected bare swe-2 id", () => {
+		expect(resolvePreset(createModel("swe-2", "devin"), { promptPreset: "auto" })?.name).not.toBe("kimi-k3");
+	});
+});


### PR DESCRIPTION
Fixes #8129

Recognizes Devin SWE-2 effort variants (swe-2-high, swe-2-max, swe-2-low, swe-2-high-lite) in native Senpi model matching and resolves them to kimi-k3. Bare swe-2 is intentionally excluded because Devin rejects it.

Tests: bun test packages/coding-agent/test/suite/prompt-presets-grok-4-5.test.ts (25 pass). The package typecheck is currently blocked by pre-existing workspace declaration errors unrelated to this change. Companion to oh-my-openagent #8130.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8129. Routes Devin SWE-2 effort variants (`swe-2-high`, `swe-2-max`, `swe-2-low`, `swe-2-high-lite`) to the `kimi-k3` preset in prompt preset resolution. Bare `swe-2` stays unmatched because Devin rejects it. Package typecheck failures are pre-existing and unrelated.

<sup>Written for commit 3051eee34f647aa6fb9aa3a7237b87d078b47cbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

