### PR TITLE
fix(release): align registry planning and recover concurrent main updates

### DIFF
--- a/scripts/calver.mjs
+++ b/scripts/calver.mjs
@@ -17,7 +17,8 @@
  *   release's suffix instead of returning a lower calendar version.
  *
  * Tolerance:
- * - Registry/git failures (404, network, timeout, ENOTFOUND, etc.) are
+ * - Unpublished packages (404) contribute an empty version baseline.
+ * - Other registry/git failures (network, timeout, ENOTFOUND, etc.) are
  *   downgraded to stderr warnings; this module NEVER throws on a single
  *   source failure. A totally offline run still returns a valid CalVer.
  *
@@ -35,13 +36,12 @@
 
 import { execFileSync } from "node:child_process";
 
-const DEFAULT_PACKAGES = [
-	"@code-yeongyu/senpi",
-	"@earendil-works/pi-ai",
-	"@earendil-works/pi-agent-core",
-	"@code-yeongyu/senpi-server",
-	"@earendil-works/pi-tui",
-];
+import { queryNpmRegistry } from "./npm-registry.mjs";
+import { registryPackageNames } from "./registry-packages.mjs";
+
+// Use the publish allowlist: source manifests may be private but rewritten for
+// publication. Private-only workspaces (server, chord, sqlite) have no registry name.
+const DEFAULT_PACKAGES = [...registryPackageNames.values()];
 
 const REGISTRY_TIMEOUT_MS = 30000;
 const CALVER_RE = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:-(\d+))?$/;
@@ -64,12 +64,8 @@ function computeToday(now = new Date()) {
  */
 function fetchRegistryVersions(pkg) {
 	try {
-		const stdout = execFileSync("npm", ["view", pkg, "versions", "--json"], {
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "pipe"],
-			timeout: REGISTRY_TIMEOUT_MS,
-		});
-		const trimmed = stdout.trim();
+		const stdout = queryNpmRegistry(pkg, "versions");
+		const trimmed = stdout?.trim();
 		if (!trimmed) {
 			return [];
 		}

--- a/scripts/calver.test.mjs
+++ b/scripts/calver.test.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { computeNextVersion } from "./calver.mjs";
+import { queryNpmRegistry } from "./npm-registry.mjs";
 
 let tempDir;
 let previousPath;
@@ -21,6 +22,43 @@ afterEach(() => {
 });
 
 describe("computeNextVersion", () => {
+	it("queries only fork publish targets, never private-only or upstream packages", () => {
+		installFakeVersionSources([]);
+		const calls = join(tempDir, "calls.jsonl");
+		writeFakeCommand("npm", `
+			import { appendFileSync } from "node:fs";
+			const name = process.argv[3];
+			appendFileSync(${JSON.stringify(calls)}, JSON.stringify(name) + "\\n");
+			process.stdout.write(JSON.stringify(name === "@code-yeongyu/senpi-telemetry" ? ["2026.9.12-2"] : []));
+		`);
+		assert.equal(computeNextVersion({ date: "2026.9.12" }), "2026.9.12-3");
+		assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n").map(JSON.parse).sort(), [
+			"@code-yeongyu/senpi", "@code-yeongyu/senpi-ai", "@code-yeongyu/senpi-agent-core",
+			"@code-yeongyu/senpi-tui", "@code-yeongyu/senpi-pty", "@code-yeongyu/senpi-telemetry",
+			"@code-yeongyu/senpi-codemode",
+		].sort());
+	});
+
+	it("treats an unpublished package's E404 as an empty baseline without a warning", (t) => {
+		installFakeVersionSources([]);
+		writeFakeCommand("npm", 'process.stderr.write("npm error code E404\\n404 Not Found"); process.exit(1);');
+		const stderr = t.mock.method(process.stderr, "write", () => true);
+		assert.equal(computeNextVersion({ date: "2026.9.12", packages: ["@example/new"] }), "2026.9.12");
+		assert.equal(stderr.mock.callCount(), 0);
+	});
+
+	it("shares publish lookup handling without hiding registry outages", () => {
+		installFakeVersionSources([]);
+		writeFakeCommand("npm", 'process.stdout.write(JSON.stringify("2026.9.12-3"));');
+		assert.equal(JSON.parse(queryNpmRegistry("@example/senpi@2026.9.12-3", "version")), "2026.9.12-3");
+		for (const message of ["E404", "404 Not Found"]) {
+			writeFakeCommand("npm", `process.stderr.write(${JSON.stringify(message)}); process.exit(1);`);
+			assert.equal(queryNpmRegistry("@example/new", "versions"), null);
+		}
+		writeFakeCommand("npm", 'process.stderr.write("E503 registry unavailable"); process.exit(1);');
+		assert.throws(() => queryNpmRegistry("@example/senpi", "versions"), /E503/);
+	});
+
 	it("stays above a future-dated published version", () => {
 		installFakeVersionSources(["2026.8.11"]);
 

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-12 - Registry planning and concurrent-main release recovery
+
+### What changed
+
+- `scripts/publish.mjs` selects its ordered publish targets from the shared owned-registry mapping and uses `scripts/npm-registry.mjs` for registry lookups. `scripts/calver.mjs` uses the same names and treats first-publish 404 responses as an empty baseline. Private-only server, chord, and sqlite workspaces remain excluded; explicitly rewritten source-private packages retain their fork registry names.
+- `scripts/release.mjs` throws command failures to its caller and handles fatal errors at the CLI boundary, allowing `syncRemoteMainBeforePush` to recover from a non-ancestor result instead of exiting before its merge.
+
+### Why
+
+- Release 34688541952 completed its tests but failed when main advanced during preparation: the ancestry probe exited before the existing merge recovery could run. The planner also queried private senpi-server and stale upstream names rather than the fork publish set.
+
+### Why an extension could not handle it
+
+- `scripts/publish.mjs` and `scripts/release.mjs` run before publication, outside the runtime extension system.
+
+### Expected merge conflict zones
+
+- `scripts/publish.mjs` package selection and registry query helper; `scripts/release.mjs` command error handling and CLI entry point.
+
 ## 2026-09-12 - Binary build script drops the `--min-release-age=0` native install clause
 
 ### What changed

--- a/scripts/npm-registry.mjs
+++ b/scripts/npm-registry.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+// A missing package/version is a normal first publish, not a registry outage.
+export function queryNpmRegistry(spec, field) {
+	const result = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", ["view", spec, field, "--json"], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		timeout: 30000,
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status === 0 && result.stdout.trim()) {
+		return result.stdout;
+	}
+	const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+	if (result.status !== 0 && (output.includes("E404") || output.includes("404 Not Found"))) {
+		return null;
+	}
+	throw new Error(output ? `Failed to query ${spec}\n${output}` : `Failed to query ${spec}`);
+}

--- a/scripts/publish-registry-dependencies.test.mjs
+++ b/scripts/publish-registry-dependencies.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { getPublicWorkspacePackages } from "./release-packages.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -38,7 +39,9 @@ describe("npm publish dependency graph", () => {
 	it("keeps upstream workspaces private and publishes owned registry aliases", () => {
 		// Given: Bun resolves declared edges from the registry, but npm only packs the
 		// original import paths when their dependency keys remain in the manifest.
-		const publishScript = readFileSync(join(repoRoot, "scripts", "publish.mjs"), "utf8");
+		const publishedNames = getPublicWorkspacePackages().map(({ name }) => name);
+		assert.equal(readJson(join(repoRoot, "packages/server/package.json")).private, true);
+		assert.ok(!publishedNames.includes("@code-yeongyu/senpi-server"));
 
 		for (const workspace of PRIVATE_UPSTREAM_WORKSPACES) {
 			const manifest = readJson(join(repoRoot, workspace.packageJsonPath));
@@ -49,17 +52,17 @@ describe("npm publish dependency graph", () => {
 			const aiManifest = readJson(join(repoRoot, "packages/ai/package.json"));
 			const agentManifest = readJson(join(repoRoot, "packages/agent/package.json"));
 			assert.equal(manifest.private, true, `${workspace.packageName} must remain excluded from fork publishing`);
-			assert.doesNotMatch(publishScript, new RegExp(`name: "${workspace.packageName}"`));
+			assert.ok(!publishedNames.includes(workspace.packageName));
 			assert.equal(manifest.dependencies["@earendil-works/pi-agent-core"], `^${agentManifest.version}`);
 			assert.equal(manifest.dependencies["@earendil-works/pi-ai"], `^${aiManifest.version}`);
 			assert.equal(manifest.devDependencies["@earendil-works/pi-agent-core"], undefined);
 			assert.equal(manifest.devDependencies["@earendil-works/pi-ai"], undefined);
 		}
 		for (const packageName of OWNED_REGISTRY_ALIASES) {
-			assert.match(publishScript, new RegExp(`name: "${packageName}"`));
+			assert.ok(publishedNames.includes(packageName));
 		}
 		for (const packageName of BUNDLED_ONLY_WORKSPACES) {
-			assert.doesNotMatch(publishScript, new RegExp(`name: "${packageName}"`));
+			assert.ok(!publishedNames.includes(packageName));
 		}
 	});
 });

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -13,6 +13,9 @@ import { buildPublishArgs } from "./publish-command.mjs";
 import { rewritePublishManifest } from "./publish-manifest.mjs";
 import { materializeMissingPublishRuntime } from "./materialize-publish-runtime.mjs";
 import { parseNpmPackJson } from "./npm-pack-json.mjs";
+import { queryNpmRegistry } from "./npm-registry.mjs";
+import { getPublicWorkspacePackages } from "./release-packages.mjs";
+import { registryPackageNames } from "./registry-packages.mjs";
 
 // Source packages retain their upstream names and private guard. Registry-backed
 // packages are published from temporary manifests under our scope, while bundled-only
@@ -20,15 +23,10 @@ import { parseNpmPackJson } from "./npm-pack-json.mjs";
 //
 // @code-yeongyu/senpi-server remains excluded because it is `private: true`, and
 // The sqlite session backend keeps upstream's independent semver line.
-const packages = [
-	{ directory: "packages/ai", name: "@code-yeongyu/senpi-ai", rewriteManifest: true },
-	{ directory: "packages/agent", name: "@code-yeongyu/senpi-agent-core", rewriteManifest: true },
-	{ directory: "packages/tui", name: "@code-yeongyu/senpi-tui", rewriteManifest: true },
-	{ directory: "packages/pty", name: "@code-yeongyu/senpi-pty", rewriteManifest: true },
-	{ directory: "packages/telemetry", name: "@code-yeongyu/senpi-telemetry", rewriteManifest: true },
-	{ directory: "packages/senpi-codemode", name: "@code-yeongyu/senpi-codemode", rewriteManifest: true },
-	{ directory: "packages/coding-agent", name: "@code-yeongyu/senpi", rewriteManifest: true },
-];
+const publishOrder = [...registryPackageNames.values()];
+const packages = getPublicWorkspacePackages()
+	.sort((a, b) => publishOrder.indexOf(a.name) - publishOrder.indexOf(b.name))
+	.map((pkg) => ({ ...pkg, rewriteManifest: true }));
 const sourceOnlyPackages = new Set(["@code-yeongyu/senpi-codemode"]);
 const temporaryPublishDirectories = [];
 
@@ -126,21 +124,7 @@ function validatePack(directory, sourceDirectory) {
 }
 
 function isPublished(name, version) {
-	const result = spawnSync(commandForPlatform("npm"), ["view", `${name}@${version}`, "version", "--json"], {
-		encoding: "utf8",
-		stdio: ["inherit", "pipe", "pipe"],
-	});
-
-	if (result.status === 0 && result.stdout.trim()) {
-		return true;
-	}
-
-	const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
-	if (result.status !== 0 && (output.includes("E404") || output.includes("404 Not Found"))) {
-		return false;
-	}
-
-	throw new Error(output ? `Failed to query ${name}@${version}\n${output}` : `Failed to query ${name}@${version}`);
+	return queryNpmRegistry(`${name}@${version}`, "version") !== null;
 }
 
 const packageVersions = new Map();

--- a/scripts/release-cli.test.mjs
+++ b/scripts/release-cli.test.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { WORKSPACE_PACKAGES } from "./release-packages.mjs";
+import { CHANGELOGS } from "./release-changelog.mjs";
+
+for (const mergeStatus of [0, 1]) {
+	it(`release CLI recovers concurrent main advancement and respects merge exit ${mergeStatus}`, () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-release-cli-"));
+		try {
+			for (const file of WORKSPACE_PACKAGES) {
+				mkdirSync(dirname(join(root, file)), { recursive: true });
+				writeFileSync(join(root, file), JSON.stringify({ version: "2026.9.12-2" }));
+			}
+			for (const file of CHANGELOGS) {
+				writeFileSync(join(root, file), "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Fixture.\n");
+			}
+			const bin = join(root, "bin");
+			mkdirSync(bin);
+			const calls = join(root, "commands.jsonl");
+			for (const name of ["git", "npm", "node", "bun", "gh"]) {
+				const body = `
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(${JSON.stringify(calls)}, JSON.stringify([${JSON.stringify(name)}, ...args]) + "\\n");
+if (${JSON.stringify(name)} === "git") {
+	if (args[0] === "branch") process.stdout.write("main\\n");
+	if (args[0] === "rev-parse") process.stdout.write("fixture-sha\\n");
+	if (args[0] === "merge-base") process.exit(1);
+	if (args[0] === "merge") process.exit(${mergeStatus});
+}
+if (${JSON.stringify(name)} === "gh") process.stdout.write("[]");
+`;
+				const runner = join(bin, `${name}.mjs`);
+				writeFileSync(runner, body);
+				if (process.platform === "win32") {
+					writeFileSync(join(bin, `${name}.cmd`), `@"${process.execPath}" "${runner}" %*\r\n`);
+				} else {
+					writeFileSync(join(bin, name), `#!${process.execPath}\n${body}`);
+					chmodSync(join(bin, name), 0o755);
+				}
+			}
+			const result = spawnSync(process.execPath, [fileURLToPath(new URL("./release.mjs", import.meta.url)), "--version", "2026.9.12-3"], {
+				cwd: root,
+				env: { ...process.env, PATH: `${bin}${delimiter}${dirname(process.execPath)}` },
+				encoding: "utf8",
+				timeout: 15000,
+			});
+			const commands = readFileSync(calls, "utf8").trim().split("\n").map(JSON.parse);
+			assert.ok(commands.some((args) => args[0] === "git" && args[1] === "merge"), result.stderr);
+			assert.equal(result.status, mergeStatus, result.stderr);
+			assert.deepEqual(commands.filter((args) => args[1] === "push"), mergeStatus === 0 ? [
+				["git", "push", "origin", "main"],
+				["git", "push", "origin", "v2026.9.12-3"],
+			] : []);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -122,8 +122,7 @@ function runCommand(bin, args, extraEnv) {
 		execFileSync(bin, args, extraEnv ? { stdio: "inherit", env: { ...process.env, ...extraEnv } } : { stdio: "inherit" });
 	} catch (err) {
 		const message = err && typeof err === "object" && "message" in err ? err.message : String(err);
-		process.stderr.write(`[release] error: ${bin} ${args.join(" ")} failed: ${message}\n`);
-		process.exit(1);
+		throw new Error(`${bin} ${args.join(" ")} failed: ${message}`, { cause: err });
 	}
 }
 
@@ -374,4 +373,9 @@ function main() {
 	}
 }
 
-main();
+try {
+	main();
+} catch (err) {
+	process.stderr.write(`[release] error: ${err instanceof Error ? err.message : String(err)}\n`);
+	process.exitCode = 1;
+}


### PR DESCRIPTION
## Root cause

Raw job logs for failed release 34688541952 show that the senpi-server E404 was a caught warning, not the fatal error. All workspace tests passed. Main advanced from b63586725 to c31a9c7e6 while preparation ran; `git merge-base --is-ancestor origin/main HEAD` returned 1, and release.mjs exited inside runCommand before syncRemoteMainBeforePush could catch it and merge. Nothing was pushed or published.

## Fix

- Use the existing owned-registry mapping for both CalVer defaults and publication, preserving publish order and excluding private-only server/chord/sqlite workspaces. Source-private packages explicitly rewritten for publication still use their fork registry aliases.
- Extract publish.mjs registry query semantics into npm-registry.mjs: E404/404 Not Found is an empty first-publish baseline; other publish lookup errors remain fatal.
- Throw command failures to the release orchestrator, with exit status handled at the CLI boundary, restoring concurrent-main merge recovery.
- Replace source-text publish-list assertions with manifest/package-selection assertions. senpi-server stays private.

## Verification

- RED: planner queried the wrong package set and warned for first publish (2 failing regression tests).
- RED: spawned release CLI exited on ancestry probe before merge (2 failing integration cases).
- GREEN: 36 targeted tests; full `npm run test:scripts` 235/235 passed.
- `npm run check`, `npm run build`, changed-file LSP diagnostics, `git diff --check`, changelog gate passed. Check autoformatted one pre-existing unrelated test; that formatting-only drift was restored and excluded.
- Live `node scripts/calver.mjs --json` returns 2026.9.12-3 with no server lookup warning.

After merge, release delivery will use the documented two phases: prepare with empty version, then publish-only for the prepared version through GitHub OIDC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release pipeline so the CalVer planner queries the same package set that publishing uses, and releases no longer abort when main advances during preparation before the merge recovery step runs.

- **Bug Fixes**
  - Treats npm E404/404 Not Found as an empty first-publish baseline instead of a warning; other registry outages remain fatal.
  - Command failures now propagate to the release orchestrator so it can merge and retry, with exit status handled at the CLI boundary.
- **Refactors**
  - Shares the owned-registry package mapping between `calver.mjs` and `publish.mjs`, excluding private-only workspaces (`@code-yeongyu/senpi-server`, chord, sqlite).
  - Replaces source-text publish-list assertions with manifest/package-selection assertions.

<sup>Written for commit c0fca22c4775720cc872361334d4e160ad0e12ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

