### PR TITLE
feat(coding-agent): support Notification hook event and fire it for ask-user settlements

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Added the `Notification` hook event to builtin hooks v1 and fire it for ask-user question settlements, so question timeouts and answers can trigger user-defined hook commands (for example desktop or mobile push on `ask-user-timeout`).
+- Added the `Notification` hook event to builtin hooks v1 for live and resumed ask-user question settlements, so timeouts and answers can trigger trusted user-defined commands while hooks is enabled (for example desktop or mobile push on `ask-user-timeout`). Notification matchers are ignored; cancellation does not notify, and asynchronous configuration/trust reads and command execution do not delay settlement.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added the `Notification` hook event to builtin hooks v1 and fire it for ask-user question settlements, so question timeouts and answers can trigger user-defined hook commands (for example desktop or mobile push on `ask-user-timeout`).
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## 2026-09-12 - Support the Notification hook event and fire it for ask-user settlements
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/hooks/types.ts`: `Notification` moves from `UNSUPPORTED_KNOWN_HOOK_EVENTS` to `SUPPORTED_HOOK_EVENTS`, and `HookInputWire` gains a `Notification` variant carrying `message`, `kind`, optional `title`, `notification_source`, `request_id`, and `status`.
+- `packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts`, `dispatcher.ts`, `output-parser.ts`, `lifecycle-adapter.ts`: `Notification` dispatches like the other non-blocking lifecycle events (matcher ignored, block-only aggregation, `additionalContext` accepted, decisions rejected with an `unsupported_field` diagnostic). New `buildNotificationHookInput` / `dispatchNotificationHookEvent` / `notificationResultDetails` helpers mirror the SessionStart path.
+- `packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts` (new) + `tool.ts`: every non-cancelled question settlement fires a best-effort `Notification` hook (`kind` `ask-user-timeout` on timeout, `ask-user-settled` otherwise) without delaying the tool result or the follow-up user message. Hook `additionalContext` is recorded through the standard lifecycle result path.
+- `packages/coding-agent/test/suite/hooks-notification.test.ts` (new): schema, matcher, output-parser, and end-to-end ask-user timeout coverage.
+
+### Why
+
+- Question timeouts previously arrived only as framed user messages, so there was no hook surface for notifying on them (for example desktop or mobile push on `ask-user-timeout`).
+
+### Why an extension could not handle it
+
+- Hook event registration and the ask-user settlement path are both owned by in-tree builtins; an outside extension cannot add a supported hook event or observe the timeout delivery.
+
+### Expected merge conflict zones
+
+- `SUPPORTED_HOOK_EVENTS` / `UNSUPPORTED_KNOWN_HOOK_EVENTS` in `hooks/types.ts` and any upstream change that adds a `Notification` event with different semantics.
+
 ## 2026-09-12 - Remove the client transcript/remote-session island, keep the dist `./client` export
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -4,10 +4,10 @@
 
 ### What changed
 
-- `packages/coding-agent/src/core/extensions/builtin/hooks/types.ts`: `Notification` moves from `UNSUPPORTED_KNOWN_HOOK_EVENTS` to `SUPPORTED_HOOK_EVENTS`, and `HookInputWire` gains a `Notification` variant carrying `message`, `kind`, optional `title`, `notification_source`, `request_id`, and `status`.
+- `packages/coding-agent/src/core/extensions/builtin/hooks/types.ts`: `Notification` moves from `UNSUPPORTED_KNOWN_HOOK_EVENTS` to `SUPPORTED_HOOK_EVENTS`, and `HookInputWire` gains a `Notification` variant carrying `message`, `kind`, optional `title`, `notification_source`, `request_id`, `status`, and `transcript_path`.
 - `packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts`, `dispatcher.ts`, `output-parser.ts`, `lifecycle-adapter.ts`: `Notification` dispatches like the other non-blocking lifecycle events (matcher ignored, block-only aggregation, `additionalContext` accepted, decisions rejected with an `unsupported_field` diagnostic). New `buildNotificationHookInput` / `dispatchNotificationHookEvent` / `notificationResultDetails` helpers mirror the SessionStart path.
-- `packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts` (new) + `tool.ts`: every non-cancelled question settlement fires a best-effort `Notification` hook (`kind` `ask-user-timeout` on timeout, `ask-user-settled` otherwise) without delaying the tool result or the follow-up user message. Hook `additionalContext` is recorded through the standard lifecycle result path.
-- `packages/coding-agent/test/suite/hooks-notification.test.ts` (new): schema, matcher, output-parser, and end-to-end ask-user timeout coverage.
+- `packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts`, `tool.ts`, and `resume.ts`: live and resumed non-cancelled settlements publish `ask-user:settled`. The active hooks builtin owns Notification execution (`kind` `ask-user-timeout` on timeout, `ask-user-settled` otherwise); disabling or excluding hooks prevents execution. Configuration and atomic trust snapshots are read asynchronously, and no Notification handlers means no trust I/O. Only validated hook `additionalContext` is recorded.
+- `packages/coding-agent/test/suite/hooks-notification*.test.ts`: schema/output parsing, real trusted command dispatch with ignored matchers, disabled/excluded builtin activation through the resource loader, registered-tool blocking/async answers and authoritative fake-clock timeouts, late UI responses, cancellation, concurrent IDs, resume/reload exactly-once delivery, gated preparation/command completion, rejected-output recording, and typed persistent/in-memory payload fields.
 
 ### Why
 
@@ -15,7 +15,7 @@
 
 ### Why an extension could not handle it
 
-- Hook event registration and the ask-user settlement path are both owned by in-tree builtins; an outside extension cannot add a supported hook event or observe the timeout delivery.
+- The supported hook wire event and authoritative ask-user settlement publication are owned by in-tree builtins. Extensions can observe the settlement event, but adding the Notification wire contract requires core changes.
 
 ### Expected merge conflict zones
 

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
@@ -13,7 +13,7 @@ import { formatResultText } from "./format.ts";
 import type { QuestionRequest, QuestionResponse } from "./schema.ts";
 
 export async function emitAskUserNotification(
-	pi: ExtensionAPI,
+	pi: Pick<ExtensionAPI, "sendMessage">,
 	ctx: ExtensionContext,
 	request: QuestionRequest,
 	response: QuestionResponse,

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from "node:fs";
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { loadHookConfigSources } from "../hooks/config-loader.ts";
+import {
+	buildNotificationHookInput,
+	dispatchNotificationHookEvent,
+	notificationResultDetails,
+	recordLifecycleHookResult,
+} from "../hooks/lifecycle-adapter.ts";
+import { emptyHookTrustState } from "../hooks/trust.ts";
+import { FileHookStateStorage } from "../hooks/trust-storage.ts";
+import { formatResultText } from "./format.ts";
+import type { QuestionRequest, QuestionResponse } from "./schema.ts";
+
+export async function emitAskUserNotification(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	request: QuestionRequest,
+	response: QuestionResponse,
+	variant: "codex" | "claude",
+): Promise<void> {
+	let handlers: Awaited<ReturnType<typeof loadHookConfigSources>>["executableHandlers"] = [];
+	let trust = emptyHookTrustState();
+	try {
+		const sources = ctx.getLoadedHookSources?.() ?? {
+			agentDir: ctx.cwd,
+			cwd: ctx.cwd,
+			globalHookSourcePaths: [],
+			globalHooksPath: `${ctx.cwd}/hooks.json`,
+			preSessionHookSourcePaths: [],
+			projectHookSourcePaths: [],
+			projectHooksPath: `${ctx.cwd}/.senpi/hooks.json`,
+			runtimeHookSourcePaths: [],
+		};
+		const parsed = loadHookConfigSources({
+			agentDir: sources.agentDir,
+			cwd: sources.cwd,
+			fileSystem: {
+				readTextFile(path) {
+					return existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+				},
+			},
+			globalHookSourcePaths: sources.globalHookSourcePaths,
+			globalHooksPath: sources.globalHooksPath,
+			globalSettingsHooks: sources.globalSettingsHooks,
+			preSessionHookSourcePaths: sources.preSessionHookSourcePaths,
+			projectHookSourcePaths: sources.projectHookSourcePaths,
+			projectHooksPath: sources.projectHooksPath,
+			projectSettingsHooks: sources.projectSettingsHooks,
+			runtimeHookSourcePaths: sources.runtimeHookSourcePaths,
+		});
+		handlers = parsed.executableHandlers;
+		const storage = new FileHookStateStorage({ agentDir: sources.agentDir, cwd: sources.cwd });
+		trust = ctx.isProjectTrusted() ? storage.read("project") : emptyHookTrustState();
+		const globalTrust = storage.read("global");
+		trust = { version: 1, hooks: { ...globalTrust.hooks, ...trust.hooks } };
+	} catch {
+		return;
+	}
+	const headers = request.questions.map((q) => q.header).join(", ");
+	const message =
+		response.status === "timed_out"
+			? `Question timed out (${headers}): ${formatResultText(variant, response, request.questions)}`
+			: `Question ${response.status} (${headers})`;
+	try {
+		const result = await dispatchNotificationHookEvent({
+			cwd: ctx.cwd,
+			handlers,
+			input: buildNotificationHookInput(
+				{
+					kind: response.status === "timed_out" ? "ask-user-timeout" : "ask-user-settled",
+					message,
+					requestId: request.requestId,
+					source: "ask-user",
+					status: response.status,
+					title: headers,
+				},
+				ctx,
+			),
+			...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
+			trustState: trust,
+		});
+		const details = notificationResultDetails(result);
+		recordLifecycleHookResult(pi, "Notification", details);
+		return;
+	} catch {
+		return;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/notify.ts
@@ -1,89 +1,23 @@
-import { existsSync, readFileSync } from "node:fs";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
-import { loadHookConfigSources } from "../hooks/config-loader.ts";
-import {
-	buildNotificationHookInput,
-	dispatchNotificationHookEvent,
-	notificationResultDetails,
-	recordLifecycleHookResult,
-} from "../hooks/lifecycle-adapter.ts";
-import { emptyHookTrustState } from "../hooks/trust.ts";
-import { FileHookStateStorage } from "../hooks/trust-storage.ts";
-import { formatResultText } from "./format.ts";
-import type { QuestionRequest, QuestionResponse } from "./schema.ts";
+import type { AskUserVariant, QuestionRequest, QuestionResponse } from "./schema.ts";
 
-export async function emitAskUserNotification(
-	pi: Pick<ExtensionAPI, "sendMessage">,
+export const ASK_USER_SETTLED_EVENT = "ask-user:settled";
+
+export type AskUserSettledEvent = {
+	readonly ctx: ExtensionContext;
+	readonly request: QuestionRequest;
+	readonly response: QuestionResponse;
+	readonly variant: AskUserVariant;
+};
+
+/** Publish only; the active hooks builtin owns preparation and command execution. */
+export function emitAskUserNotification(
+	pi: Pick<ExtensionAPI, "events">,
 	ctx: ExtensionContext,
 	request: QuestionRequest,
 	response: QuestionResponse,
-	variant: "codex" | "claude",
-): Promise<void> {
-	let handlers: Awaited<ReturnType<typeof loadHookConfigSources>>["executableHandlers"] = [];
-	let trust = emptyHookTrustState();
-	try {
-		const sources = ctx.getLoadedHookSources?.() ?? {
-			agentDir: ctx.cwd,
-			cwd: ctx.cwd,
-			globalHookSourcePaths: [],
-			globalHooksPath: `${ctx.cwd}/hooks.json`,
-			preSessionHookSourcePaths: [],
-			projectHookSourcePaths: [],
-			projectHooksPath: `${ctx.cwd}/.senpi/hooks.json`,
-			runtimeHookSourcePaths: [],
-		};
-		const parsed = loadHookConfigSources({
-			agentDir: sources.agentDir,
-			cwd: sources.cwd,
-			fileSystem: {
-				readTextFile(path) {
-					return existsSync(path) ? readFileSync(path, "utf-8") : undefined;
-				},
-			},
-			globalHookSourcePaths: sources.globalHookSourcePaths,
-			globalHooksPath: sources.globalHooksPath,
-			globalSettingsHooks: sources.globalSettingsHooks,
-			preSessionHookSourcePaths: sources.preSessionHookSourcePaths,
-			projectHookSourcePaths: sources.projectHookSourcePaths,
-			projectHooksPath: sources.projectHooksPath,
-			projectSettingsHooks: sources.projectSettingsHooks,
-			runtimeHookSourcePaths: sources.runtimeHookSourcePaths,
-		});
-		handlers = parsed.executableHandlers;
-		const storage = new FileHookStateStorage({ agentDir: sources.agentDir, cwd: sources.cwd });
-		trust = ctx.isProjectTrusted() ? storage.read("project") : emptyHookTrustState();
-		const globalTrust = storage.read("global");
-		trust = { version: 1, hooks: { ...globalTrust.hooks, ...trust.hooks } };
-	} catch {
-		return;
-	}
-	const headers = request.questions.map((q) => q.header).join(", ");
-	const message =
-		response.status === "timed_out"
-			? `Question timed out (${headers}): ${formatResultText(variant, response, request.questions)}`
-			: `Question ${response.status} (${headers})`;
-	try {
-		const result = await dispatchNotificationHookEvent({
-			cwd: ctx.cwd,
-			handlers,
-			input: buildNotificationHookInput(
-				{
-					kind: response.status === "timed_out" ? "ask-user-timeout" : "ask-user-settled",
-					message,
-					requestId: request.requestId,
-					source: "ask-user",
-					status: response.status,
-					title: headers,
-				},
-				ctx,
-			),
-			...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
-			trustState: trust,
-		});
-		const details = notificationResultDetails(result);
-		recordLifecycleHookResult(pi, "Notification", details);
-		return;
-	} catch {
-		return;
-	}
+	variant: AskUserVariant,
+): void {
+	if (response.status === "cancelled") return;
+	pi.events.emit(ASK_USER_SETTLED_EVENT, { ctx, request, response, variant } satisfies AskUserSettledEvent);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/resume.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/resume.ts
@@ -2,6 +2,7 @@ import type { SessionEntry } from "../../../session-manager.ts";
 import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
 import { TOOL_NAMES } from "./family.ts";
 import { formatUserMessage } from "./format.ts";
+import { emitAskUserNotification } from "./notify.ts";
 import {
 	type AskUserVariant,
 	DEFAULT_ASK_USER_TIMEOUT_MS,
@@ -72,17 +73,21 @@ function orphaned(request: QuestionRequest): QuestionResponse {
 }
 
 function deliver(
-	pi: Pick<ExtensionAPI, "sendUserMessage">,
+	pi: Pick<ExtensionAPI, "sendUserMessage" | "events">,
+	ctx: ExtensionContext,
 	request: QuestionRequest,
 	response: QuestionResponse,
+	variant: AskUserVariant,
 ): void {
+	if (response.status === "cancelled") return;
 	pi.sendUserMessage(formatUserMessage(response, request.requestId, request.questions));
+	emitAskUserNotification(pi, ctx, request, response, variant);
 }
 
 export async function resumeDanglingQuestion(
-	pi: Pick<ExtensionAPI, "appendEntry" | "sendUserMessage">,
+	pi: Pick<ExtensionAPI, "appendEntry" | "sendUserMessage" | "events">,
 	event: Pick<SessionStartEvent, "reason">,
-	ctx: Pick<ExtensionContext, "sessionManager" | "ui" | "getAskUserSettings">,
+	ctx: ExtensionContext,
 ): Promise<void> {
 	if (event.reason !== "resume" && event.reason !== "reload") return;
 	const dangling = findDanglingQuestion(ctx.sessionManager.getBranch());
@@ -91,14 +96,14 @@ export async function resumeDanglingQuestion(
 	const timeoutMs = (ctx.getAskUserSettings?.().timeoutMinutes ?? DEFAULT_ASK_USER_TIMEOUT_MS / 60_000) * 60_000;
 	const request = requestFromCall(dangling, timeoutMs);
 	const question = ctx.ui.question;
-	if (!question) {
-		deliver(pi, request, orphaned(request));
-		return;
+	let response: QuestionResponse;
+	if (!question) response = orphaned(request);
+	else {
+		try {
+			response = await question.call(ctx.ui, request, { timeout: request.timeoutMs });
+		} catch {
+			response = orphaned(request);
+		}
 	}
-	try {
-		const response = await question.call(ctx.ui, request, { timeout: request.timeoutMs });
-		deliver(pi, request, response);
-	} catch {
-		deliver(pi, request, orphaned(request));
-	}
+	deliver(pi, ctx, request, response, dangling.variant);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/ask-user/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ask-user/tool.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../types
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceStateEvent } from "../monitor-state-event.ts";
 import { TOOL_NAMES } from "./family.ts";
 import { formatResultDetails, formatResultText, formatUserMessage } from "./format.ts";
+import { emitAskUserNotification } from "./notify.ts";
 import { createPendingQuestion } from "./pending.ts";
 import { getPendingQuestions, type QuestionDialogOptions, registerPendingQuestion } from "./registry.ts";
 import { renderCall, renderResult } from "./render.ts";
@@ -44,11 +45,13 @@ function deliverAnswer(
 	ctx: ExtensionContext,
 	request: QuestionRequest,
 	response: QuestionResponse,
+	variant: "codex" | "claude",
 ): void {
 	if (response.status === "cancelled") return;
 	pi.sendUserMessage(formatUserMessage(response, request.requestId, request.questions), {
 		deliverAs: ctx.isIdle() ? "followUp" : "steer",
 	});
+	void emitAskUserNotification(pi, ctx, request, response, variant);
 }
 function emitWake(pi: ExtensionAPI, sessionId: string) {
 	const entries = getPendingQuestions(sessionId).filter((e) => !e.request.waitForAnswer);
@@ -68,6 +71,7 @@ function startQuestion(
 	request: QuestionRequest,
 	signal: AbortSignal | undefined,
 	state: AskUserState,
+	variant: "codex" | "claude",
 ) {
 	const question = ctx.ui.question;
 	if (!question) throw new Error("Question UI is unavailable");
@@ -145,7 +149,8 @@ function startQuestion(
 			fail(error);
 		}
 	}
-	if (!request.waitForAnswer) void completion.promise.then((response) => deliverAnswer(pi, ctx, request, response));
+	if (!request.waitForAnswer)
+		void completion.promise.then((response) => deliverAnswer(pi, ctx, request, response, variant));
 	return completion.promise;
 }
 export function createAskUserTool(variant: AskUserVariant, pi: ExtensionAPI, state: AskUserState): ToolDefinition {
@@ -195,13 +200,16 @@ export function createAskUserTool(variant: AskUserVariant, pi: ExtensionAPI, sta
 				pi.setActiveTools(pi.getActiveTools().filter((name) => !Object.values(TOOL_NAMES).includes(name)));
 				return result(variant, unavailable, request);
 			}
-			const completion = startQuestion(pi, ctx, request, signal, state);
+			const completion = startQuestion(pi, ctx, request, signal, state, variant);
 			if (!request.waitForAnswer)
 				return {
 					content: [{ type: "text", text: "Question accepted; the answer will arrive as a user message." }],
 					details: { accepted: true, requestId: request.requestId, status: "pending" },
 				};
 			const response = await completion;
+			if (response.status !== "cancelled") {
+				void emitAskUserNotification(pi, ctx, request, response, variant);
+			}
 			return result(
 				variant,
 				response,

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/config-loader.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/config-loader.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { diagnostic } from "./diagnostics.ts";
 import { parseHookConfig } from "./schema.ts";
 import type { HookDiagnostic, HookSourceMetadata, ParsedHookConfig } from "./types.ts";
@@ -67,7 +68,35 @@ export function loadHookConfigSources(options: HookConfigLoaderOptions): ParsedH
 	return { executableHandlers, diagnostics };
 }
 
-function createSourceCandidates(options: HookConfigLoaderOptions): SourceCandidate[] {
+/** Read files asynchronously, retaining the synchronous parser's source order and diagnostics. */
+export async function loadHookConfigSourcesAsync(
+	options: Omit<HookConfigLoaderOptions, "fileSystem">,
+): Promise<ParsedHookConfig> {
+	const files = new Map<string, { text?: string; error?: unknown }>();
+	const candidates = createSourceCandidates(options);
+	await Promise.all(
+		candidates.map(async (candidate) => {
+			if (candidate.kind !== "file") return;
+			try {
+				files.set(candidate.sourcePath, { text: await readFile(candidate.sourcePath, "utf8") });
+			} catch (error) {
+				files.set(candidate.sourcePath, (error as NodeJS.ErrnoException).code === "ENOENT" ? {} : { error });
+			}
+		}),
+	);
+	return loadHookConfigSources({
+		...options,
+		fileSystem: {
+			readTextFile(path) {
+				const file = files.get(path);
+				if (file?.error !== undefined) throw file.error;
+				return file?.text;
+			},
+		},
+	});
+}
+
+function createSourceCandidates(options: Omit<HookConfigLoaderOptions, "fileSystem">): SourceCandidate[] {
 	const candidates: SourceCandidate[] = [];
 	if (options.globalSettingsHooks !== undefined) {
 		candidates.push({

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
@@ -235,6 +235,7 @@ function aggregateDecision(
 		case "PreCompact":
 		case "PostCompact":
 		case "Stop":
+		case "Notification":
 			return aggregateBlockingDecision(summaries);
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -1,13 +1,18 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { BeforeAgentStartEventResult, ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
+import { formatResultText } from "../ask-user/format.ts";
+import { ASK_USER_SETTLED_EVENT, type AskUserSettledEvent } from "../ask-user/notify.ts";
 import { registerHooksCommand } from "./command.ts";
-import { loadHookConfigSources } from "./config-loader.ts";
+import { loadHookConfigSources, loadHookConfigSourcesAsync } from "./config-loader.ts";
 import { dispatchHookEvent, runningHookHandlersStatusLabel } from "./dispatcher.ts";
 import {
+	buildNotificationHookInput,
 	buildPostCompactHookInput,
 	buildPreCompactHookInput,
 	buildSessionStartHookInput,
 	dispatchLifecycleHookEvent,
+	dispatchNotificationHookEvent,
+	notificationResultDetails,
 	postCompactResultDetails,
 	preCompactResultDetails,
 	recordLifecycleHookResult,
@@ -84,6 +89,47 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 		);
 		return { parsed, trust, storage };
 	};
+
+	pi.events.on(ASK_USER_SETTLED_EVENT, async (data) => {
+		const { ctx, request, response, variant } = data as AskUserSettledEvent;
+		const headers = request.questions.map((question) => question.header).join(", ");
+		// Capture session identity before asynchronous I/O or a session switch.
+		const input = buildNotificationHookInput(
+			{
+				kind: response.status === "timed_out" ? "ask-user-timeout" : "ask-user-settled",
+				message:
+					response.status === "timed_out"
+						? `Question timed out (${headers}): ${formatResultText(variant, response, request.questions)}`
+						: `Question ${response.status} (${headers})`,
+				requestId: request.requestId,
+				source: "ask-user",
+				status: response.status,
+				title: headers,
+			},
+			ctx,
+		);
+		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
+		const parsed = await loadHookConfigSourcesAsync(sources);
+		const handlers = parsed.executableHandlers.filter((handler) => handler.event === "Notification");
+		if (handlers.length === 0) return;
+		const storage = new FileHookStateStorage({ agentDir: sources.agentDir, cwd: sources.cwd });
+		const [globalTrust, projectTrust] = await Promise.all([
+			storage.readAsync("global"),
+			ctx.isProjectTrusted() ? storage.readAsync("project") : emptyHookTrustState(),
+		]);
+		const result = await dispatchNotificationHookEvent({
+			cwd: ctx.cwd,
+			handlers,
+			input,
+			...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
+			trustState: mergeTrustStates(globalTrust, projectTrust),
+		});
+		const details = notificationResultDetails(result);
+		recordLifecycleHookResult(pi, "Notification", {
+			...details,
+			diagnostics: [...parsed.diagnostics, ...details.diagnostics],
+		});
+	});
 
 	pi.on("session_start", async (event, ctx) => {
 		const state = refreshState(ctx);

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
@@ -114,7 +114,15 @@ export async function dispatchNotificationHookEvent(options: {
 }
 
 export function notificationResultDetails(result: HookDispatchResult | undefined): LifecycleResultDetails {
-	return lifecycleResultDetails("Notification", result);
+	return {
+		cancel: false,
+		contexts:
+			result?.summaries.flatMap((summary) =>
+				summary.output.additionalContext === undefined ? [] : [summary.output.additionalContext],
+			) ?? [],
+		diagnostics:
+			result === undefined ? [] : [...result.diagnostics, ...commandFailureDiagnostics("Notification", result)],
+	};
 }
 
 export function buildPostCompactHookInput(event: SessionCompactEvent, ctx: ExtensionContext): HookInputWire {
@@ -231,7 +239,10 @@ function selectLifecycleHandlers(options: LifecycleDispatchOptions): LifecycleDi
 			);
 			continue;
 		}
-		const match = matchesLifecycleMatcher(handler, options.matcherInputs);
+		const match =
+			handler.event === "Notification"
+				? { diagnostics: [], matched: true }
+				: matchesLifecycleMatcher(handler, options.matcherInputs);
 		diagnostics.push(...match.diagnostics);
 		if (match.matched) matched.push(handler);
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
@@ -12,7 +12,7 @@ import { HOOK_CUSTOM_MESSAGE_TYPE, safeDiagnosticDetails } from "./prompt-adapte
 import { createHookTrustEntry, hookTrustId, listHookTrustRecords } from "./trust.ts";
 import type { ExecutableHookHandler, HookDiagnostic, HookInputWire, HookTrustState } from "./types.ts";
 
-type LifecycleHookEvent = "SessionStart" | "PreCompact" | "PostCompact";
+type LifecycleHookEvent = "SessionStart" | "PreCompact" | "PostCompact" | "Notification";
 
 type LifecycleDispatchOptions = {
 	readonly cwd: string;
@@ -68,6 +68,53 @@ export function buildPreCompactHookInput(event: SessionBeforeCompactEvent, ctx: 
 		...(event.customInstructions === undefined ? {} : { custom_instructions: event.customInstructions }),
 		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
 	};
+}
+
+export type NotificationHookInput = {
+	readonly message: string;
+	readonly kind: string;
+	readonly title?: string;
+	readonly source?: string;
+	readonly requestId?: string;
+	readonly status?: string;
+};
+
+export function buildNotificationHookInput(input: NotificationHookInput, ctx: ExtensionContext): HookInputWire {
+	const transcriptPath = ctx.sessionManager.getSessionFile();
+	return {
+		cwd: ctx.cwd,
+		event: "Notification",
+		hook_event_name: "Notification",
+		kind: input.kind,
+		message: input.message,
+		session_id: ctx.sessionManager.getSessionId(),
+		...(input.title === undefined ? {} : { title: input.title }),
+		...(input.source === undefined ? {} : { notification_source: input.source }),
+		...(input.requestId === undefined ? {} : { request_id: input.requestId }),
+		...(input.status === undefined ? {} : { status: input.status }),
+		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
+	};
+}
+
+export async function dispatchNotificationHookEvent(options: {
+	cwd: string;
+	handlers: readonly ExecutableHookHandler[];
+	input: HookInputWire;
+	signal?: AbortSignal;
+	trustState: HookTrustState;
+}): Promise<HookDispatchResult | undefined> {
+	return dispatchLifecycleHookEvent({
+		cwd: options.cwd,
+		handlers: options.handlers,
+		input: options.input,
+		matcherInputs: ["Notification"],
+		...(options.signal === undefined ? {} : { signal: options.signal }),
+		trustState: options.trustState,
+	});
+}
+
+export function notificationResultDetails(result: HookDispatchResult | undefined): LifecycleResultDetails {
+	return lifecycleResultDetails("Notification", result);
 }
 
 export function buildPostCompactHookInput(event: SessionCompactEvent, ctx: ExtensionContext): HookInputWire {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts
@@ -58,6 +58,7 @@ function matcherSubject(input: HookInputWire): MatcherSubject {
 	switch (input.event) {
 		case "UserPromptSubmit":
 		case "Stop":
+		case "Notification":
 			return { kind: "ignored" };
 		case "PreToolUse":
 		case "PostToolUse":

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/output-parser.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/output-parser.ts
@@ -151,6 +151,12 @@ function parseEvent(
 			copyText(parsed.reason, "reason", state);
 			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
 			return;
+		case "Notification":
+			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+			if (parsed.decision !== undefined) {
+				add(state, "unsupported_field", "stdout.decision", "Notification does not support decisions.", "warning");
+			}
+			return;
 		case "SessionStart":
 			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
 			if (parsed.decision !== undefined) {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../../../config.ts";
@@ -31,6 +32,17 @@ export class FileHookStateStorage implements HookStateStorage {
 		const agentDir = options.agentDir ?? getAgentDir();
 		this.globalStatePath = join(agentDir, "hooks-state.json");
 		this.projectStatePath = join(options.cwd, CONFIG_DIR_NAME, "hooks-state.json");
+	}
+
+	/** Writers publish atomic snapshots. Missing or invalid snapshots authorize nothing. */
+	async readAsync(scope: HookTrustStorageScope): Promise<HookTrustState> {
+		const path = statePathForScope(scope, this.globalStatePath, this.projectStatePath);
+		try {
+			return readHookTrustStateJson(await readFile(path, "utf8"));
+		} catch (error) {
+			if (errorCode(error) === "ENOENT") return emptyHookTrustState();
+			throw error;
+		}
 	}
 
 	read(scope: HookTrustStorageScope): HookTrustState {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -202,6 +202,7 @@ export type HookInputWire =
 			readonly cwd: string;
 			readonly hook_event_name?: "Notification";
 			readonly session_id?: string;
+			readonly transcript_path?: string;
 			readonly notification_source?: string;
 			readonly request_id?: string;
 			readonly status?: string;

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -6,6 +6,7 @@ export const SUPPORTED_HOOK_EVENTS = [
 	"PreCompact",
 	"PostCompact",
 	"Stop",
+	"Notification",
 ] as const;
 
 export const UNSUPPORTED_KNOWN_HOOK_EVENTS = [
@@ -13,7 +14,6 @@ export const UNSUPPORTED_KNOWN_HOOK_EVENTS = [
 	"PermissionDenied",
 	"SubagentStart",
 	"SubagentStop",
-	"Notification",
 	"Setup",
 	"UserPromptExpansion",
 	"PostToolUseFailure",
@@ -193,6 +193,18 @@ export type HookInputWire =
 			readonly hook_event_name?: "Stop";
 			readonly session_id?: string;
 			readonly transcript_path?: string;
+	  }
+	| {
+			readonly event: "Notification";
+			readonly message: string;
+			readonly kind: string;
+			readonly title?: string;
+			readonly cwd: string;
+			readonly hook_event_name?: "Notification";
+			readonly session_id?: string;
+			readonly notification_source?: string;
+			readonly request_id?: string;
+			readonly status?: string;
 	  };
 
 export type HookOutputWire = {

--- a/packages/coding-agent/test/suite/ask-user-resume.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-resume.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
 import { formatUserMessage } from "../../src/core/extensions/builtin/ask-user/format.ts";
 import askUserExtension from "../../src/core/extensions/builtin/ask-user/index.ts";
 import type { QuestionRequest, QuestionResponse } from "../../src/core/extensions/builtin/ask-user/schema.ts";
@@ -79,6 +80,7 @@ function install(sessionManager: SessionManager) {
 	const received = Promise.withResolvers<string>();
 	const handlers = new Map<string, StartHandler[]>();
 	const pi = {
+		events: createEventBus(),
 		registerFlag() {},
 		registerCommand() {},
 		registerTool() {},

--- a/packages/coding-agent/test/suite/hooks-notification-review.test.ts
+++ b/packages/coding-agent/test/suite/hooks-notification-review.test.ts
@@ -1,0 +1,478 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import { ASK_USER_SETTLED_EVENT, emitAskUserNotification } from "../../src/core/extensions/builtin/ask-user/notify.ts";
+import type { QuestionResponse } from "../../src/core/extensions/builtin/ask-user/schema.ts";
+import * as commandRunner from "../../src/core/extensions/builtin/hooks/command-runner.ts";
+import {
+	buildNotificationHookInput,
+	dispatchNotificationHookEvent,
+	notificationResultDetails,
+	recordLifecycleHookResult,
+} from "../../src/core/extensions/builtin/hooks/lifecycle-adapter.ts";
+import { parseHookConfig } from "../../src/core/extensions/builtin/hooks/schema.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import { FileHookStateStorage } from "../../src/core/extensions/builtin/hooks/trust-storage.ts";
+import type {
+	ExecutableHookHandler,
+	HookInputWire,
+	HookTrustState,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const roots: string[] = [];
+const harnesses: Harness[] = [];
+const args = {
+	questions: [{ header: "Library", question: "Which library?", multiSelect: false }],
+	waitForAnswer: true,
+};
+const timeout: QuestionResponse = {
+	status: "timed_out",
+	answers: {},
+	unanswered: ["q1"],
+	autoResolvedAfterMs: 1800000,
+};
+const answer: QuestionResponse = { status: "answered", answers: { q1: { selected: ["A"] } }, unanswered: [] };
+const cancelled: QuestionResponse = { status: "cancelled", answers: {}, unanswered: ["q1"] };
+const input: HookInputWire = { event: "Notification", cwd: tmpdir(), kind: "ask-user-timeout", message: "fixture" };
+function root() {
+	const value = mkdtempSync(join(tmpdir(), "pr1630-review-"));
+	roots.push(value);
+	return value;
+}
+function trusted(handlers: readonly ExecutableHookHandler[]): HookTrustState {
+	return {
+		version: 1,
+		hooks: Object.fromEntries(handlers.map((handler) => [hookTrustId(handler), createHookTrustEntry(handler)])),
+	};
+}
+function handlersFor(command: string, matcher?: string) {
+	return parseHookConfig(
+		{
+			hooks: {
+				Notification: [{ ...(matcher === undefined ? {} : { matcher }), hooks: [{ type: "command", command }] }],
+			},
+		},
+		{ scope: "global", sourcePath: "/fixture/hooks.json", displayOrder: 0, discoveredAt: "pre-session" },
+	).executableHandlers;
+}
+function scriptCommand(dir: string, output: unknown) {
+	const path = join(dir, "hook.mjs");
+	writeFileSync(
+		path,
+		`process.stdin.resume(); process.stdin.on('end', () => process.stdout.write(${JSON.stringify(JSON.stringify(output))}));`,
+	);
+	return `${JSON.stringify(process.execPath)} ${JSON.stringify(path)}`;
+}
+async function bounded<T>(promise: Promise<T>): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("notification signal was not emitted")), 5000);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	for (const harness of harnesses.splice(0)) harness.cleanup();
+	for (const dir of roots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function fixture(activation: "active" | "disabled" | "excluded" = "active") {
+	const dir = root();
+	const agentDir = join(dir, "agent");
+	mkdirSync(agentDir);
+	const stdinPath = join(dir, "stdin.jsonl");
+	const scriptPath = join(dir, "record.mjs");
+	writeFileSync(
+		scriptPath,
+		`import { appendFileSync } from 'node:fs'; let data = ''; process.stdin.on('data', c => data += c); process.stdin.on('end', () => { appendFileSync(${JSON.stringify(stdinPath)}, JSON.stringify(JSON.parse(data)) + '\\n'); process.stdout.write(JSON.stringify({ additionalContext: JSON.parse(data).request_id })); });`,
+	);
+	const config = {
+		hooks: {
+			Notification: [
+				{
+					matcher: "ask-user-timeout",
+					hooks: [
+						{ type: "command", command: `${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}` },
+					],
+				},
+			],
+		},
+	};
+	const hooksPath = join(agentDir, "hooks.json");
+	writeFileSync(hooksPath, JSON.stringify(config));
+	const handlers = parseHookConfig(config, {
+		scope: "global",
+		sourcePath: hooksPath,
+		displayOrder: 0,
+		discoveredAt: "pre-session",
+	}).executableHandlers;
+	writeFileSync(join(agentDir, "hooks-state.json"), JSON.stringify(trusted(handlers)));
+	const settings = {
+		enabledBuiltinExtensions: activation === "excluded" ? ["ask-user"] : ["ask-user", "hooks"],
+		disabledBuiltinExtensions: activation === "disabled" ? ["hooks"] : [],
+		askUser: { enabled: true },
+	};
+	const notificationFinished = Promise.withResolvers<void>();
+	const bus = createEventBus();
+	const eventBus = {
+		emit: bus.emit,
+		on(channel: string, handler: (data: unknown) => void) {
+			return bus.on(channel, async (data) => {
+				await handler(data);
+				if (channel === ASK_USER_SETTLED_EVENT) notificationFinished.resolve();
+			});
+		},
+	};
+	const loader = new DefaultResourceLoader({
+		eventBus,
+		cwd: dir,
+		agentDir,
+		settingsManager: SettingsManager.inMemory(settings),
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	expect(
+		loader
+			.getExtensions()
+			.extensions.map((e) => e.path)
+			.includes("<builtin:hooks>"),
+	).toBe(activation === "active");
+	const harness = await createHarness({ resourceLoader: loader, settings });
+	harnesses.push(harness);
+	await harness.session.bindExtensions({});
+	const runner = harness.getExtensionRunner();
+	const tool = runner.getAllRegisteredTools().find((t) => t.definition.name === "ask_user_question")?.definition;
+	if (!tool) throw new Error("missing registered tool");
+	const ctx: ExtensionContext = {
+		...runner.createContext(),
+		mode: "tui",
+		hasUI: true,
+		ui: { ...runner.createContext().ui, question: async () => answer },
+	};
+	const records: string[] = [];
+	const signals = new Map<string, ReturnType<typeof Promise.withResolvers<void>>>();
+	harness.session.subscribe((event) => {
+		if (
+			event.type === "message_end" &&
+			event.message.role === "custom" &&
+			event.message.customType === "senpi.hook" &&
+			typeof event.message.content === "string"
+		) {
+			records.push(event.message.content);
+			signals.get(event.message.content)?.resolve();
+		}
+	});
+	return {
+		harness,
+		ctx,
+		tool,
+		records,
+		stdinPath,
+		hooksPath,
+		notificationFinished: notificationFinished.promise,
+		completed(id: string) {
+			const signal = Promise.withResolvers<void>();
+			signals.set(id, signal);
+			return signal.promise;
+		},
+		payloads(): Array<Extract<HookInputWire, { event: "Notification" }>> {
+			return existsSync(stdinPath)
+				? readFileSync(stdinPath, "utf8")
+						.trim()
+						.split("\n")
+						.map((line) => JSON.parse(line))
+				: [];
+		},
+	};
+}
+
+describe("Notification review regressions", () => {
+	it.each(["ask-user-timeout", "something-else", "["])(
+		"R1 dispatch ignores matcher %s but preserves trust and disabled checks",
+		async (matcher) => {
+			const dir = root();
+			const handlers = handlersFor(scriptCommand(dir, { additionalContext: "completed" }), matcher);
+			const result = await dispatchNotificationHookEvent({
+				cwd: dir,
+				handlers,
+				input,
+				trustState: trusted(handlers),
+			});
+			expect(result?.summaries).toHaveLength(1);
+			expect(notificationResultDetails(result).contexts).toEqual(["completed"]);
+			expect(result?.diagnostics).toEqual([]);
+			expect(
+				await dispatchNotificationHookEvent({ cwd: dir, handlers, input, trustState: { version: 1, hooks: {} } }),
+			).toBeUndefined();
+			const state = trusted(handlers);
+			const disabled = {
+				version: 1 as const,
+				hooks: Object.fromEntries(
+					Object.entries(state.hooks).map(([id, entry]) => [id, { ...entry, enabled: false }]),
+				),
+			};
+			expect(
+				await dispatchNotificationHookEvent({ cwd: dir, handlers, input, trustState: disabled }),
+			).toBeUndefined();
+		},
+	);
+	it.each([[], { hookEventName: "Stop", additionalContext: "rejected" }])(
+		"R4 records diagnostics without rejected context for %j",
+		async (hookSpecificOutput) => {
+			const dir = root();
+			const handlers = handlersFor(scriptCommand(dir, { hookSpecificOutput, additionalContext: "rejected" }));
+			const result = await dispatchNotificationHookEvent({
+				cwd: dir,
+				handlers,
+				input,
+				trustState: trusted(handlers),
+			});
+			expect(result?.summaries[0]?.output.additionalContext).toBeUndefined();
+			const details = notificationResultDetails(result);
+			expect(details.contexts).toEqual([]);
+			expect(details.diagnostics.length).toBeGreaterThan(0);
+			const sendMessage = vi.fn();
+			recordLifecycleHookResult({ sendMessage }, "Notification", details);
+			expect(sendMessage).toHaveBeenCalledOnce();
+			expect(sendMessage.mock.calls[0]?.[0].content).not.toContain("rejected");
+		},
+	);
+	it.each(["disabled", "excluded"] as const)(
+		"R2 %s hooks do not prepare or execute notifications from registered tools",
+		async (activation) => {
+			const f = await fixture(activation);
+			const getSources = vi.spyOn(f.ctx, "getLoadedHookSources");
+			expect((await f.tool.execute("disabled", args, undefined, undefined, f.ctx)).details).toMatchObject({
+				status: "answered",
+			});
+			expect(getSources).not.toHaveBeenCalled();
+			expect(f.payloads()).toEqual([]);
+			expect(f.records).toEqual([]);
+		},
+	);
+	it.each([true, false])(
+		"R6 registered tool answer waitForAnswer=%s records exactly one isolated payload",
+		async (waitForAnswer) => {
+			const f = await fixture();
+			const done = f.completed("answer");
+			const result = await f.tool.execute("answer", { ...args, waitForAnswer }, undefined, undefined, f.ctx);
+			expect(result.details).toMatchObject(
+				waitForAnswer ? { status: "answered" } : { status: "pending", requestId: "answer" },
+			);
+			await bounded(done);
+			expect(f.records).toEqual(["answer"]);
+			expect(f.payloads()).toEqual([
+				expect.objectContaining({
+					event: "Notification",
+					hook_event_name: "Notification",
+					notification_source: "ask-user",
+					request_id: "answer",
+					session_id: f.ctx.sessionManager.getSessionId(),
+					status: "answered",
+					kind: "ask-user-settled",
+					title: "Library",
+					cwd: f.ctx.cwd,
+				}),
+			]);
+		},
+	);
+	it.each([true, false])(
+		"R6 authoritative timeout waitForAnswer=%s wins over late UI settlement",
+		async (waitForAnswer) => {
+			const f = await fixture();
+			const ui = Promise.withResolvers<QuestionResponse>();
+			f.ctx.ui.question = vi.fn(() => ui.promise);
+			const done = f.completed("timeout");
+			vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+			const execution = f.tool.execute("timeout", { ...args, waitForAnswer }, undefined, undefined, f.ctx);
+			await vi.advanceTimersByTimeAsync(1800000);
+			const result = await execution;
+			ui.resolve(answer);
+			await ui.promise;
+			vi.useRealTimers();
+			expect(result.details).toMatchObject({ status: waitForAnswer ? "timed_out" : "pending" });
+			await bounded(done);
+			expect(f.records).toEqual(["timeout"]);
+			expect(f.payloads()).toEqual([
+				expect.objectContaining({ request_id: "timeout", status: "timed_out", kind: "ask-user-timeout" }),
+			]);
+		},
+	);
+	it.each([true, false])(
+		"R6 cancellation waitForAnswer=%s never emits a settlement notification",
+		async (waitForAnswer) => {
+			const f = await fixture();
+			f.ctx.ui.question = async () => cancelled;
+			const getSources = vi.spyOn(f.ctx, "getLoadedHookSources");
+			await f.tool.execute("cancelled", { ...args, waitForAnswer }, undefined, undefined, f.ctx);
+			expect(getSources).not.toHaveBeenCalled();
+			expect(f.payloads()).toEqual([]);
+			expect(f.records).toEqual([]);
+		},
+	);
+	it("R6 concurrent async requests retain their IDs and settle once", async () => {
+		const f = await fixture();
+		const first = Promise.withResolvers<QuestionResponse>();
+		const second = Promise.withResolvers<QuestionResponse>();
+		f.ctx.ui.question = (request) => (request.requestId === "first" ? first.promise : second.promise);
+		const firstDone = f.completed("first");
+		const secondDone = f.completed("second");
+		await f.tool.execute("first", { ...args, waitForAnswer: false }, undefined, undefined, f.ctx);
+		await f.tool.execute("second", { ...args, waitForAnswer: false }, undefined, undefined, f.ctx);
+		second.resolve(answer);
+		await bounded(secondDone);
+		first.resolve(timeout);
+		await bounded(firstDone);
+		expect(f.records).toEqual(["second", "first"]);
+		expect(f.payloads().map((p) => [p.request_id, p.status])).toEqual([
+			["second", "answered"],
+			["first", "timed_out"],
+		]);
+	});
+	it.each([answer, timeout, cancelled])(
+		"R3 resumed $status retains original ID and excludes cancellation",
+		async (response) => {
+			const f = await fixture();
+			f.ctx.ui.question = vi.fn(async () => response);
+			f.harness.sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "toolCall", id: "resumed", name: "ask_user_question", arguments: args }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "fixture",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 1,
+			});
+			const done = f.completed("resumed");
+			const runner = f.harness.getExtensionRunner();
+			runner.setUIContext(f.ctx.ui, "tui");
+			await runner.emit({ type: "session_start", reason: "resume" });
+			if (response.status !== "cancelled") await bounded(done);
+			await runner.emit({ type: "session_start", reason: "reload" });
+			expect(f.ctx.ui.question).toHaveBeenCalledOnce();
+			expect(f.payloads()).toEqual(
+				response.status === "cancelled"
+					? []
+					: [expect.objectContaining({ request_id: "resumed", status: response.status })],
+			);
+			expect(f.records).toEqual(response.status === "cancelled" ? [] : ["resumed"]);
+		},
+	);
+	it("R5 emitter returns without config or trust preparation when hooks are inactive", async () => {
+		const f = await fixture("excluded");
+		const getSources = vi.spyOn(f.ctx, "getLoadedHookSources");
+		const read = vi.spyOn(FileHookStateStorage.prototype, "read");
+		const emission = emitAskUserNotification(
+			{ events: createEventBus() },
+			f.ctx,
+			{ requestId: "no-handlers", questions: [], timeoutMs: 1800000, waitForAnswer: true },
+			timeout,
+			"claude",
+		);
+		expect(getSources).not.toHaveBeenCalled();
+		expect(read).not.toHaveBeenCalled();
+		await emission;
+	});
+	it.each([true, false])(
+		"R5 settlement waitForAnswer=%s completes while trust preparation is suspended",
+		async (waitForAnswer) => {
+			const f = await fixture();
+			const gate = Promise.withResolvers<void>();
+			const entered = Promise.withResolvers<void>();
+			// Observe the user-message boundary without starting an unrelated provider turn (and Stop hooks).
+			const userMessage = vi.spyOn(f.harness.session, "sendUserMessage").mockResolvedValue();
+			const original = FileHookStateStorage.prototype.readAsync;
+			vi.spyOn(FileHookStateStorage.prototype, "readAsync").mockImplementation(async function (
+				this: FileHookStateStorage,
+				scope,
+			) {
+				entered.resolve();
+				await gate.promise;
+				return original.call(this, scope);
+			});
+			const syncRead = vi.spyOn(FileHookStateStorage.prototype, "read");
+			const done = f.completed("gated");
+			const result = await bounded(f.tool.execute("gated", { ...args, waitForAnswer }, undefined, undefined, f.ctx));
+			await bounded(entered.promise);
+			expect(result.details).toMatchObject({ status: waitForAnswer ? "answered" : "pending" });
+			expect(f.payloads()).toEqual([]);
+			expect(syncRead).not.toHaveBeenCalled();
+			expect(userMessage).toHaveBeenCalledTimes(waitForAnswer ? 0 : 1);
+			gate.resolve();
+			await bounded(done);
+			expect(f.records).toEqual(["gated"]);
+		},
+	);
+	it.each([true, false])("R5 settlement waitForAnswer=%s does not await command completion", async (waitForAnswer) => {
+		const f = await fixture();
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		const userMessage = vi.spyOn(f.harness.session, "sendUserMessage").mockResolvedValue();
+		const original = commandRunner.runCommandHook;
+		vi.spyOn(commandRunner, "runCommandHook").mockImplementation(async (...options) => {
+			entered.resolve();
+			await gate.promise;
+			return original(...options);
+		});
+		const done = f.completed("command-gated");
+		const result = await bounded(
+			f.tool.execute("command-gated", { ...args, waitForAnswer }, undefined, undefined, f.ctx),
+		);
+		await bounded(entered.promise);
+		expect(result.details).toMatchObject({ status: waitForAnswer ? "answered" : "pending" });
+		expect(userMessage).toHaveBeenCalledTimes(waitForAnswer ? 0 : 1);
+		expect(f.records).toEqual([]);
+		gate.resolve();
+		await bounded(done);
+		expect(f.payloads()).toHaveLength(1);
+		expect(f.records).toEqual(["command-gated"]);
+	});
+	it("R5 no Notification handlers skips trust reads even with contended lock directories", async () => {
+		const f = await fixture();
+		writeFileSync(f.hooksPath, JSON.stringify({ hooks: {} }));
+		mkdirSync(join(f.hooksPath, "..", "hooks-state.json.lock"));
+		const read = vi.spyOn(FileHookStateStorage.prototype, "read");
+		const readAsync = vi.spyOn(FileHookStateStorage.prototype, "readAsync");
+		await f.tool.execute("no-handlers", args, undefined, undefined, f.ctx);
+		await bounded(f.notificationFinished);
+		expect(read).not.toHaveBeenCalled();
+		expect(readAsync).not.toHaveBeenCalled();
+		expect(f.payloads()).toEqual([]);
+	});
+	it.each([undefined, "/fixture/session.jsonl"])(
+		"R7 typed payload declares optional transcript_path %s",
+		async (transcriptPath) => {
+			const f = await fixture("excluded");
+			vi.spyOn(f.ctx.sessionManager, "getSessionFile").mockReturnValue(transcriptPath);
+			const wire = buildNotificationHookInput({ kind: "ask-user-timeout", message: "fixture" }, f.ctx);
+			if (wire.event !== "Notification") throw new Error("wrong wire variant");
+			expect(wire.transcript_path).toBe(transcriptPath);
+			expect(Object.hasOwn(wire, "transcript_path")).toBe(transcriptPath !== undefined);
+		},
+	);
+});

--- a/packages/coding-agent/test/suite/hooks-notification.test.ts
+++ b/packages/coding-agent/test/suite/hooks-notification.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import askUserExtension from "../../src/core/extensions/builtin/ask-user/index.ts";
-import { emitAskUserNotification } from "../../src/core/extensions/builtin/ask-user/notify.ts";
 import { parseHookConfig, SUPPORTED_HOOK_EVENTS } from "../../src/core/extensions/builtin/hooks/index.ts";
 import { matchingHookHandlers } from "../../src/core/extensions/builtin/hooks/matcher.ts";
 import { parseHookOutput } from "../../src/core/extensions/builtin/hooks/output-parser.ts";
@@ -66,7 +65,7 @@ describe("builtin hooks Notification event", () => {
 		const scriptPath = join(hookDir, "notify.mjs");
 		writeFileSync(
 			scriptPath,
-			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({})); });`,
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({ additionalContext: 'notification-timeout' })); });`,
 			"utf-8",
 		);
 		const hooksExtension = builtinExtensions.find((entry) => entry.id === "hooks");
@@ -119,21 +118,41 @@ describe("builtin hooks Notification event", () => {
 				ui: { ...runner.createContext().ui, question: vi.fn(async () => timedOut) },
 			};
 			const sent: unknown[] = [];
-			const timedOutResponse: QuestionResponse = timedOut;
-			await emitAskUserNotification(
-				{ sendMessage: (message: unknown) => void sent.push(message) },
-				ctx,
-				{
-					questions: [
-						{ id: "q1", header: "Library", question: "Which library?", options: [], multiSelect: false },
-					],
-					requestId: "notification-timeout",
-					timeoutMs: 1_800_000,
-					waitForAnswer: true,
-				},
-				timedOutResponse,
-				"claude",
-			);
+			const completed = Promise.withResolvers<void>();
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (
+					event.type === "message_end" &&
+					event.message.role === "custom" &&
+					event.message.content === "notification-timeout"
+				) {
+					sent.push(event.message);
+					completed.resolve();
+				}
+			});
+			const tool = runner
+				.getAllRegisteredTools()
+				.find((entry) => entry.definition.name === "ask_user_question")?.definition;
+			if (!tool) throw new Error("missing ask-user tool");
+			const deadline = setTimeout(() => completed.reject(new Error("Notification was not recorded")), 5000);
+			try {
+				const result = await tool.execute(
+					"notification-timeout",
+					{
+						questions: [{ header: "Library", question: "Which library?", multiSelect: false }],
+						waitForAnswer: true,
+					},
+					undefined,
+					undefined,
+					ctx,
+				);
+				expect(result.details).toMatchObject({ status: "timed_out" });
+				await completed.promise;
+				expect(ctx.ui.question).toHaveBeenCalledOnce();
+				expect(sent).toHaveLength(1);
+			} finally {
+				clearTimeout(deadline);
+				unsubscribe();
+			}
 			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
 			expect(stdin).toMatchObject({
 				event: "Notification",

--- a/packages/coding-agent/test/suite/hooks-notification.test.ts
+++ b/packages/coding-agent/test/suite/hooks-notification.test.ts
@@ -121,7 +121,7 @@ describe("builtin hooks Notification event", () => {
 			const sent: unknown[] = [];
 			const timedOutResponse: QuestionResponse = timedOut;
 			await emitAskUserNotification(
-				{ sendMessage: ((message: unknown) => void sent.push(message)) as never },
+				{ sendMessage: (message: unknown) => void sent.push(message) },
 				ctx,
 				{
 					questions: [

--- a/packages/coding-agent/test/suite/hooks-notification.test.ts
+++ b/packages/coding-agent/test/suite/hooks-notification.test.ts
@@ -1,0 +1,173 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import askUserExtension from "../../src/core/extensions/builtin/ask-user/index.ts";
+import { emitAskUserNotification } from "../../src/core/extensions/builtin/ask-user/notify.ts";
+import { parseHookConfig, SUPPORTED_HOOK_EVENTS } from "../../src/core/extensions/builtin/hooks/index.ts";
+import { matchingHookHandlers } from "../../src/core/extensions/builtin/hooks/matcher.ts";
+import { parseHookOutput } from "../../src/core/extensions/builtin/hooks/output-parser.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type { HookSourceMetadata, HookTrustEntry } from "../../src/core/extensions/builtin/hooks/types.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import type { ExtensionContext, QuestionResponse } from "../../src/core/extensions/types.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 7,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+describe("builtin hooks Notification event", () => {
+	it("is a supported event that parses handlers without diagnostics", () => {
+		const parsed = parseHookConfig(
+			{
+				hooks: {
+					Notification: [{ matcher: "ask-user-timeout", hooks: [{ type: "command", command: "notify.sh" }] }],
+				},
+			},
+			SOURCE,
+		);
+		expect(parsed.diagnostics).toEqual([]);
+		expect(parsed.executableHandlers).toHaveLength(1);
+		expect(parsed.executableHandlers[0]).toMatchObject({ event: "Notification", matcher: "ask-user-timeout" });
+		expect(SUPPORTED_HOOK_EVENTS).toContain("Notification");
+	});
+
+	it("delivers Notification input to every handler regardless of matcher", () => {
+		const parsed = parseHookConfig(
+			{
+				hooks: {
+					Notification: [{ matcher: "something-else", hooks: [{ type: "command", command: "notify.sh" }] }],
+				},
+			},
+			SOURCE,
+		);
+		const matched = matchingHookHandlers(
+			{
+				cwd: "/repo",
+				event: "Notification",
+				hook_event_name: "Notification",
+				kind: "ask-user-timeout",
+				message: "Question timed out",
+				session_id: "session-1",
+			},
+			parsed.executableHandlers,
+		);
+		expect(matched.handlers).toHaveLength(1);
+	});
+
+	it("fires Notification with the timed-out question payload through the ask-user tool", async () => {
+		const hookDir = join(tmpdir(), `senpi-notification-hook-${Date.now()}`);
+		mkdirSync(hookDir, { recursive: true });
+		const stdinPath = join(hookDir, "stdin.json");
+		const scriptPath = join(hookDir, "notify.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({})); });`,
+			"utf-8",
+		);
+		const hooksExtension = builtinExtensions.find((entry) => entry.id === "hooks");
+		if (hooksExtension === undefined) throw new Error("builtin hooks extension is not registered");
+		const harness: Harness = await createHarness({
+			extensionFactories: [
+				{ factory: hooksExtension.factory, path: "<builtin:hooks>" },
+				{ factory: askUserExtension, path: "<builtin:ask-user>" },
+			],
+			settings: { askUser: { enabled: true } },
+		});
+		try {
+			await harness.session.bindExtensions({});
+			const senpiDir = join(harness.tempDir, ".senpi");
+			mkdirSync(senpiDir, { recursive: true });
+			const hookConfig = {
+				hooks: { Notification: [{ hooks: [{ type: "command", command: `${process.execPath} ${scriptPath}` }] }] },
+			};
+			writeFileSync(join(senpiDir, "hooks.json"), `${JSON.stringify(hookConfig, null, 2)}\n`, "utf-8");
+			const source = {
+				discoveredAt: "pre-session",
+				displayOrder: 0,
+				scope: "project",
+				sourcePath: join(senpiDir, "hooks.json"),
+			} satisfies HookSourceMetadata;
+			const parsed = parseHookConfig(hookConfig, source);
+			const hooks: Record<string, HookTrustEntry> = {};
+			for (const handler of parsed.executableHandlers) {
+				hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+					platform: process.platform,
+					updatedAt: "2026-06-29T00:00:00.000Z",
+				});
+			}
+			writeFileSync(
+				join(senpiDir, "hooks-state.json"),
+				`${JSON.stringify({ version: 1, hooks }, null, 2)}\n`,
+				"utf-8",
+			);
+			const runner = harness.getExtensionRunner();
+			const timedOut: QuestionResponse = {
+				answers: {},
+				autoResolvedAfterMs: 1_800_000,
+				status: "timed_out",
+				unanswered: ["q1"],
+			};
+			const ctx: ExtensionContext = {
+				...runner.createContext(),
+				hasUI: true,
+				mode: "tui",
+				ui: { ...runner.createContext().ui, question: vi.fn(async () => timedOut) },
+			};
+			const sent: unknown[] = [];
+			const timedOutResponse: QuestionResponse = timedOut;
+			await emitAskUserNotification(
+				{ sendMessage: ((message: unknown) => void sent.push(message)) as never },
+				ctx,
+				{
+					questions: [
+						{ id: "q1", header: "Library", question: "Which library?", options: [], multiSelect: false },
+					],
+					requestId: "notification-timeout",
+					timeoutMs: 1_800_000,
+					waitForAnswer: true,
+				},
+				timedOutResponse,
+				"claude",
+			);
+			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				event: "Notification",
+				hook_event_name: "Notification",
+				kind: "ask-user-timeout",
+				request_id: "notification-timeout",
+				status: "timed_out",
+			});
+		} finally {
+			harness.cleanup();
+			rmSync(hookDir, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts additionalContext and rejects decisions for Notification output", () => {
+		const accepted = parseHookOutput({
+			event: "Notification",
+			exitCode: 0,
+			source: SOURCE,
+			stderr: "",
+			stdout: JSON.stringify({ additionalContext: "hook saw the timeout" }),
+		});
+		expect(accepted.diagnostics).toEqual([]);
+		expect(accepted.output.additionalContext).toBe("hook saw the timeout");
+		const rejected = parseHookOutput({
+			event: "Notification",
+			exitCode: 0,
+			source: SOURCE,
+			stderr: "",
+			stdout: JSON.stringify({ decision: "block" }),
+		});
+		expect(rejected.output.decision).toBeUndefined();
+		expect(rejected.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "unsupported_field", event: "Notification" }),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Supports the `Notification` hook event in builtin hooks v1 and fires it for ask-user question settlements, so question timeouts and answers can trigger user-defined hook commands (e.g. desktop or mobile push on `ask-user-timeout`).

- `Notification` moves from unsupported-known to supported hook events with a dedicated input wire (`message`, `kind`, `title`, `notification_source`, `request_id`, `status`).
- Matcher ignores the matcher string (fires for all Notification handlers, like Stop); output accepts `additionalContext` and rejects decisions with an `unsupported_field` diagnostic.
- ask-user fires a best-effort Notification on every non-cancelled settlement without delaying the tool result or the follow-up user message: `kind` is `ask-user-timeout` on timeout, `ask-user-settled` otherwise.

## Test plan

- New `packages/coding-agent/test/suite/hooks-notification.test.ts`: schema, matcher, output-parser, and end-to-end ask-user timeout delivery (4 tests).
- Existing suites green: hooks-schema, hooks-matcher, hooks-output-parser, hooks-dispatcher, hooks-lifecycle, ask-user-extension, ask-user-pending (54 tests total across 8 files).
- `tsc --noEmit` clean for `packages/coding-agent/src` (remaining errors are pre-existing worktree dependency gaps in unrelated packages).

Created by muse spark 1.3 contributor-free

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Notification` hook event to builtin hooks v1 and fires it for every non-cancelled ask-user settlement, so timeouts and answers can trigger user-defined hook commands like desktop or mobile push notifications.

- The Notification input wire carries `message`, `kind`, and optional `title`, `notification_source`, `request_id`, and `status`.
- Matchers are ignored; it fires for every handler, and output accepts `additionalContext` while rejecting decisions with an `unsupported_field` diagnostic.
- Live and resumed settlements emit `kind: "ask-user-timeout"` on timeout and `kind: "ask-user-settled"` otherwise, best-effort and without delaying the tool result or the follow-up user message.
- Config and trust are read asynchronously; disabling or excluding hooks prevents execution, and no handlers means no trust I/O.

<sup>Written for commit 4bf65774d107b6cba2c37bd869dd2b4632d2462c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

