### PR TITLE
fix(release): publish chord under the fork alias so bundled installs resolve

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed `bun add @code-yeongyu/senpi` failing with `No version matching "^<version>" found for specifier "@earendil-works/chord"`. The bundled chord workspace had no published fork alias, so the packaged manifest declared a CalVer range that only upstream's own 0.85.x line could answer; chord is now published as `@code-yeongyu/senpi-chord` and the packaged dependency points at that alias, like every other bundled runtime workspace (fixes #1632).
+
 ### Removed
 
 ## [2026.9.12-3] - 2026-09-12

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -30,7 +30,7 @@ cell grid. Prefixes encode role:
 - `release.mjs`: CalVer release composing `calver.mjs` and
   `release-{packages,artifacts,changelog,git,test-gate}.mjs`. Preflight: on `main`, clean tree
   (dry-run warns), valid CalVer; `--dry-run` previews every command and file write.
-- `publish.mjs`: publishes seven fork-owned packages (`senpi-ai`, `senpi-agent-core`, `senpi-tui`,
+- `publish.mjs`: publishes eight fork-owned packages (`senpi-chord`, `senpi-ai`, `senpi-agent-core`, `senpi-tui`,
   `senpi-pty`, `senpi-telemetry`, `senpi-codemode`, `senpi`); sources stay `private`, copied to
   temporary public manifests under the fork scope (`@code-yeongyu/senpi-server` stays excluded).
   Provenance requires GitHub Actions (`publish-command.mjs` throws outside it);

--- a/scripts/calver.test.mjs
+++ b/scripts/calver.test.mjs
@@ -35,7 +35,7 @@ describe("computeNextVersion", () => {
 		assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n").map(JSON.parse).sort(), [
 			"@code-yeongyu/senpi", "@code-yeongyu/senpi-ai", "@code-yeongyu/senpi-agent-core",
 			"@code-yeongyu/senpi-tui", "@code-yeongyu/senpi-pty", "@code-yeongyu/senpi-telemetry",
-			"@code-yeongyu/senpi-codemode",
+			"@code-yeongyu/senpi-codemode", "@code-yeongyu/senpi-chord",
 		].sort());
 	});
 

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-12 - Chord joins the owned registry aliases so bundled installs resolve
+
+### What changed
+
+- `scripts/release-packages.mjs`: the `packages/chord` entry in `WORKSPACE_PACKAGES` is documented as a published fork alias rather than a bundle-only workspace, and `getRuntimeDepsCheckPackages()`'s comment no longer lists chord among the unpublished workspaces. `getPublicWorkspacePackages()` now resolves eight registry packages because the shared mapping gained chord; the function itself is unchanged.
+- `scripts/sync-versions.test.mjs`: the fixture workspace set includes `packages/chord`, matching the real tree, so the registry-source completeness guard in `resolveRegistryPackages` is satisfied.
+
+### Why
+
+- `@code-yeongyu/senpi@2026.9.12-3` could not be installed with bun: the packaged manifest declared `"@earendil-works/chord": "^2026.9.12-3"`, and only upstream's 0.85.x line exists on the registry. Bun resolves declared edges for bundled packages too and synthesizes `^<bundled version>` when the manifest omits one, so chord needs a published fork alias exactly like agent-core, ai, tui, pty and telemetry (issue #1632). `scripts/release-packages.mjs` is where the fork records which workspaces ride the CalVer lockstep and which are published, so its chord rationale had to change with the mapping; `scripts/sync-versions.test.mjs` asserts the stamping behavior over a fixture that must mirror the real workspace set.
+
+### Why an extension could not handle it
+
+- Release planning, version stamping and publish-target selection run in the release scripts before publication, outside the runtime extension system: `scripts/release-packages.mjs` and `scripts/sync-versions.test.mjs` execute in the release pipeline, never inside a running agent session.
+
+### Expected merge conflict zones
+
+- `scripts/release-packages.mjs` workspace list and its surrounding comments; the fixture workspace list in `scripts/sync-versions.test.mjs`.
+
 ## 2026-09-12 - Registry planning and concurrent-main release recovery
 
 ### What changed

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -38,11 +38,13 @@ export function nativePrebuildFile(target) {
 }
 
 const bundledWorkspaces = [
-	// Chord is a local workspace, never a registry package for this fork: the vendored
-	// client/protocol dist and the bundled agent-core dist both import
-	// `@earendil-works/chord`, so the packed copy under coding-agent/node_modules must be
-	// the only thing that resolves. `/context` ships too because the client runtime
-	// imports `@earendil-works/chord/context`.
+	// The vendored client/protocol dist and the bundled agent-core dist both import
+	// `@earendil-works/chord`, so the packed copy under coding-agent/node_modules is what the
+	// runtime loads. The declared dependency edge still has to point at the fork's published
+	// alias (`@code-yeongyu/senpi-chord`): Bun resolves bundled entries from the registry too and
+	// otherwise synthesizes `^<bundled version>`, which no upstream release satisfies (issue
+	// #1632). `/context` ships too because the client runtime imports
+	// `@earendil-works/chord/context`.
 	{
 		source: "packages/chord",
 		packageName: "@earendil-works/chord",

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -290,7 +290,7 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		assert.deepEqual(manifest.files, ["dist", "README.md", "vendor"]);
 		assert.deepEqual(manifest.dependencies, {
 			"@code-yeongyu/senpi-codemode": "2026.7.22",
-			"@earendil-works/chord": "^2026.7.22",
+			"@earendil-works/chord": "npm:@code-yeongyu/senpi-chord@2026.7.22",
 			"@earendil-works/pi-agent-core": "npm:@code-yeongyu/senpi-agent-core@2026.7.22",
 			"@earendil-works/pi-ai": "npm:@code-yeongyu/senpi-ai@2026.7.22",
 			"@earendil-works/pi-pty": "npm:@code-yeongyu/senpi-pty@2026.7.22",

--- a/scripts/publish-registry-dependencies.test.mjs
+++ b/scripts/publish-registry-dependencies.test.mjs
@@ -3,11 +3,14 @@ import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { bundledWorkspacePackageChecks } from "./prepare-senpi-bundled-workspaces.mjs";
+import { registryPackageNames } from "./registry-packages.mjs";
 import { getPublicWorkspacePackages } from "./release-packages.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const PRIVATE_UPSTREAM_WORKSPACES = [
+	{ packageJsonPath: "packages/chord/package.json", packageName: "@earendil-works/chord" },
 	{ packageJsonPath: "packages/ai/package.json", packageName: "@earendil-works/pi-ai" },
 	{ packageJsonPath: "packages/agent/package.json", packageName: "@earendil-works/pi-agent-core" },
 	{ packageJsonPath: "packages/tui/package.json", packageName: "@earendil-works/pi-tui" },
@@ -21,6 +24,7 @@ const INDEPENDENT_UPSTREAM_WORKSPACES = [
 	},
 ];
 const OWNED_REGISTRY_ALIASES = [
+	"@code-yeongyu/senpi-chord",
 	"@code-yeongyu/senpi-ai",
 	"@code-yeongyu/senpi-agent-core",
 	"@code-yeongyu/senpi-tui",
@@ -64,5 +68,22 @@ describe("npm publish dependency graph", () => {
 		for (const packageName of BUNDLED_ONLY_WORKSPACES) {
 			assert.ok(!publishedNames.includes(packageName));
 		}
+	});
+
+	it("publishes a registry alias for every bundled workspace", () => {
+		// Given: npm installs a bundled workspace from the packed copy, but Bun resolves the
+		// declared edge from the registry and synthesizes `^<bundled version>` when the manifest
+		// has none. A bundled workspace without an owned alias therefore ships a CalVer spec no
+		// upstream release satisfies, and `bun add @code-yeongyu/senpi@<version>` fails outright
+		// (issue #1632: chord shipped that way in 2026.9.12-3).
+		const publishedNames = getPublicWorkspacePackages().map(({ name }) => name);
+		const unaliased = [];
+		for (const { packageName } of bundledWorkspacePackageChecks()) {
+			const registryName = registryPackageNames.get(packageName);
+			if (registryName === undefined || !publishedNames.includes(registryName)) {
+				unaliased.push(packageName);
+			}
+		}
+		assert.deepEqual(unaliased, [], `bundled workspaces without a published registry alias: ${unaliased.join(", ")}`);
 	});
 });

--- a/scripts/publish-release-announcement.test.mjs
+++ b/scripts/publish-release-announcement.test.mjs
@@ -9,6 +9,7 @@ test("announces every fork-owned registry package from private sources", () => {
 		[
 			"@code-yeongyu/senpi-agent-core",
 			"@code-yeongyu/senpi-ai",
+			"@code-yeongyu/senpi-chord",
 			"@code-yeongyu/senpi",
 			"@code-yeongyu/senpi-pty",
 			"@code-yeongyu/senpi-codemode",

--- a/scripts/registry-packages.mjs
+++ b/scripts/registry-packages.mjs
@@ -1,4 +1,5 @@
 export const registryPackageNames = new Map([
+	["@earendil-works/chord", "@code-yeongyu/senpi-chord"],
 	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
 	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
 	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],

--- a/scripts/registry-packages.test.mjs
+++ b/scripts/registry-packages.test.mjs
@@ -8,7 +8,9 @@ import {
 const completeSources = [...registrySourcePackageNames].map((name) => ({ name }));
 
 test("resolves every registry package source exactly once", () => {
-	assert.equal(resolveRegistryPackages(completeSources).length, 7);
+	// The owned-alias content is enumerated by publish-registry-dependencies.test.mjs; this asserts
+	// resolution completeness, so it tracks the mapping instead of restating its size.
+	assert.equal(resolveRegistryPackages(completeSources).length, registrySourcePackageNames.size);
 });
 
 test("rejects a missing registry package source", () => {

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -5,9 +5,10 @@ import { registrySourcePackageNames, resolveRegistryPackages } from "./registry-
 
 export const WORKSPACE_PACKAGES = [
 	"packages/ai/package.json",
-	// Chord is bundled into the senpi tarball rather than published, but it still rides the
-	// fork's CalVer lockstep so the install lock treats it as an internal workspace instead of
-	// trying to resolve a registry-absent `@earendil-works/chord` link entry.
+	// Chord rides the fork's CalVer lockstep and is published under the fork alias
+	// (`@code-yeongyu/senpi-chord`) like every other bundled runtime workspace: the tarball still
+	// carries the packed copy, but the declared edge has to resolve from the registry because Bun
+	// resolves bundled entries too (issue #1632).
 	"packages/chord/package.json",
 	"packages/agent/package.json",
 	"packages/client/package.json",
@@ -71,7 +72,7 @@ export function getPublicWorkspacePackages() {
 // names (publish.mjs rewrites them to `@code-yeongyu/senpi-*` manifests), so the fork's
 // runtime-dependency contract is the union: public-by-flag packages (client/protocol here,
 // everything in upstream-shaped fixtures) plus the fork's registry sources. Private,
-// unpublished workspaces (chord, senpi-server, sqlite-node) stay out.
+// unpublished workspaces (senpi-server, sqlite-node) stay out.
 export function getRuntimeDepsCheckPackages() {
 	return findPackageDirectories()
 		.map((directory) => ({

--- a/scripts/sync-versions.test.mjs
+++ b/scripts/sync-versions.test.mjs
@@ -39,6 +39,7 @@ test("synchronizes private dependencies without touching registry aliases, gener
 			private: true,
 		});
 		for (const [directory, name] of [
+			["chord", "@earendil-works/chord"],
 			["agent", "@earendil-works/pi-agent-core"],
 			["tui", "@earendil-works/pi-tui"],
 			["pty", "@earendil-works/pi-pty"],


### PR DESCRIPTION
## What changed

`@earendil-works/chord` — the bundled runtime workspace that arrived with the upstream sync (#1626) — is now published under the fork alias `@code-yeongyu/senpi-chord`, so the packaged `@code-yeongyu/senpi` manifest carries `"@earendil-works/chord": "npm:@code-yeongyu/senpi-chord@<version>"` instead of a bare `^<CalVer>` range no registry version can satisfy.

- `scripts/registry-packages.mjs`: chord joins the owned alias map, which is what drives the publish set, the CalVer baseline query, and the packaged-manifest alias rewrite.
- `scripts/publish-registry-dependencies.test.mjs`: new guard test — **every bundled workspace must have a published registry alias**. It fails on the pre-fix tree naming chord.
- Expected-set updates in the release/publish/prepare suites, and comment corrections where the old "never a registry package" decision was recorded.

## Why

`@code-yeongyu/senpi@2026.9.12-3` is uninstallable with bun:

```
error: No version matching "^2026.9.12-3" found for specifier "@earendil-works/chord" (but package exists)
```

The upstream package only publishes 0.85.x. npm installs fine because it honours the packed copy, but bun resolves declared edges for bundled packages too — and when the manifest has no entry it synthesizes `^<bundled version>`, so removing the dependency (or removing it from `bundle(d)Dependencies`) does not help. The edge has to resolve, which is exactly why the other five bundled workspaces are aliased.

## Observed behavior (real installers, published artifact)

| probe | result |
| --- | --- |
| `bun add @code-yeongyu/senpi@2026.9.12-3` | fails, chord `^2026.9.12-3` unresolvable |
| `bun add @code-yeongyu/senpi@2026.9.12-2` (control) | 255 packages installed |
| `npm i --ignore-scripts` 2026.9.12-3 tarball | succeeds (packed copy honoured) |
| tarball with the chord entry removed | bun still fails (synthesized `^<bundled version>`) |
| tarball with chord also removed from `bundle(d)Dependencies` | bun still fails |
| tarball with a resolvable same-version alias | **exit 0**, bundled chord present at the CalVer version |

## Verification

- Guard test: fails on the pre-fix tree (`bundled workspaces without a published registry alias: @earendil-works/chord`), passes after.
- `node --test` over `publish-registry-dependencies`, `prepare-senpi-bundled-workspaces.prepare`, `publish-release-announcement`, `calver`, `release-packages`: **19 tests, 19 pass, 0 fail**.
- `node scripts/audit-changes-md.mjs`: exit 0.
- `biome check` on the changed scripts: those paths are config-ignored (no formatting surface).

## Residual risk

The first publish of `@code-yeongyu/senpi-chord` creates a new public package name; the publish job uses the same fork-scoped path as the other six, so it needs no new configuration beyond the scope it already publishes to. Verified for real by the next release's install check.

Fixes #1632

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `bun add @code-yeongyu/senpi` failing because the bundled chord workspace had no published registry alias, so the packaged manifest declared a CalVer range no registry version satisfies. Chord now publishes as `@code-yeongyu/senpi-chord` and the packaged dependency edge points at that alias.

- Adds a guard test that fails if any bundled workspace lacks a published registry alias.
- Updates release-script fixtures so the registry-source completeness guard sees chord, and makes registry resolution tests track the alias map instead of a fixed package count.
- The first publish of `@code-yeongyu/senpi-chord` creates a new public package under the existing fork scope.

Fixes #1632.

<sup>Written for commit 626dc2b9c72946bc5bec3ccf4307f1a8f5958861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

