### PR TITLE
fix(coding-agent): clear the ask-user own-answer editor when advancing to the next question

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed the ask-user question dialog carrying a committed own-answer into the next question: after answering a question with typed text, the next question's editor no longer shows the previous answer's text and pressing Enter again no longer submits it as the next question's own answer.
+
 ### Removed
 
 ## [2026.9.12-3] - 2026-09-12

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-09-12 - Clear the ask-user own-answer editor when advancing to the next question
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/ask-user-question.ts`: `commitOwnAnswer()` clears `ownAnswerInput` after committing the typed text to the active question. Previously the editor kept the committed value, so the Enter path (commit + `advance()`) left focus in own-answer on the next question with the previous question's text still in the editor, and pressing Enter again committed that stale text as the next question's own answer (it also reached `onProgress` drafts through `emitProgress`).
+- Revisiting a tab is unchanged: `openOwnAnswer()` still reloads the question's saved text from `AskUserQuestionState.textFor()`, so committed answers stay editable per question.
+- `packages/coding-agent/test/suite/ask-user-question-component.test.ts`: regression coverage for the empty editor on the next question, no stale `onProgress` answer for the next question, and the saved answer reloading when the tab is revisited.
+
+### Why
+
+- With multi-question `ask-user` requests, answering a question with the own-answer editor prefilled the following question with the previous answer's text and submitted it as that question's custom answer when the user pressed Enter again — silently answering a question the user had not answered.
+
+### Why an extension could not handle it
+
+- The editor lifetime is owned by the fork's in-tree question overlay component; `AskUserQuestionState` deliberately stays free of pi-tui input state, so only the component can reset the editor.
+
+### Expected merge conflict zones
+
+- `commitOwnAnswer()` in `packages/coding-agent/src/modes/interactive/components/ask-user-question.ts` if upstream changes the own-answer commit/advance flow.
+
 ## 2026-09-12 - Support the Notification hook event and fire it for ask-user settlements
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/ask-user-question.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ask-user-question.ts
@@ -144,6 +144,10 @@ export class AskUserQuestionComponent extends Container implements Focusable {
 
 	private commitOwnAnswer(): void {
 		this.state.setOwnAnswer(this.state.activeQuestion.id, this.ownAnswerInput.getValue());
+		// Clear the editor after committing: the Enter path advances to the next
+		// question while focus stays in own-answer, and a leftover value would
+		// prefill that question's editor and submit as its own answer on repeat.
+		this.ownAnswerInput.setValue("");
 		this.emitProgress();
 	}
 

--- a/packages/coding-agent/test/suite/ask-user-question-component.test.ts
+++ b/packages/coding-agent/test/suite/ask-user-question-component.test.ts
@@ -14,6 +14,7 @@ const ENTER = "\r";
 const ESC = "\x1b";
 const CTRL_C = "\x03";
 const TAB = "\t";
+const SHIFT_TAB = "\x1b[Z";
 const SPACE = " ";
 const CTRL_ENTER = "\x1b[13;5u";
 
@@ -299,6 +300,46 @@ describe("AskUserQuestionComponent", () => {
 		const last = h.progressCalls[h.progressCalls.length - 1];
 		expect(last?.answers?.auth).toEqual({ selected: [], text: "use a vault token" });
 		expect(h.render()).toContain("Which extras should be enabled?");
+	});
+
+	it("clears the own-answer editor when advancing to the next question", () => {
+		const h = mount();
+
+		// Q1: open the own-answer editor and commit a typed answer.
+		h.component.handleInput(DOWN);
+		h.component.handleInput(DOWN);
+		h.component.handleInput(ENTER);
+		h.component.handleInput("use a vault token");
+		h.component.handleInput(ENTER);
+
+		// Q2: the editor must start empty instead of carrying Q1's text over.
+		expect(h.render()).toContain("Which extras should be enabled?");
+		expect(h.render()).not.toContain("use a vault token");
+
+		// Committing again on Q2 must not submit Q1's text as Q2's own answer.
+		h.component.handleInput(ENTER);
+
+		const last = h.progressCalls[h.progressCalls.length - 1];
+		expect(last?.answers?.extras).toBeUndefined();
+		expect(h.doneCalls).toHaveLength(0);
+	});
+
+	it("reloads a saved own answer when the question is revisited", () => {
+		const h = mount();
+
+		h.component.handleInput(DOWN);
+		h.component.handleInput(DOWN);
+		h.component.handleInput(ENTER);
+		h.component.handleInput("use a vault token");
+		h.component.handleInput(ENTER);
+
+		// Back to Q1 via the tab bar and reopen its own-answer editor.
+		h.component.handleInput(SHIFT_TAB);
+		h.component.handleInput(DOWN);
+		h.component.handleInput(DOWN);
+		h.component.handleInput(ENTER);
+
+		expect(h.render()).toContain("use a vault token");
 	});
 
 	it("formats the countdown as minutes above five minutes and mm:ss below", () => {


### PR DESCRIPTION
## Summary

When a multi-question ask-user dialog is answered via the own-answer ("Type your own answer...") editor, the typed text leaked into the next question:

- `commitOwnAnswer()` stored the text in `AskUserQuestionState` but never cleared `ownAnswerInput`.
- The Enter path runs commit + `state.advance()` and keeps focus in own-answer, so the next question's editor rendered with the previous question's text still in it (the user's report: the entered content "remains entered on the next question").
- Pressing Enter again committed that stale text as the next question's own answer, and `emitProgress()` had already advertised it as the next question's draft answer (the user's report: it "remains in the choices as the custom answer").

Fix: `commitOwnAnswer()` clears `ownAnswerInput` after storing the value. Revisiting a tab is unchanged — `openOwnAnswer()` still reloads the question's saved text from `AskUserQuestionState.textFor()`, so committed answers stay editable per question.

## Changes

- `packages/coding-agent/src/modes/interactive/components/ask-user-question.ts`: clear the own-answer editor after commit.
- `packages/coding-agent/test/suite/ask-user-question-component.test.ts`: regressions for the empty editor on the next question, no stale `onProgress` answer, and saved-answer reload on revisit.
- `packages/coding-agent/src/changes.md`: tracker entry.

## Verification

- Regression test fails before the fix (render contains the previous question's text on the next question) and passes after.
- Full `ask-user` test surface: 15 test files, 119 tests, all passing.
- Root `bun run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, platform-lock, `tsc --noEmit`, browser smoke): exit 0.

## Risk

- `commitOwnAnswer()` also runs on the ctrl+Enter submit path; clearing the editor there is inert because the dialog is already finishing. No behavioral change for single-question dialogs or the comment editor (dialog-scoped by design).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ask-user own-answer editor so typed text no longer carries over to the next question in multi-question dialogs, and pressing Enter again no longer submits the previous answer as the next question's own answer.

- `commitOwnAnswer()` now clears the editor after storing the value.
- Revisiting a question still reloads its saved answer, so committed answers remain editable per question.
- Adds a changelog entry for the fix.

<sup>Written for commit 3f6871e221a27608cf79d9d81e3fac1b078c5961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

