### PR TITLE
fix(coding-agent): read working/retry status cadence from an O(1) entry count

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed long, compaction-trimmed sessions re-parsing the entire session file every time the working/retry status animation cadence was decided, which made the UI periodically freeze on multi-day sessions. The cadence now reads an O(1) maintained entry count (`SessionManager#getEntryCount()`); explicit full-history retrieval is unchanged.
 - Fixed `bun add @code-yeongyu/senpi` failing with `No version matching "^<version>" found for specifier "@earendil-works/chord"`. The bundled chord workspace had no published fork alias, so the packaged manifest declared a CalVer range that only upstream's own 0.85.x line could answer; chord is now published as `@code-yeongyu/senpi-chord` and the packaged dependency points at that alias, like every other bundled runtime workspace (fixes #1632).
 
 ### Removed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,37 @@
 # changes
 
+## 2026-09-12 - O(1) full-history entry count on SessionManager
+
+### What changed
+
+- `packages/coding-agent/src/core/session-manager.ts`: new `getEntryCount()` returns the number of
+  ALL non-header entries across the full history in O(1). The count is maintained incrementally:
+  `_appendEntry()` increments per actual append, `_buildIndex()` recomputes it from the loaded
+  entries (skipping the recompute when the mirror is compaction-trimmed, where the mirror no longer
+  represents the full history), and `_resetToNewSession()` clears it.
+- `packages/coding-agent/test/session-manager/entry-count.test.ts`: persisted-lifecycle coverage -
+  header exclusion, the full-history count across an `appendCompaction()` trim with zero
+  full-history loads on repeated count reads, append-after-trim, reopen and `setSessionFile()`
+  rebuilds, branched-session recompute, and the real `startToolHookStatusTimer` cadence boundary
+  (999/1000 entries) without loading history.
+
+### Why
+
+- After a persisted compaction trims the in-memory mirror (`mirrorTrimmed`), every
+  `getEntries().length` reloads and materializes the entire JSONL. Count-only UI cadence decisions
+  sit on hot paths; profiling a live multi-day session attributed roughly a third of one sampled
+  60-second window to the tool-hook status timer's repeated full-history loads.
+
+### Why an extension could not handle it
+
+- The count is derived state inside `SessionManager` below the extension boundary; extensions only
+  receive `ReadonlySessionManager` and would have to call the loading `getEntries()` to count.
+
+### Expected merge conflict zones
+
+- LOW: the `fullEntryCount` field beside `mirrorTrimmed`, the guarded recompute at the end of
+  `_buildIndex()`, the increment in `_appendEntry()`, and the accessor beside `getEntries()`.
+
 ## 2026-09-12 - `app.question.answer` keybinding and `/answer` command for the async ask-user widget (senpi#1623)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,6 +1,6 @@
 # changes
 
-## 2026-09-12 - O(1) full-history entry count on SessionManager
+## 2026-09-12 - O(1) full-history entry count on SessionManager (senpi#1635)
 
 ### What changed
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -875,6 +875,11 @@ export class SessionManager {
 	private leafId: string | null = null;
 	private residentStore = new ResidentStringStore();
 	private mirrorTrimmed = false;
+	// Maintained count of ALL non-header entries across the full history. Equals
+	// getEntries().length, but survives _trimMirrorAfterCompaction() so count-only
+	// readers never pay the full-history load that getEntries() performs once the
+	// mirror is trimmed.
+	private fullEntryCount = 0;
 	private compactEntriesCache: { mutation: number; entries: SessionEntry[] } | null = null;
 	// Monotonic counter bumped by every mutator; memoized materialized views are
 	// keyed on it so read hot paths (footer, RPC) never re-materialize unchanged sessions.
@@ -1017,6 +1022,7 @@ export class SessionManager {
 		};
 		this.fileEntries = [header];
 		this.mirrorTrimmed = false;
+		this.fullEntryCount = 0;
 		this.residentStore.clear();
 		this.byId.clear();
 		this.entryOrdersById.clear();
@@ -1076,8 +1082,10 @@ export class SessionManager {
 			cost: 0,
 			latestCacheHitRate: undefined,
 		};
+		let fullEntryCount = 0;
 		for (const [order, entry] of this.fileEntries.entries()) {
 			if (entry.type === "session") continue;
+			fullEntryCount++;
 			this.byId.set(entry.id, entry);
 			this.entryOrdersById.set(entry.id, order);
 			this.leafId = entry.id;
@@ -1095,6 +1103,12 @@ export class SessionManager {
 					this.labelTimestampsById.delete(entry.targetId);
 				}
 			}
+		}
+		// A compaction-trimmed mirror retains only kept entries while the full
+		// history still counts every persisted entry, so a trimmed rebuild must
+		// keep the maintained full-history count.
+		if (!this.mirrorTrimmed) {
+			this.fullEntryCount = fullEntryCount;
 		}
 	}
 
@@ -1176,6 +1190,7 @@ export class SessionManager {
 		this.byId.set(residentEntry.id, residentEntry);
 		this.entryOrdersById.set(residentEntry.id, this.fileEntries.length - 1);
 		this.leafId = residentEntry.id;
+		this.fullEntryCount++;
 		this._accumulateUsage(residentEntry);
 		this.mutationCount++;
 		this._persist(residentEntry);
@@ -1655,6 +1670,16 @@ export class SessionManager {
 		const materializedEntries = this._materializeEntries(entries);
 		this.entriesCache = { mutation: this.mutationCount, entries: materializedEntries };
 		return materializedEntries;
+	}
+
+	/**
+	 * O(1) count of ALL session entries across the full history (excludes the
+	 * header, not branch-scoped). Maintained incrementally and identical to
+	 * getEntries().length, so count-only readers do not pay the full-history
+	 * load that getEntries() performs once the mirror is trimmed.
+	 */
+	getEntryCount(): number {
+		return this.fullEntryCount;
 	}
 
 	private _materializeEntries(entries: readonly SessionEntry[]): SessionEntry[] {

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,30 @@
+## 2026-09-12 - Working/retry status cadence reads the O(1) entry count
+
+### What changed
+
+- `interactive-mode.ts`: the three count-only cadence decisions - `startToolHookStatusTimer()`,
+  `getWorkingIndicatorOptions()`, and `showRetryStatusIndicatorWithCadence()` - read
+  `sessionManager.getEntryCount()` instead of `getEntries().length`, so starting the tool-hook
+  status timer or a retry indicator no longer reloads and materializes the full persisted history
+  on compaction-trimmed long sessions. Explicit full-history readers in this file (cache-miss
+  detection, tree view) are unchanged.
+
+### Why
+
+- On a compaction-trimmed session `getEntries()` re-parses the whole JSONL on every call; these UI
+  timers only need the entry count to pick the small/large-session animation cadence, and the
+  repeated loads dominated the timer path on multi-day sessions.
+
+### Why an extension could not handle it
+
+- The cadence choices live inside interactive-mode's own timer and indicator constructors; the
+  session count they need is core `SessionManager` state exposed as `getEntryCount()`.
+
+### Expected merge conflict zones
+
+- LOW: the three `largeSessionWorkingStatusInterval(...)` call sites and the `sessionEntryCount`
+  line in `getWorkingIndicatorOptions()`.
+
 ## 2026-09-12 - Upstream sync: status spinners in the editor border, mouse toggles, renderer-only tool cards
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,4 @@
-## 2026-09-12 - Working/retry status cadence reads the O(1) entry count
+## 2026-09-12 - Working/retry status cadence reads the O(1) entry count (senpi#1635)
 
 ### What changed
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2966,7 +2966,7 @@ export class InteractiveMode {
 			return;
 		}
 		const intervalMs = largeSessionWorkingStatusInterval(
-			this.sessionManager.getEntries().length,
+			this.sessionManager.getEntryCount(),
 			DEFAULT_WORKING_STATUS_MESSAGE_ANIMATION_INTERVAL_MS,
 			LARGE_SESSION_WORKING_STATUS_MESSAGE_INTERVAL_MS,
 		);
@@ -3140,7 +3140,7 @@ export class InteractiveMode {
 		if (this.workingIndicatorOptions !== undefined) {
 			return this.workingIndicatorOptions;
 		}
-		const sessionEntryCount = this.sessionManager.getEntries().length;
+		const sessionEntryCount = this.sessionManager.getEntryCount();
 		return {
 			frames: theme.getColorMode() === "truecolor" ? ["•"] : [theme.fg("accent", "•"), theme.fg("muted", "◦")],
 			intervalMs: largeSessionWorkingStatusInterval(
@@ -5439,7 +5439,7 @@ export class InteractiveMode {
 
 	private showRetryStatusIndicatorWithCadence(event: { attempt: number; maxAttempts: number; delayMs: number }): void {
 		const refreshIntervalMs = largeSessionWorkingStatusInterval(
-			this.sessionManager.getEntries().length,
+			this.sessionManager.getEntryCount(),
 			DEFAULT_RETRY_STATUS_REFRESH_INTERVAL_MS,
 			LARGE_SESSION_RETRY_STATUS_REFRESH_INTERVAL_MS,
 		);

--- a/packages/coding-agent/test/hook-status-ticker.test.ts
+++ b/packages/coding-agent/test/hook-status-ticker.test.ts
@@ -7,7 +7,7 @@ type HookStatusTickerPrototype = {
 
 type HookStatusTickerThis = {
 	hookStatusIntervalId: ReturnType<typeof setInterval> | undefined;
-	sessionManager: { getEntries(): readonly unknown[] };
+	sessionManager: { getEntries(): readonly unknown[]; getEntryCount(): number };
 	refreshToolHookStatuses(): void;
 };
 
@@ -20,7 +20,7 @@ describe("InteractiveMode hook status ticker", () => {
 		const unrefSpy = vi.spyOn(intervalHandle, "unref");
 		const fakeThis: HookStatusTickerThis = {
 			hookStatusIntervalId: undefined,
-			sessionManager: { getEntries: () => [] },
+			sessionManager: { getEntries: () => [], getEntryCount: () => 0 },
 			refreshToolHookStatuses: vi.fn(),
 		};
 
@@ -44,7 +44,10 @@ describe("InteractiveMode hook status ticker", () => {
 		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(intervalHandle);
 		const fakeThis: HookStatusTickerThis = {
 			hookStatusIntervalId: undefined,
-			sessionManager: { getEntries: () => Array.from({ length: 1000 }) },
+			sessionManager: {
+				getEntries: () => Array.from({ length: 1000 }),
+				getEntryCount: () => 1000,
+			},
 			refreshToolHookStatuses: vi.fn(),
 		};
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -726,7 +726,7 @@ describe("InteractiveMode.getWorkingIndicatorOptions", () => {
 		// Given
 		const fakeThis: any = {
 			workingIndicatorOptions: undefined,
-			sessionManager: { getEntries: () => [] },
+			sessionManager: { getEntries: () => [], getEntryCount: () => 0 },
 			getWorkingElapsedSeconds: () => 7,
 		};
 
@@ -761,7 +761,7 @@ describe("InteractiveMode.getWorkingIndicatorOptions", () => {
 		initTheme("dark");
 		const fakeThis: any = {
 			workingIndicatorOptions: undefined,
-			sessionManager: { getEntries: () => [] },
+			sessionManager: { getEntries: () => [], getEntryCount: () => 0 },
 			getWorkingElapsedSeconds: () => 7,
 		};
 

--- a/packages/coding-agent/test/session-manager/entry-count.test.ts
+++ b/packages/coding-agent/test/session-manager/entry-count.test.ts
@@ -1,0 +1,180 @@
+import { mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	loadEntriesFromFile,
+	SessionManager,
+	setSessionEntryLoaderForTesting,
+} from "../../src/core/session-manager.ts";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
+import { assistantMsg, userMsg } from "../utilities.ts";
+
+type HookStatusTimerThis = {
+	sessionManager: SessionManager;
+	hookStatusIntervalId: ReturnType<typeof setInterval> | undefined;
+};
+
+type HookStatusTimerPrototype = {
+	startToolHookStatusTimer(this: HookStatusTimerThis): void;
+};
+
+function startHookStatusTimer(owner: HookStatusTimerThis): void {
+	(InteractiveMode.prototype as unknown as HookStatusTimerPrototype).startToolHookStatusTimer.call(owner);
+}
+
+describe("SessionManager entry count", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-entry-count-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("excludes the session header from the count", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		expect(session.getEntryCount()).toBe(0);
+		session.appendMessage(assistantMsg("ready"));
+		expect(session.getEntryCount()).toBe(1);
+		expect(session.getEntryCount()).toBe(session.getEntries().length);
+	});
+
+	it("keeps the full-history count across compaction trim without loading history", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(assistantMsg("ready"));
+		session.appendMessage(userMsg("pruned"));
+		const firstKeptEntryId = session.appendMessage(userMsg("kept"));
+		for (let i = 0; i < 20; i++) {
+			session.appendMessage(userMsg(`turn ${i}`));
+		}
+		const appendedBeforeCompaction = 23;
+		expect(session.getEntryCount()).toBe(appendedBeforeCompaction);
+
+		session.appendCompaction("summary", firstKeptEntryId, 100);
+
+		let loadCount = 0;
+		const restoreLoader = setSessionEntryLoaderForTesting((filePath) => {
+			loadCount++;
+			return loadEntriesFromFile(filePath);
+		});
+		try {
+			// The trimmed mirror drops pre-compaction entries, but the full-history
+			// count still covers them plus the compaction entry itself.
+			expect(session.getEntryCount()).toBe(appendedBeforeCompaction + 1);
+			for (let i = 0; i < 5; i++) {
+				expect(session.getEntryCount()).toBe(appendedBeforeCompaction + 1);
+			}
+			expect(loadCount).toBe(0);
+
+			// Appends after the trim advance the full-history count.
+			session.appendCustomEntry("synthetic-event", { turn: 1 });
+			for (let i = 0; i < 5; i++) {
+				expect(session.getEntryCount()).toBe(appendedBeforeCompaction + 2);
+			}
+			expect(loadCount).toBe(0);
+
+			// Explicit full-history retrieval still loads once and agrees with the count.
+			expect(session.getEntries()).toHaveLength(appendedBeforeCompaction + 2);
+			expect(loadCount).toBe(1);
+		} finally {
+			restoreLoader();
+		}
+	});
+
+	it("rebuilds the count when reopening or switching sessions", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(assistantMsg("ready"));
+		const firstKeptEntryId = session.appendMessage(userMsg("kept"));
+		session.appendMessage(userMsg("after"));
+		session.appendCompaction("summary", firstKeptEntryId, 100);
+		const fullCount = session.getEntryCount();
+		const sessionFile = session.getSessionFile();
+		expect(sessionFile).toBeDefined();
+
+		const reopened = SessionManager.open(sessionFile!, tempDir);
+		expect(reopened.getEntryCount()).toBe(fullCount);
+
+		reopened.newSession();
+		expect(reopened.getEntryCount()).toBe(0);
+
+		reopened.setSessionFile(sessionFile!);
+		expect(reopened.getEntryCount()).toBe(fullCount);
+	});
+
+	it("counts only the retained path in a persisted branched session", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(assistantMsg("ready"));
+		const firstEntryId = session.appendMessage(userMsg("one"));
+		session.appendMessage(userMsg("two"));
+		session.appendMessage(userMsg("three"));
+		expect(session.getEntryCount()).toBe(4);
+
+		const branchedFile = session.createBranchedSession(firstEntryId);
+		expect(branchedFile).toBeDefined();
+		expect(session.getEntryCount()).toBe(2);
+		expect(session.getEntryCount()).toBe(session.getEntries().length);
+
+		session.appendCustomEntry("synthetic", {});
+		expect(session.getEntryCount()).toBe(3);
+	});
+
+	it("starts the hook status timer on a trimmed session without loading history", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(assistantMsg("ready"));
+		const firstKeptEntryId = session.appendMessage(userMsg("kept"));
+		for (let i = 0; i < 998; i++) {
+			session.appendMessage(userMsg(`turn ${i}`));
+		}
+		session.appendCompaction("summary", firstKeptEntryId, 100);
+		expect(session.getEntryCount()).toBe(1001);
+
+		const fakeTimerHandle = { unref: () => {} } as unknown as ReturnType<typeof setInterval>;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(fakeTimerHandle);
+		let loadCount = 0;
+		const restoreLoader = setSessionEntryLoaderForTesting((filePath) => {
+			loadCount++;
+			return loadEntriesFromFile(filePath);
+		});
+		try {
+			const owner: HookStatusTimerThis = { sessionManager: session, hookStatusIntervalId: undefined };
+			startHookStatusTimer(owner);
+			const intervalMs = setIntervalSpy.mock.calls.at(-1)?.[1];
+			expect(intervalMs).toBe(1_000);
+			expect(loadCount).toBe(0);
+		} finally {
+			restoreLoader();
+			setIntervalSpy.mockRestore();
+		}
+	});
+
+	it("preserves the working-status cadence boundary at 999 and 1000 entries", () => {
+		const session = SessionManager.inMemory(tempDir);
+		const fakeTimerHandle = { unref: () => {} } as unknown as ReturnType<typeof setInterval>;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(fakeTimerHandle);
+		try {
+			const owner: HookStatusTimerThis = { sessionManager: session, hookStatusIntervalId: undefined };
+
+			startHookStatusTimer(owner);
+			expect(setIntervalSpy.mock.calls.at(-1)?.[1]).toBe(32);
+			owner.hookStatusIntervalId = undefined;
+
+			for (let i = 0; i < 999; i++) {
+				session.appendCustomEntry("synthetic", { index: i });
+			}
+			startHookStatusTimer(owner);
+			expect(setIntervalSpy.mock.calls.at(-1)?.[1]).toBe(32);
+			owner.hookStatusIntervalId = undefined;
+
+			session.appendCustomEntry("synthetic", { index: 999 });
+			startHookStatusTimer(owner);
+			expect(setIntervalSpy.mock.calls.at(-1)?.[1]).toBe(1_000);
+			owner.hookStatusIntervalId = undefined;
+		} finally {
+			setIntervalSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

After compaction trims a persisted session's in-memory mirror, `getEntries().length` reloads and materializes the full JSONL history. Three UI cadence decisions use it even though they only need a count: the tool-hook ticker, working indicator, and retry indicator.

## Change

Add an O(1) `SessionManager.getEntryCount()` backed by a counter maintained on append, load, and reset. Preserve that count when the resident mirror is trimmed, and replace the three count-only UI reads.

Explicit history retrieval, persistence, checkpoint handling, and cadence thresholds are unchanged. The accessor reports the maintained count of loaded/appended non-header entries, not a fresh disk snapshot; this PR does not repair the existing pre-first-assistant compaction/persistence edge case.

## Coverage

- Persisted-session tests cover header exclusion, compaction trim, append-after-trim, reopen, reset, and branching. Repeated count reads perform zero full-history loads; explicit history retrieval still loads once.
- Existing ticker tests cover the 0/999/1000-entry cadence cases and start the real timer owner on a trimmed 1001-entry persisted session without loading history.
- Session-manager tests remain independent of interactive mode. Timer coverage uses the existing ticker fixture rather than fabricated timer handles.

## Verification

At `4e18241f08b0ecb02dd421fdf1d2297edf1410f4`:

- Session-manager and five interactive status/TUI test files: **254 tests passed** across 22 files.
- `bun run check`: passed; repeat run applied **no formatting fixes**.
- Changelog gate against `561c24fbe`: passed.
- Real, isolated TUI smoke: **5/5 passed** (boot, render, composer input, teardown, auth unchanged).
- `git diff --check`: passed.

This verification is scoped to the change, not a claim that the entire workspace test suite or every long-session freeze is resolved.

**Clarification for the generated summary below:** the maintained count is not guaranteed to equal a fresh `getEntries().length` in every persistence state. The contract and scope are described above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long, compaction-trimmed sessions from re-parsing the full JSONL history when deciding working or retry status cadence. These checks now use the O(1) maintained `SessionManager#getEntryCount()`; explicit `getEntries()` history loads remain unchanged.

- Replaces count-only reads in the hook-status ticker, working indicator, and retry indicator.
- Maintains the non-header count across append, compaction trim, reopen, reset, and branching without changing the 999/1000-entry cadence boundary.
- Adds regression coverage for persisted lifecycle changes and verifies the ticker performs zero history loads after trimming.

<sup>Written for commit 5c286a5912cc4ce88b7e2d1808f015645b165dc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

